### PR TITLE
Add Qwen GGUF/Jinja render-tokenize bridge for subprocess worker and readiness smoke

### DIFF
--- a/desktop-tauri/src-tauri/python/requirements_desktop_runtime.txt
+++ b/desktop-tauri/src-tauri/python/requirements_desktop_runtime.txt
@@ -2,3 +2,4 @@ psutil==7.1.0
 requests==2.32.5
 python-dotenv==1.1.1
 cryptography==46.0.1
+Jinja2==3.1.6

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -360,6 +360,112 @@ def test_compute_node_runtime_qwen_64k_readiness_reports_yarn_rope():
     assert diagnostics["api_v1_readiness_tokenizer_render_bridge_available"] is True
 
 
+def test_compute_node_runtime_readiness_smoke_completion_passes(monkeypatch):
+    class SmokeRuntime:
+        def __init__(self):
+            self.completion_kwargs = None
+
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **kwargs):
+            self.completion_kwargs = kwargs
+            return {"choices": [{"message": {"role": "assistant", "content": "ready"}}]}
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", "1")
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    llm_runtime = SmokeRuntime()
+    model_manager.get_llm_instance.return_value = llm_runtime
+    relay_client = SimpleNamespace(
+        _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+    )
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=relay_client,
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
+    assert diagnostics["api_v1_readiness_result"] == "passed"
+    assert llm_runtime.completion_kwargs["stream"] is False
+    assert llm_runtime.completion_kwargs["max_tokens"] == 4
+    assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
+
+
+def test_compute_node_runtime_readiness_smoke_completion_rejects_think_output(monkeypatch):
+    class ThinkRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **_kwargs):
+            return {"choices": [{"message": {"role": "assistant", "content": "<think>no"}}]}
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", "1")
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = ThinkRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(
+            _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+        ),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
+    assert diagnostics["api_v1_readiness_result"] == "failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+
+
+def test_compute_node_runtime_readiness_smoke_completion_records_safe_exception(monkeypatch):
+    class RaisingRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **_kwargs):
+            raise RuntimeError("prompt text must not leak")
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", "1")
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = RaisingRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(
+            _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+        ),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
+    assert diagnostics["api_v1_readiness_completion_smoke_exception_type"] == "RuntimeError"
+    assert "prompt text" not in str(diagnostics)
+
 @pytest.mark.parametrize(
     "llm_instance,getter,expected",
     [

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4135,6 +4135,7 @@ def test_llama_worker_render_and_tokenize_chat_uses_gguf_jinja_metadata(tmp_path
         llama_body=r"""
 class Llama:
     metadata = {
+        'general.name': 'Qwen3 test',
         'tokenizer.chat_template': (
             "{% for message in messages %}"
             "<|im_start|>{{ message['role'] }}\n{{ message['content'] }}<|im_end|>\n"
@@ -4192,6 +4193,29 @@ class Llama:
     assert 'secret prompt' not in json.dumps(response)
 
 
+def test_llama_worker_render_and_tokenize_chat_fails_closed_without_qwen_evidence(tmp_path):
+    response = _run_llama_worker_request(
+        tmp_path,
+        {
+            'method': 'render_and_tokenize_chat',
+            'args': [[{'role': 'user', 'content': 'secret prompt'}]],
+            'kwargs': {'tokenize': False, 'add_generation_prompt': True},
+        },
+        llama_body=r"""
+class Llama:
+    metadata = {'tokenizer.chat_template': "{% for message in messages %}{{ message['content'] }}{% endfor %}"}
+    def __init__(self, *args, **kwargs):
+        pass
+    def tokenize(self, prompt, add_bos=False):
+        raise AssertionError('must fail closed before rendering non-Qwen metadata')
+""",
+    )
+
+    assert response['status'] == 'error'
+    assert response['diagnostics']['reason'] == 'runtime_chat_template_qwen_evidence_missing'
+    assert 'secret prompt' not in json.dumps(response)
+
+
 def test_llama_worker_render_and_tokenize_chat_does_not_use_llama_formatter_for_qwen_metadata_path(tmp_path):
     response = _run_llama_worker_request(
         tmp_path,
@@ -4203,6 +4227,7 @@ def test_llama_worker_render_and_tokenize_chat_does_not_use_llama_formatter_for_
         llama_body=r"""
 class Llama:
     metadata = {
+        'general.name': 'Qwen3 test',
         'tokenizer.chat_template': "{% for message in messages %}qwen:{{ message['role'] }}{% endfor %}{% if add_generation_prompt %}assistant{% endif %}"
     }
     chat_format = 'llama-3'
@@ -4231,7 +4256,7 @@ def test_llama_worker_render_and_tokenize_chat_formatter_falls_back_without_enab
         },
         llama_body=r"""
 class Llama:
-    metadata = {'tokenizer.chat_template': "{% for message in messages %}plain:{{ message['content'] }}{% endfor %}{% if enable_thinking == false %}:no-think{% endif %}"}
+    metadata = {'general.name': 'Qwen3 test', 'tokenizer.chat_template': "{% for message in messages %}plain:{{ message['content'] }}{% endfor %}{% if enable_thinking == false %}:no-think{% endif %}"}
     def __init__(self, *args, **kwargs):
         pass
     def tokenize(self, prompt, add_bos=False):
@@ -4263,7 +4288,7 @@ def test_llama_worker_render_and_tokenize_chat_passes_bos_eos_to_formatter_and_j
         },
         llama_body=r"""
 class Llama:
-    metadata = {'tokenizer.chat_template': "{{ bos_token }}{% for message in messages %}{{ message['content'] }}{% endfor %}{{ eos_token }}"}
+    metadata = {'general.name': 'Qwen3 test', 'tokenizer.chat_template': "{{ bos_token }}{% for message in messages %}{{ message['content'] }}{% endfor %}{{ eos_token }}"}
     def __init__(self, *args, **kwargs):
         pass
     def token_bos(self):
@@ -4304,7 +4329,7 @@ def test_llama_worker_render_and_tokenize_chat_plain_jinja_uses_bos_eos_and_sand
         },
         llama_body=r"""
 class Llama:
-    metadata = {'tokenizer.chat_template': "{{ bos_token }}{% for message in messages %}{{ message['content'] }}{% endfor %}{{ eos_token }}"}
+    metadata = {'general.name': 'Qwen3 test', 'tokenizer.chat_template': "{{ bos_token }}{% for message in messages %}{{ message['content'] }}{% endfor %}{{ eos_token }}"}
     def __init__(self, *args, **kwargs):
         pass
     def token_bos(self):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4193,6 +4193,60 @@ class Llama:
     assert 'secret prompt' not in json.dumps(response)
 
 
+def test_llama_worker_render_and_tokenize_chat_error_diagnostics_are_request_scoped(tmp_path):
+    package_dir = tmp_path / 'llama_cpp'
+    package_dir.mkdir()
+    (package_dir / '__init__.py').write_text(r"""
+class Llama:
+    metadata = {
+        'general.name': 'Qwen3 test',
+        'tokenizer.chat_template': "{% for message in messages %}{{ message['content'] }}{% endfor %}",
+    }
+    def __init__(self, *args, **kwargs):
+        self.calls = 0
+    def tokenize(self, prompt, add_bos=False):
+        self.calls += 1
+        self.metadata = {}
+        return [1]
+""")
+    env = os.environ.copy()
+    env['PYTHONPATH'] = os.pathsep.join([str(tmp_path), str(Path(__file__).parent.parent.parent)])
+    process = subprocess.Popen(
+        [sys.executable, '-c', 'from utils.llm.model_manager import _LLAMA_CPP_RUNTIME_WORKER_CODE; exec(_LLAMA_CPP_RUNTIME_WORKER_CODE)'],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+    )
+    assert process.stdin is not None
+    assert process.stdout is not None
+    process.stdin.write(json.dumps({'args': [], 'kwargs': {}}) + '\n')
+    process.stdin.flush()
+    assert json.loads(process.stdout.readline().split(':', 1)[1])['status'] == 'ok'
+
+    request = {
+        'method': 'render_and_tokenize_chat',
+        'args': [[{'role': 'user', 'content': 'secret prompt'}]],
+        'kwargs': {'tokenize': False, 'add_generation_prompt': True},
+    }
+    process.stdin.write(json.dumps(request) + '\n')
+    process.stdin.flush()
+    first_response = json.loads(process.stdout.readline().split(':', 1)[1])
+    process.stdin.write(json.dumps(request) + '\n')
+    process.stdin.flush()
+    second_response = json.loads(process.stdout.readline().split(':', 1)[1])
+    process.kill()
+    process.wait(timeout=5)
+
+    assert first_response == {'status': 'ok', 'result': {'prompt_tokens': 1}}
+    assert second_response['status'] == 'error'
+    assert second_response['diagnostics']['reason'] == 'runtime_chat_template_metadata_missing'
+    assert 'metadata_template_available' not in second_response['diagnostics']
+    assert 'secret prompt' not in json.dumps(second_response)
+
+
 def test_llama_worker_render_and_tokenize_chat_fails_closed_without_qwen_evidence(tmp_path):
     response = _run_llama_worker_request(
         tmp_path,

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4247,6 +4247,34 @@ class Llama:
     assert 'secret prompt' not in json.dumps(second_response)
 
 
+def test_llama_worker_render_and_tokenize_chat_keeps_qwen_evidence_from_later_metadata(tmp_path):
+    response = _run_llama_worker_request(
+        tmp_path,
+        {
+            'method': 'render_and_tokenize_chat',
+            'args': [[{'role': 'user', 'content': 'secret prompt'}]],
+            'kwargs': {'tokenize': False, 'add_generation_prompt': True},
+        },
+        llama_body=r"""
+class Metadata(dict):
+    pass
+
+class Llama:
+    metadata = {
+        'tokenizer.chat_template': "{% for message in messages %}{{ message['content'] }}{% endfor %}",
+    }
+    def __init__(self, *args, **kwargs):
+        self._model = type('Model', (), {'metadata': {'general.name': 'Qwen3 test'}})()
+    def tokenize(self, prompt, add_bos=False):
+        assert prompt == b'secret prompt'
+        return [1, 2, 3]
+""",
+    )
+
+    assert response == {'status': 'ok', 'result': {'prompt_tokens': 3}}
+    assert 'secret prompt' not in json.dumps(response)
+
+
 def test_llama_worker_render_and_tokenize_chat_fails_closed_without_qwen_evidence(tmp_path):
     response = _run_llama_worker_request(
         tmp_path,

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4221,6 +4221,132 @@ def format_llama3(*args, **kwargs):
     assert response == {'status': 'ok', 'result': {'prompt_tokens': 1}}
 
 
+def test_llama_worker_render_and_tokenize_chat_formatter_falls_back_without_enable_thinking_support(tmp_path):
+    response = _run_llama_worker_request(
+        tmp_path,
+        {
+            'method': 'render_and_tokenize_chat',
+            'args': [[{'role': 'user', 'content': 'secret prompt'}]],
+            'kwargs': {'tokenize': False, 'add_generation_prompt': True, 'enable_thinking': False},
+        },
+        llama_body=r"""
+class Llama:
+    metadata = {'tokenizer.chat_template': "{% for message in messages %}plain:{{ message['content'] }}{% endfor %}{% if enable_thinking == false %}:no-think{% endif %}"}
+    def __init__(self, *args, **kwargs):
+        pass
+    def tokenize(self, prompt, add_bos=False):
+        assert prompt == b'plain:secret prompt:no-think'
+        return [1, 2, 3]
+""",
+        llama_chat_format_body="""
+class Jinja2ChatFormatter:
+    def __init__(self, *, template, bos_token='', eos_token=''):
+        self.template = template
+    def __call__(self, **kwargs):
+        if 'enable_thinking' in kwargs:
+            raise TypeError("got an unexpected keyword argument 'enable_thinking'")
+        raise RuntimeError('formatter cannot render this template')
+""",
+    )
+
+    assert response == {'status': 'ok', 'result': {'prompt_tokens': 3}}
+    assert 'secret prompt' not in json.dumps(response)
+
+
+def test_llama_worker_render_and_tokenize_chat_passes_bos_eos_to_formatter_and_jinja(tmp_path):
+    response = _run_llama_worker_request(
+        tmp_path,
+        {
+            'method': 'render_and_tokenize_chat',
+            'args': [[{'role': 'user', 'content': 'hello'}]],
+            'kwargs': {'tokenize': False, 'add_generation_prompt': False},
+        },
+        llama_body=r"""
+class Llama:
+    metadata = {'tokenizer.chat_template': "{{ bos_token }}{% for message in messages %}{{ message['content'] }}{% endfor %}{{ eos_token }}"}
+    def __init__(self, *args, **kwargs):
+        pass
+    def token_bos(self):
+        return 101
+    def token_eos(self):
+        return 102
+    def token_get_text(self, token_id):
+        return {101: b'<s>', 102: b'</s>'}[token_id]
+    def tokenize(self, prompt, add_bos=False):
+        assert prompt == b'<s>formatter hello</s>'
+        return [1, 2, 3, 4]
+""",
+        llama_chat_format_body="""
+class Rendered:
+    def __init__(self, prompt):
+        self.prompt = prompt
+class Jinja2ChatFormatter:
+    def __init__(self, *, template, bos_token='', eos_token=''):
+        self.bos_token = bos_token
+        self.eos_token = eos_token
+    def __call__(self, **kwargs):
+        assert self.bos_token == '<s>'
+        assert self.eos_token == '</s>'
+        return Rendered(self.bos_token + 'formatter hello' + self.eos_token)
+""",
+    )
+
+    assert response == {'status': 'ok', 'result': {'prompt_tokens': 4}}
+
+
+def test_llama_worker_render_and_tokenize_chat_plain_jinja_uses_bos_eos_and_sandbox(tmp_path):
+    response = _run_llama_worker_request(
+        tmp_path,
+        {
+            'method': 'render_and_tokenize_chat',
+            'args': [[{'role': 'user', 'content': 'hello'}]],
+            'kwargs': {'tokenize': False, 'add_generation_prompt': False},
+        },
+        llama_body=r"""
+class Llama:
+    metadata = {'tokenizer.chat_template': "{{ bos_token }}{% for message in messages %}{{ message['content'] }}{% endfor %}{{ eos_token }}"}
+    def __init__(self, *args, **kwargs):
+        pass
+    def token_bos(self):
+        return 101
+    def token_eos(self):
+        return 102
+    def detokenize(self, token_ids):
+        return {101: b'<s>', 102: b'</s>'}[token_ids[0]]
+    def tokenize(self, prompt, add_bos=False):
+        assert prompt == b'<s>hello</s>'
+        return [1, 2, 3]
+""",
+    )
+
+    assert response == {'status': 'ok', 'result': {'prompt_tokens': 3}}
+
+
+def test_llama_worker_render_and_tokenize_chat_does_not_retry_unrelated_type_error(tmp_path):
+    response = _run_llama_worker_request(
+        tmp_path,
+        {
+            'method': 'render_and_tokenize_chat',
+            'args': [[{'role': 'user', 'content': 'secret prompt'}]],
+            'kwargs': {'tokenize': False, 'add_generation_prompt': True, 'enable_thinking': False},
+        },
+        llama_body="""
+class Llama:
+    def __init__(self, *args, **kwargs):
+        self.calls = 0
+    def apply_chat_template(self, messages, **kwargs):
+        self.calls += 1
+        raise TypeError('template helper failed internally')
+    def tokenize(self, prompt, add_bos=False):
+        raise AssertionError('tokenize should not run')
+""",
+    )
+
+    assert response['status'] == 'error'
+    assert response['diagnostics']['reason'] == 'runtime_chat_template_render_exception'
+    assert 'secret prompt' not in json.dumps(response)
+
+
 def test_llama_worker_apply_chat_template_fallback_still_supports_chat_format(tmp_path):
     package_dir = tmp_path / 'llama_cpp'
     package_dir.mkdir()

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4031,10 +4031,12 @@ def test_subprocess_llama_proxy_prompt_helpers_mark_closed_on_eof(monkeypatch):
     assert proxy._closed is True
 
 
-def _run_llama_worker_request(tmp_path, request, *, llama_body):
+def _run_llama_worker_request(tmp_path, request, *, llama_body, llama_chat_format_body=None):
     package_dir = tmp_path / 'llama_cpp'
     package_dir.mkdir()
     (package_dir / '__init__.py').write_text(llama_body)
+    if llama_chat_format_body is not None:
+        (package_dir / 'llama_chat_format.py').write_text(llama_chat_format_body)
     env = os.environ.copy()
     env['PYTHONPATH'] = os.pathsep.join([str(tmp_path), str(Path(__file__).parent.parent.parent)])
     process = subprocess.Popen(
@@ -4116,6 +4118,107 @@ class Llama:
     assert response == {'status': 'ok', 'result': {'prompt_tokens': 2}}
     assert 'secret prompt' not in json.dumps(response)
     assert 'rendered fallback prompt' not in json.dumps(response)
+
+
+def test_llama_worker_render_and_tokenize_chat_uses_gguf_jinja_metadata(tmp_path):
+    response = _run_llama_worker_request(
+        tmp_path,
+        {
+            'method': 'render_and_tokenize_chat',
+            'args': [[{'role': 'user', 'content': '/no_think\nsecret prompt'}]],
+            'kwargs': {
+                'tokenize': False,
+                'add_generation_prompt': True,
+                'enable_thinking': False,
+            },
+        },
+        llama_body=r"""
+class Llama:
+    metadata = {
+        'tokenizer.chat_template': (
+            "{% for message in messages %}"
+            "<|im_start|>{{ message['role'] }}\n{{ message['content'] }}<|im_end|>\n"
+            "{% endfor %}"
+            "{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}"
+            "{% if enable_thinking == false %}<|no_think|>{% endif %}"
+        )
+    }
+    def __init__(self, *args, **kwargs):
+        pass
+    def tokenizer(self):
+        class Tokenizer:
+            pass
+        return Tokenizer()
+    def tokenize(self, prompt, add_bos=False):
+        text = prompt.decode('utf-8')
+        assert '/no_think\nsecret prompt' in text
+        assert '<|im_start|>assistant' in text
+        assert '<|no_think|>' in text
+        return [1, 2, 3, 4]
+    def create_chat_completion(self, **kwargs):
+        return {'choices': [{'message': {'role': 'assistant', 'content': 'ok'}}]}
+""",
+    )
+
+    assert response == {'status': 'ok', 'result': {'prompt_tokens': 4}}
+    assert 'secret prompt' not in json.dumps(response)
+
+
+def test_llama_worker_render_and_tokenize_chat_fails_closed_without_metadata(tmp_path):
+    response = _run_llama_worker_request(
+        tmp_path,
+        {
+            'method': 'render_and_tokenize_chat',
+            'args': [[{'role': 'user', 'content': 'secret prompt'}]],
+            'kwargs': {'tokenize': False, 'add_generation_prompt': True},
+        },
+        llama_body="""
+class Llama:
+    def __init__(self, *args, **kwargs):
+        pass
+    def tokenizer(self):
+        class Tokenizer:
+            pass
+        return Tokenizer()
+    def tokenize(self, prompt, add_bos=False):
+        return [1, 2]
+    def create_chat_completion(self, **kwargs):
+        return {'choices': [{'message': {'role': 'assistant', 'content': 'ok'}}]}
+""",
+    )
+
+    assert response['status'] == 'error'
+    assert response['diagnostics']['reason'] == 'runtime_chat_template_metadata_missing'
+    assert 'secret prompt' not in json.dumps(response)
+
+
+def test_llama_worker_render_and_tokenize_chat_does_not_use_llama_formatter_for_qwen_metadata_path(tmp_path):
+    response = _run_llama_worker_request(
+        tmp_path,
+        {
+            'method': 'render_and_tokenize_chat',
+            'args': [[{'role': 'user', 'content': 'hello'}]],
+            'kwargs': {'tokenize': False, 'add_generation_prompt': True},
+        },
+        llama_body=r"""
+class Llama:
+    metadata = {
+        'tokenizer.chat_template': "{% for message in messages %}qwen:{{ message['role'] }}{% endfor %}{% if add_generation_prompt %}assistant{% endif %}"
+    }
+    chat_format = 'llama-3'
+    def __init__(self, *args, **kwargs):
+        pass
+    def tokenize(self, prompt, add_bos=False):
+        assert prompt.startswith(b'qwen:')
+        return [1]
+""",
+        llama_chat_format_body="""
+def format_llama3(*args, **kwargs):
+    raise AssertionError('Llama formatter must not be used for render_and_tokenize_chat metadata path')
+""",
+    )
+
+    assert response == {'status': 'ok', 'result': {'prompt_tokens': 1}}
 
 
 def test_llama_worker_apply_chat_template_fallback_still_supports_chat_format(tmp_path):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -22,6 +22,21 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from utils.networking import relay_client as relay_client_module
 from utils.networking.relay_client import RelayClient, MESSAGE_SCHEMA, RELAY_RESPONSE_SCHEMA
 
+
+def test_api_v1_models_module_import_failure_does_not_capture_worker_diagnostics(monkeypatch):
+    """Module import probing is separate from request-scoped worker diagnostics."""
+
+    class ImportFailureWithDiagnostics(RuntimeError):
+        diagnostics = {"reason": "runtime_chat_template_metadata_missing"}
+
+    def fail_import(name):
+        assert name == "api.v1.models"
+        raise ImportFailureWithDiagnostics("api v1 models unavailable")
+
+    monkeypatch.setattr(relay_client_module.importlib, "import_module", fail_import)
+
+    assert RelayClient._api_v1_models_module() is None
+
 # Common test data
 TEST_VALID_RESPONSE = {
     'client_public_key': 'Y2xpZW50X2tleV9iNjQ=',  # Base64 encoded "client_key_b64"

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5057,3 +5057,87 @@ def test_qwen_profile_generation_defaults_include_top_k():
     assert kwargs['temperature'] == 0.7
     assert kwargs['top_p'] == 0.8
     assert kwargs['top_k'] == 20
+
+
+def test_qwen_render_tokenize_worker_diagnostics_propagate_to_admission_error():
+    from utils.llm.model_manager import LlamaCppInferenceRequestError
+
+    class Runtime:
+        def __init__(self):
+            self.calls = []
+
+        def render_and_tokenize_chat(self, messages, **kwargs):
+            self.calls.append({"messages": messages, "kwargs": kwargs})
+            raise LlamaCppInferenceRequestError(
+                "llama_cpp request failed",
+                diagnostics={
+                    "reason": "runtime_chat_template_metadata_missing",
+                    "method": "unsupported",
+                    "stream": False,
+                    "exception_type": "RuntimeError",
+                    "unsafe_prompt": "do not expose me",
+                    "nested": {"message": "do not expose me"},
+                },
+            )
+
+        def create_chat_completion(self, **kwargs):  # pragma: no cover - admission fails first
+            raise AssertionError("generation should not run when admission is unavailable")
+
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = "qwen3-8b-instruct"
+    manager.model_profile = {
+        "id": "qwen3-local",
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "chat_template_policy": "qwen3-no-think",
+    }
+    manager.runtime = Runtime()
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-worker-diagnostics",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello diagnostic secret"}],
+        options={"max_tokens": 5},
+        requested_context_tier="8k-fast",
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_admission_unavailable"
+    assert error["internal_reason"] == "runtime_chat_template_metadata_missing"
+    assert error["active_model_id"] == "qwen3-8b-instruct"
+    assert error["active_profile_id"] == "qwen3-local"
+    assert error["context_tier"] == "8k-fast"
+    assert error["template_policy"] == "qwen3-no-think"
+    assert error["non_thinking_mode"] is True
+    assert error["runtime_facade_type"] == "Runtime"
+    assert error["direct_apply_chat_template_available"] is False
+    assert error["metadata_template_available"] is False
+    assert error["jinja_renderer_available"] is True
+    assert manager.runtime._token_place_last_render_tokenize_error["reason"] == "runtime_chat_template_metadata_missing"
+    serialized = json.dumps(error, sort_keys=True)
+    assert "hello diagnostic secret" not in serialized
+    assert "do not expose me" not in serialized
+    assert "unsafe_prompt" not in serialized
+
+
+def test_render_tokenize_success_clears_stale_worker_diagnostics():
+    class Runtime:
+        def __init__(self):
+            self._token_place_last_render_tokenize_error = {
+                "reason": "runtime_chat_template_metadata_missing"
+            }
+
+        def render_and_tokenize_chat(self, messages, **kwargs):
+            return {"prompt_tokens": 3}
+
+    runtime = Runtime()
+
+    prompt_tokens = RelayClient._api_v1_render_and_tokenize_chat_prompt(
+        runtime,
+        [{"role": "user", "content": "hello"}],
+        model_profile={"provider": "qwen", "chat_template_policy": "qwen3-no-think"},
+    )
+
+    assert prompt_tokens == 3
+    assert not hasattr(runtime, "_token_place_last_render_tokenize_error")

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -460,6 +460,47 @@ class ComputeNodeRuntime:
             ) if not admitted else None,
         })
         self.model_manager.last_compute_diagnostics = diagnostics
+        if admitted and os.getenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION") == "1":
+            try:
+                smoke_completion = create_chat_completion(
+                    messages=smoke_messages,
+                    max_tokens=4,
+                    stream=False,
+                )
+                smoke_message = None
+                if (
+                    isinstance(smoke_completion, dict)
+                    and isinstance(smoke_completion.get("choices"), list)
+                    and smoke_completion["choices"]
+                    and isinstance(smoke_completion["choices"][0], dict)
+                ):
+                    smoke_message = smoke_completion["choices"][0].get("message")
+                smoke_content = smoke_message.get("content") if isinstance(smoke_message, dict) else None
+                smoke_ok = isinstance(smoke_content, str) and bool(smoke_content.strip()) and "<think" not in smoke_content.lower()
+                diagnostics["api_v1_readiness_completion_smoke_result"] = "passed" if smoke_ok else "failed"
+                if not smoke_ok:
+                    admitted = False
+                    admission_error = {
+                        "code": "compute_node_context_admission_unavailable",
+                        "internal_reason": "runtime_completion_smoke_failed",
+                    }
+            except Exception as exc:
+                admitted = False
+                admission_error = {
+                    "code": "compute_node_context_admission_unavailable",
+                    "internal_reason": "runtime_completion_smoke_failed",
+                }
+                diagnostics["api_v1_readiness_completion_smoke_result"] = "failed"
+                diagnostics["api_v1_readiness_completion_smoke_exception_type"] = type(exc).__name__
+            diagnostics["api_v1_runtime_ready"] = bool(admitted)
+            diagnostics["api_v1_readiness_result"] = "passed" if admitted else "failed"
+            diagnostics["api_v1_readiness_error_code"] = (admission_error or {}).get("code") if not admitted else None
+            diagnostics["api_v1_readiness_error_reason"] = (
+                (admission_error or {}).get("internal_reason")
+                or (admission_error or {}).get("reason")
+            ) if not admitted else None
+            self.model_manager.last_compute_diagnostics = diagnostics
+
         if not admitted:
             admission_code = (admission_error or {}).get("code") or "unknown"
             admission_reason = (

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1354,6 +1354,7 @@ for line in sys.stdin:
             continue
         if method in {'apply_chat_template', 'render_and_tokenize_chat'}:
             if method == 'render_and_tokenize_chat':
+                _render_diagnostics = None
                 try:
                     rendered_prompt, _render_diagnostics = _render_chat_with_runtime_template(
                         llama, request.get('args', []), kwargs

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1149,34 +1149,81 @@ def _runtime_chat_template(llama):
 
 def _jinja_renderer_available():
     try:
-        importlib.import_module('jinja2')
+        importlib.import_module('jinja2.sandbox')
         return True
     except Exception:
         return False
 
-def _render_gguf_jinja_chat_template(template, messages, *, add_generation_prompt=True, enable_thinking=None):
+def _runtime_token_text(llama, token_name):
+    token_id_getter = getattr(llama, 'token_' + token_name, None)
+    token_id = None
+    if callable(token_id_getter):
+        try:
+            token_id = token_id_getter()
+        except Exception:
+            token_id = None
+    if isinstance(token_id, str):
+        return token_id
+    if token_id is None:
+        return ''
+    text_getter = getattr(llama, 'token_get_text', None)
+    if callable(text_getter):
+        try:
+            token_text = text_getter(token_id)
+            if isinstance(token_text, bytes):
+                return token_text.decode('utf-8', errors='ignore')
+            if isinstance(token_text, str):
+                return token_text
+        except Exception:
+            pass
+    detokenize = getattr(llama, 'detokenize', None)
+    if callable(detokenize):
+        try:
+            token_text = detokenize([token_id])
+            if isinstance(token_text, bytes):
+                return token_text.decode('utf-8', errors='ignore')
+            if isinstance(token_text, str):
+                return token_text
+        except Exception:
+            pass
+    return ''
+
+def _render_gguf_jinja_chat_template(template, messages, llama, *, add_generation_prompt=True, enable_thinking=None):
     chat_format_module = None
     try:
         chat_format_module = importlib.import_module('llama_cpp.llama_chat_format')
     except Exception:
         chat_format_module = None
+    bos_token = _runtime_token_text(llama, 'bos')
+    eos_token = _runtime_token_text(llama, 'eos')
     if chat_format_module is not None:
         formatter_cls = getattr(chat_format_module, 'Jinja2ChatFormatter', None)
         if callable(formatter_cls):
-            formatter = formatter_cls(template=template)
-            rendered = formatter(
-                messages=messages,
-                functions=None,
-                tools=None,
-                tool_choice=None,
-                add_generation_prompt=add_generation_prompt,
-                enable_thinking=enable_thinking,
-            )
-            prompt = getattr(rendered, 'prompt', rendered)
-            if isinstance(prompt, str):
-                return prompt
-    jinja2 = importlib.import_module('jinja2')
-    env = jinja2.Environment(autoescape=False)
+            try:
+                formatter = formatter_cls(template=template, bos_token=bos_token, eos_token=eos_token)
+                formatter_kwargs = {
+                    'messages': messages,
+                    'functions': None,
+                    'tools': None,
+                    'tool_choice': None,
+                    'add_generation_prompt': add_generation_prompt,
+                }
+                if enable_thinking is not None:
+                    formatter_kwargs['enable_thinking'] = enable_thinking
+                try:
+                    rendered = formatter(**formatter_kwargs)
+                except TypeError as exc:
+                    if not _type_error_is_unexpected_keyword(exc, 'enable_thinking'):
+                        raise
+                    formatter_kwargs.pop('enable_thinking', None)
+                    rendered = formatter(**formatter_kwargs)
+                prompt = getattr(rendered, 'prompt', rendered)
+                if isinstance(prompt, str):
+                    return prompt
+            except Exception:
+                pass
+    sandbox = importlib.import_module('jinja2.sandbox')
+    env = sandbox.SandboxedEnvironment(autoescape=False)
     def _raise_exception(message):
         raise RuntimeError('runtime_chat_template_render_exception')
     env.globals['raise_exception'] = _raise_exception
@@ -1184,8 +1231,8 @@ def _render_gguf_jinja_chat_template(template, messages, *, add_generation_promp
         messages=messages,
         add_generation_prompt=add_generation_prompt,
         enable_thinking=enable_thinking,
-        bos_token='',
-        eos_token='',
+        bos_token=bos_token,
+        eos_token=eos_token,
         tools=None,
         documents=None,
         date_string='',
@@ -1193,6 +1240,17 @@ def _render_gguf_jinja_chat_template(template, messages, *, add_generation_promp
     if not isinstance(rendered, str):
         raise RuntimeError('GGUF/Jinja chat template did not render text')
     return rendered
+
+def _type_error_is_unexpected_keyword(exc, keyword):
+    message = str(exc)
+    return (
+        ("unexpected keyword argument '%s'" % keyword) in message
+        or ('unexpected keyword argument "%s"' % keyword) in message
+        or ("got an unexpected keyword argument '%s'" % keyword) in message
+        or ('got an unexpected keyword argument "%s"' % keyword) in message
+        or ('unexpected keyword argument %s' % keyword) in message
+        or ('got an unexpected keyword argument %s' % keyword) in message
+    )
 
 def _render_chat_with_runtime_template(llama, args, kwargs):
     render = getattr(llama, 'apply_chat_template', None)
@@ -1212,8 +1270,8 @@ def _render_chat_with_runtime_template(llama, args, kwargs):
                 'metadata_template': False,
                 'jinja_renderer': False,
             }
-        except TypeError:
-            if 'enable_thinking' not in kwargs:
+        except TypeError as exc:
+            if 'enable_thinking' not in kwargs or not _type_error_is_unexpected_keyword(exc, 'enable_thinking'):
                 raise
             compatibility_kwargs = dict(kwargs)
             compatibility_kwargs.pop('enable_thinking', None)
@@ -1233,6 +1291,7 @@ def _render_chat_with_runtime_template(llama, args, kwargs):
     rendered = _render_gguf_jinja_chat_template(
         template,
         messages,
+        llama,
         add_generation_prompt=bool(kwargs.get('add_generation_prompt', True)),
         enable_thinking=kwargs.get('enable_thinking'),
     )

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1151,6 +1151,8 @@ def _runtime_chat_template(llama):
                 evidence = evidence.decode('utf-8', errors='ignore')
             if isinstance(evidence, str) and 'qwen' in evidence.lower():
                 qwen_evidence = True
+
+    for metadata in metadata_candidates:
         for key in (
             'tokenizer.chat_template',
             'chat_template',

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -802,7 +802,7 @@ def _read_llama_subprocess_message(
         raise LlamaCppWorkerEOFError(str(message.get('error') or f'{stage} worker exited before response'))
     if message.get('status') == 'error':
         error = str(message.get('error') or f'{stage} failed')
-        if stage == 'llama_cpp_inference' and message.get('request_error'):
+        if stage in {'llama_cpp_inference', 'llama_cpp_prompt_render_tokenize'} and message.get('request_error'):
             diagnostics = message.get('diagnostics')
             safe_diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
             raise LlamaCppInferenceRequestError(error, diagnostics=safe_diagnostics)
@@ -1081,8 +1081,12 @@ def _jsonable(value):
 def _emit(payload):
     print('TOKEN_PLACE_LLAMA_CPP_JSON:' + json.dumps(_jsonable(payload)), flush=True)
 
-def _safe_request_error(reason, *, request=None, exc=None):
+def _safe_request_error(reason, *, request=None, exc=None, extra=None):
     diagnostics = {'reason': reason}
+    if isinstance(extra, dict):
+        for key, value in extra.items():
+            if isinstance(key, str) and isinstance(value, (str, bool, int, float, type(None))):
+                diagnostics[key] = value
     if isinstance(request, dict):
         method = request.get('method')
         if method == 'create_chat_completion':
@@ -1133,7 +1137,20 @@ def _runtime_chat_template(llama):
             getattr(tokenizer, 'metadata', None),
             getattr(tokenizer, 'model_metadata', None),
         ])
+    qwen_evidence = False
     for metadata in metadata_candidates:
+        for evidence_key in (
+            'general.name',
+            'general.architecture',
+            'tokenizer.ggml.model',
+            'tokenizer.chat_template.policy',
+            'chat_template_policy',
+        ):
+            evidence = _metadata_value(metadata, evidence_key)
+            if isinstance(evidence, bytes):
+                evidence = evidence.decode('utf-8', errors='ignore')
+            if isinstance(evidence, str) and 'qwen' in evidence.lower():
+                qwen_evidence = True
         for key in (
             'tokenizer.chat_template',
             'chat_template',
@@ -1144,8 +1161,8 @@ def _runtime_chat_template(llama):
             if isinstance(value, bytes):
                 value = value.decode('utf-8', errors='ignore')
             if isinstance(value, str) and value.strip():
-                return value
-    return None
+                return value, qwen_evidence
+    return None, qwen_evidence
 
 def _jinja_renderer_available():
     try:
@@ -1253,6 +1270,9 @@ def _type_error_is_unexpected_keyword(exc, keyword):
     )
 
 def _render_chat_with_runtime_template(llama, args, kwargs):
+    kwargs = dict(kwargs)
+    provider_hint = str(kwargs.pop('token_place_provider', '') or '').lower()
+    policy_hint = str(kwargs.pop('token_place_template_policy', '') or '').lower()
     render = getattr(llama, 'apply_chat_template', None)
     direct_apply_available = callable(render)
     if not direct_apply_available:
@@ -1280,9 +1300,12 @@ def _render_chat_with_runtime_template(llama, args, kwargs):
                 'metadata_template': False,
                 'jinja_renderer': False,
             }
-    template = _runtime_chat_template(llama)
+    template, metadata_qwen_evidence = _runtime_chat_template(llama)
     if not isinstance(template, str) or not template.strip():
         raise RuntimeError('runtime_chat_template_metadata_missing')
+    qwen_safe = metadata_qwen_evidence or provider_hint == 'qwen' or 'qwen' in policy_hint
+    if not qwen_safe:
+        raise RuntimeError('runtime_chat_template_qwen_evidence_missing')
     if not _jinja_renderer_available():
         raise RuntimeError('runtime_chat_template_renderer_unavailable')
     messages = args[0] if args else kwargs.get('messages')
@@ -1299,6 +1322,7 @@ def _render_chat_with_runtime_template(llama, args, kwargs):
         'direct_apply_chat_template': False,
         'metadata_template': True,
         'jinja_renderer': True,
+        'qwen_evidence': True,
     }
 
 try:
@@ -1353,8 +1377,9 @@ for line in sys.stdin:
                         'runtime_tokenizer_unavailable',
                         'runtime_template_tokenizer_bridge_unavailable',
                         'runtime_chat_template_render_exception',
+                        'runtime_chat_template_qwen_evidence_missing',
                     } else 'runtime_chat_template_render_exception'
-                    _emit(_safe_request_error(reason, request=request, exc=exc))
+                    _emit(_safe_request_error(reason, request=request, exc=exc, extra=_render_diagnostics if isinstance(locals().get('_render_diagnostics'), dict) else None))
                 continue
             render = getattr(llama, 'apply_chat_template', None)
             if not callable(render):

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1101,6 +1101,147 @@ def _safe_request_error(reason, *, request=None, exc=None):
         'diagnostics': diagnostics,
     }
 
+def _metadata_value(container, key):
+    if container is None:
+        return None
+    try:
+        if isinstance(container, dict):
+            return container.get(key)
+        getter = getattr(container, 'get', None)
+        if callable(getter):
+            value = getter(key)
+            if value is not None:
+                return value
+        return getattr(container, key, None)
+    except Exception:
+        return None
+
+def _runtime_chat_template(llama):
+    metadata_candidates = [
+        getattr(llama, 'metadata', None),
+        getattr(llama, 'model_metadata', None),
+        getattr(getattr(llama, '_model', None), 'metadata', None),
+        getattr(getattr(llama, 'model', None), 'metadata', None),
+    ]
+    tokenizer_factory = getattr(llama, 'tokenizer', None)
+    if callable(tokenizer_factory):
+        try:
+            tokenizer = tokenizer_factory()
+        except Exception:
+            tokenizer = None
+        metadata_candidates.extend([
+            getattr(tokenizer, 'metadata', None),
+            getattr(tokenizer, 'model_metadata', None),
+        ])
+    for metadata in metadata_candidates:
+        for key in (
+            'tokenizer.chat_template',
+            'chat_template',
+            'tokenizer_chat_template',
+            'llama.chat_template',
+        ):
+            value = _metadata_value(metadata, key)
+            if isinstance(value, bytes):
+                value = value.decode('utf-8', errors='ignore')
+            if isinstance(value, str) and value.strip():
+                return value
+    return None
+
+def _jinja_renderer_available():
+    try:
+        importlib.import_module('jinja2')
+        return True
+    except Exception:
+        return False
+
+def _render_gguf_jinja_chat_template(template, messages, *, add_generation_prompt=True, enable_thinking=None):
+    chat_format_module = None
+    try:
+        chat_format_module = importlib.import_module('llama_cpp.llama_chat_format')
+    except Exception:
+        chat_format_module = None
+    if chat_format_module is not None:
+        formatter_cls = getattr(chat_format_module, 'Jinja2ChatFormatter', None)
+        if callable(formatter_cls):
+            formatter = formatter_cls(template=template)
+            rendered = formatter(
+                messages=messages,
+                functions=None,
+                tools=None,
+                tool_choice=None,
+                add_generation_prompt=add_generation_prompt,
+                enable_thinking=enable_thinking,
+            )
+            prompt = getattr(rendered, 'prompt', rendered)
+            if isinstance(prompt, str):
+                return prompt
+    jinja2 = importlib.import_module('jinja2')
+    env = jinja2.Environment(autoescape=False)
+    def _raise_exception(message):
+        raise RuntimeError('runtime_chat_template_render_exception')
+    env.globals['raise_exception'] = _raise_exception
+    rendered = env.from_string(template).render(
+        messages=messages,
+        add_generation_prompt=add_generation_prompt,
+        enable_thinking=enable_thinking,
+        bos_token='',
+        eos_token='',
+        tools=None,
+        documents=None,
+        date_string='',
+    )
+    if not isinstance(rendered, str):
+        raise RuntimeError('GGUF/Jinja chat template did not render text')
+    return rendered
+
+def _render_chat_with_runtime_template(llama, args, kwargs):
+    render = getattr(llama, 'apply_chat_template', None)
+    direct_apply_available = callable(render)
+    if not direct_apply_available:
+        tokenizer = getattr(llama, 'tokenizer', None)
+        if callable(tokenizer):
+            try:
+                tokenizer = tokenizer()
+            except Exception:
+                tokenizer = None
+        render = getattr(tokenizer, 'apply_chat_template', None) if tokenizer is not None else None
+    if callable(render):
+        try:
+            return render(*args, **kwargs), {
+                'direct_apply_chat_template': direct_apply_available,
+                'metadata_template': False,
+                'jinja_renderer': False,
+            }
+        except TypeError:
+            if 'enable_thinking' not in kwargs:
+                raise
+            compatibility_kwargs = dict(kwargs)
+            compatibility_kwargs.pop('enable_thinking', None)
+            return render(*args, **compatibility_kwargs), {
+                'direct_apply_chat_template': direct_apply_available,
+                'metadata_template': False,
+                'jinja_renderer': False,
+            }
+    template = _runtime_chat_template(llama)
+    if not isinstance(template, str) or not template.strip():
+        raise RuntimeError('runtime_chat_template_metadata_missing')
+    if not _jinja_renderer_available():
+        raise RuntimeError('runtime_chat_template_renderer_unavailable')
+    messages = args[0] if args else kwargs.get('messages')
+    if not isinstance(messages, list):
+        raise RuntimeError('runtime_chat_template_render_exception')
+    rendered = _render_gguf_jinja_chat_template(
+        template,
+        messages,
+        add_generation_prompt=bool(kwargs.get('add_generation_prompt', True)),
+        enable_thinking=kwargs.get('enable_thinking'),
+    )
+    return rendered, {
+        'direct_apply_chat_template': False,
+        'metadata_template': True,
+        'jinja_renderer': True,
+    }
+
 try:
     init_line = sys.stdin.readline()
     if not init_line:
@@ -1129,6 +1270,33 @@ for line in sys.stdin:
             _emit(_safe_request_error('malformed_kwargs', request=request))
             continue
         if method in {'apply_chat_template', 'render_and_tokenize_chat'}:
+            if method == 'render_and_tokenize_chat':
+                try:
+                    rendered_prompt, _render_diagnostics = _render_chat_with_runtime_template(
+                        llama, request.get('args', []), kwargs
+                    )
+                    if not isinstance(rendered_prompt, str):
+                        _emit(_safe_request_error('prompt_render_unavailable', request=request))
+                        continue
+                    tokenize = getattr(llama, 'tokenize', None)
+                    if not callable(tokenize):
+                        _emit(_safe_request_error('runtime_tokenizer_unavailable', request=request))
+                        continue
+                    tokens = tokenize(rendered_prompt.encode('utf-8'), add_bos=False)
+                    if not isinstance(tokens, (list, tuple)):
+                        _emit(_safe_request_error('runtime_tokenizer_unavailable', request=request))
+                        continue
+                    _emit({'status': 'ok', 'result': {'prompt_tokens': len(tokens)}})
+                except Exception as exc:
+                    reason = str(exc) if str(exc) in {
+                        'runtime_chat_template_metadata_missing',
+                        'runtime_chat_template_renderer_unavailable',
+                        'runtime_tokenizer_unavailable',
+                        'runtime_template_tokenizer_bridge_unavailable',
+                        'runtime_chat_template_render_exception',
+                    } else 'runtime_chat_template_render_exception'
+                    _emit(_safe_request_error(reason, request=request, exc=exc))
+                continue
             render = getattr(llama, 'apply_chat_template', None)
             if not callable(render):
                 tokenizer = getattr(llama, 'tokenizer', None)
@@ -1138,37 +1306,6 @@ for line in sys.stdin:
                     except Exception:
                         tokenizer = None
                 render = getattr(tokenizer, 'apply_chat_template', None) if tokenizer is not None else None
-            if method == 'render_and_tokenize_chat':
-                if not callable(render):
-                    _emit(_safe_request_error('runtime_template_tokenizer_bridge_unavailable', request=request))
-                    continue
-                try:
-                    try:
-                        rendered_prompt = render(*request.get('args', []), **kwargs)
-                    except TypeError:
-                        if 'enable_thinking' not in kwargs:
-                            raise
-                        compatibility_kwargs = dict(kwargs)
-                        compatibility_kwargs.pop('enable_thinking', None)
-                        rendered_prompt = render(
-                            *request.get('args', []),
-                            **compatibility_kwargs,
-                        )
-                    if not isinstance(rendered_prompt, str):
-                        _emit(_safe_request_error('prompt_render_unavailable', request=request))
-                        continue
-                    tokenize = getattr(llama, 'tokenize', None)
-                    if not callable(tokenize):
-                        _emit(_safe_request_error('runtime_template_tokenizer_bridge_unavailable', request=request))
-                        continue
-                    tokens = tokenize(rendered_prompt.encode('utf-8'), add_bos=False)
-                    if not isinstance(tokens, (list, tuple)):
-                        _emit(_safe_request_error('tokenizer_unavailable', request=request))
-                        continue
-                    _emit({'status': 'ok', 'result': {'prompt_tokens': len(tokens)}})
-                except Exception as exc:
-                    _emit(_safe_request_error('runtime_template_tokenizer_bridge_unavailable', request=request, exc=exc))
-                continue
             if not callable(render):
                 try:
                     chat_format = getattr(llama, 'chat_format', None) or 'llama-2'

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2127,7 +2127,13 @@ class RelayClient:
 
         try:
             return importlib.import_module("api.v1.models")
-        except Exception:
+        except Exception as exc:
+            diagnostics = getattr(exc, "diagnostics", None)
+            if isinstance(diagnostics, dict):
+                try:
+                    setattr(llm_instance, "_token_place_last_render_tokenize_error", dict(diagnostics))
+                except Exception:
+                    pass
             return None
 
     @staticmethod
@@ -2438,6 +2444,7 @@ class RelayClient:
         messages: List[Dict[str, Any]],
         *,
         enable_thinking: Optional[bool] = None,
+        model_profile: Optional[Dict[str, Any]] = None,
     ) -> Optional[int]:
         """Render and tokenize in one runtime bridge call when the facade exposes it."""
 
@@ -2445,6 +2452,13 @@ class RelayClient:
         if not callable(render_and_tokenize):
             return None
         kwargs = {"tokenize": False, "add_generation_prompt": True}
+        model_manager = getattr(llm_instance, "model_manager", None)
+        profile = model_profile or getattr(model_manager, "model_profile", None) or getattr(llm_instance, "model_profile", None) or {}
+        if isinstance(profile, dict):
+            if profile.get("provider"):
+                kwargs["token_place_provider"] = profile.get("provider")
+            if profile.get("chat_template_policy"):
+                kwargs["token_place_template_policy"] = profile.get("chat_template_policy")
         if enable_thinking is not None:
             kwargs["enable_thinking"] = enable_thinking
         try:
@@ -2622,8 +2636,10 @@ class RelayClient:
         active_context_tier: str,
         configured_context_tokens: int,
         requested_context_tier: str,
+        internal_reason: str = "runtime_template_tokenizer_bridge_unavailable",
+        diagnostics: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        return {
+        error = {
             "code": "compute_node_context_admission_unavailable",
             "type": "validation_error",
             "message": (
@@ -2634,8 +2650,23 @@ class RelayClient:
             "requested_context_tier": requested_context_tier,
             "configured_context_tokens": configured_context_tokens,
             "retryable": False,
-            "internal_reason": "runtime_template_tokenizer_bridge_unavailable",
+            "internal_reason": internal_reason,
         }
+        safe_diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
+        for key in (
+            "active_model_id",
+            "active_profile_id",
+            "context_tier",
+            "template_policy",
+            "non_thinking_mode",
+            "runtime_facade_type",
+            "direct_apply_chat_template_available",
+            "metadata_template_available",
+            "jinja_renderer_available",
+        ):
+            if key in safe_diagnostics:
+                error[key] = safe_diagnostics[key]
+        return error
 
     def _api_v1_context_admission_error(
         self,
@@ -2709,6 +2740,7 @@ class RelayClient:
             llm_instance,
             messages,
             enable_thinking=None,
+            model_profile=model_profile,
         )
         if prompt_tokens is None:
             rendered_prompt = self._api_v1_render_chat_prompt(
@@ -2729,11 +2761,34 @@ class RelayClient:
                 else None
             )
         if prompt_tokens is None:
+            worker_diagnostics = getattr(llm_instance, "_token_place_last_render_tokenize_error", None)
+            internal_reason = "runtime_template_tokenizer_bridge_unavailable"
+            if isinstance(worker_diagnostics, dict) and isinstance(worker_diagnostics.get("reason"), str):
+                internal_reason = worker_diagnostics["reason"]
+            safe_diagnostics = {
+                "active_model_id": getattr(self.model_manager, "api_model_id", None),
+                "active_profile_id": model_profile.get("id") or model_profile.get("model_id"),
+                "context_tier": active_context_tier,
+                "template_policy": model_profile.get("chat_template_policy") or "llama-3",
+                "non_thinking_mode": is_qwen_non_thinking,
+                "runtime_facade_type": type(llm_instance).__name__,
+                "direct_apply_chat_template_available": callable(getattr(llm_instance, "apply_chat_template", None)),
+                "metadata_template_available": internal_reason != "runtime_chat_template_metadata_missing",
+                "jinja_renderer_available": internal_reason != "runtime_chat_template_renderer_unavailable",
+            }
             log_error(
-                "api_v1.context_admission active_tier={} result=rejected reason={} safe_error_code={}",
+                "api_v1.context_admission active_tier={} result=rejected reason={} safe_error_code={} model_id={} profile_id={} template_policy={} non_thinking={} runtime_facade={} direct_apply_chat_template_available={} metadata_template_available={} jinja_renderer_available={}",
                 active_context_tier,
-                "runtime_template_tokenizer_bridge_unavailable",
+                internal_reason,
                 "compute_node_context_admission_unavailable",
+                safe_diagnostics["active_model_id"],
+                safe_diagnostics["active_profile_id"],
+                safe_diagnostics["template_policy"],
+                safe_diagnostics["non_thinking_mode"],
+                safe_diagnostics["runtime_facade_type"],
+                safe_diagnostics["direct_apply_chat_template_available"],
+                safe_diagnostics["metadata_template_available"],
+                safe_diagnostics["jinja_renderer_available"],
             )
             return (
                 False,
@@ -2741,6 +2796,8 @@ class RelayClient:
                     active_context_tier=active_context_tier,
                     configured_context_tokens=configured_context_tokens,
                     requested_context_tier=requested_context_tier,
+                    internal_reason=internal_reason,
+                    diagnostics=safe_diagnostics,
                 ),
                 None,
             )

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2465,13 +2465,25 @@ class RelayClient:
                     "compute_node_context_admission_unavailable",
                 )
             return None
-        except Exception:
+        except Exception as exc:
+            if _is_llama_cpp_inference_request_error(exc):
+                diagnostics = getattr(exc, "diagnostics", None)
+                if isinstance(diagnostics, dict):
+                    safe_diagnostics = {}
+                    for key, value in diagnostics.items():
+                        if isinstance(key, str) and isinstance(value, (str, bool, int, float, type(None))):
+                            safe_diagnostics[key] = value
+                    llm_instance._token_place_last_render_tokenize_error = safe_diagnostics
+                else:
+                    llm_instance._token_place_last_render_tokenize_error = {}
             return None
         if isinstance(result, dict):
             prompt_tokens = result.get("prompt_tokens")
         else:
             prompt_tokens = result
         if isinstance(prompt_tokens, int) and prompt_tokens >= 0:
+            if hasattr(llm_instance, "_token_place_last_render_tokenize_error"):
+                delattr(llm_instance, "_token_place_last_render_tokenize_error")
             return prompt_tokens
         return None
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2127,13 +2127,7 @@ class RelayClient:
 
         try:
             return importlib.import_module("api.v1.models")
-        except Exception as exc:
-            diagnostics = getattr(exc, "diagnostics", None)
-            if isinstance(diagnostics, dict):
-                try:
-                    setattr(llm_instance, "_token_place_last_render_tokenize_error", dict(diagnostics))
-                except Exception:
-                    pass
+        except Exception:
             return None
 
     @staticmethod


### PR DESCRIPTION
### Motivation
- Packaged macOS Qwen runtimes exposed model generation but often lacked direct `apply_chat_template` helpers, causing API v1 readiness to fail before registration with `runtime_template_tokenizer_bridge_unavailable`.
- API v1 context admission must use the same exact template shape that generation uses, enforce Qwen non-thinking behavior, and count tokens with the runtime tokenizer without leaking rendered prompts.
- The system must fail closed when a verified Qwen/GGUF/Jinja path cannot be proven, and provide safe diagnostic reasons (without logging plaintext prompts).

### Description
- Implemented worker-side GGUF/Jinja discovery and rendering in the llama-cpp subprocess; added metadata probing across `llama`, `llama.model/_model`, and tokenizer metadata to extract the GGUF chat template.
- Prefer a `llama_cpp.llama_chat_format.Jinja2ChatFormatter` when present; otherwise render the GGUF Jinja template with `jinja2`, then call the runtime `tokenize` inside the worker and return only `prompt_tokens` to the parent process.
- Kept the existing direct `apply_chat_template`/tokenizer-backed paths intact and explicitly avoided any Llama-family chat-format fallbacks for Qwen; added fail-closed checks that raise specific safe reasons such as `runtime_chat_template_metadata_missing`, `runtime_chat_template_renderer_unavailable`, `runtime_tokenizer_unavailable`, and `runtime_chat_template_render_exception`.
- Added focused unit tests and worker smoke coverage for packaged-style runtimes and readiness: updated `utils/llm/model_manager.py` and tests in `tests/unit/test_model_manager.py` to cover GGUF/Jinja fallback, fail-closed missing metadata, no rendered prompt leakage, and ensuring Llama formatters are not used for Qwen metadata paths.

### Testing
- Ran the focused test suites and CI checks and they all passed: `python -m pytest tests/unit/test_model_manager.py -q` (passed), `python -m pytest tests/unit/test_relay_client.py -q` (passed), `python -m pytest tests/unit/test_compute_node_runtime.py -q` (passed), `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (passed), `python -m pytest tests/unit/test_context_profiles.py -q` (passed), and `python -m pytest tests/unit/test_desktop_model_bridge.py -q` (passed).
- Pre-commit hooks were run and passed via `pre-commit run --all-files` and repository checks `git diff --check` returned clean results.
- New tests added: worker render/tokenize GGUF/Jinja metadata fallback, worker returns `prompt_tokens` only, fail-closed when metadata missing, and metadata-path does not invoke Llama formatter; all new and existing tests succeeded in the local test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a433ace1194832f9cd31851636a8a85)