### PR TITLE
Fix Qwen API v1 response handling and surface safe relay diagnostics

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -1211,11 +1211,24 @@ new Vue({
             }
 
             const code = typeof error.code === 'string' && error.code.trim() ? error.code.trim() : '';
-            return {
+            const sanitized = {
                 userMessage: this.getUserFacingApiError(response),
                 terminalSelectedServer: error.terminalSelectedServer === true,
                 code
             };
+            [
+                'request_id',
+                'internal_reason',
+                'active_context_tier',
+                'requested_context_tier',
+                'retryable'
+            ].forEach((field) => {
+                const value = error[field];
+                if (typeof value === 'string' || typeof value === 'boolean' || typeof value === 'number') {
+                    sanitized[field] = value;
+                }
+            });
+            return sanitized;
         },
 
         isInvalidAssistantResponseContent(content) {
@@ -1255,7 +1268,7 @@ new Vue({
                     const normalizedError = this.normalizeApiV1ResponseError(response);
                     if (normalizedError) {
                         if (normalizedError.code) {
-                            console.warn('API v1 structured error rendered:', { code: normalizedError.code });
+                            console.warn('API v1 structured error rendered:', normalizedError);
                         }
                         this.chatHistory.push({
                             role: 'assistant',

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5141,3 +5141,102 @@ def test_render_tokenize_success_clears_stale_worker_diagnostics():
 
     assert prompt_tokens == 3
     assert not hasattr(runtime, "_token_place_last_render_tokenize_error")
+
+
+def test_qwen_completion_text_shape_converts_to_assistant_message():
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = 'qwen3-8b-instruct'
+    manager.model_profile = {'provider': 'qwen', 'thinking_mode': 'disabled'}
+    manager.runtime.create_chat_completion = lambda **kwargs: {
+        'choices': [{'text': 'text fallback ok'}]
+    }
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id='req-qwen-text',
+        model_id='qwen3-8b-instruct',
+        messages=[{'role': 'user', 'content': 'hello'}],
+        options={'max_tokens': 5},
+        requested_context_tier='8k-fast',
+    )
+
+    assert envelope['api_v1_response']['message'] == {
+        'role': 'assistant',
+        'content': 'text fallback ok',
+    }
+
+
+def test_qwen_completion_message_without_role_converts_to_assistant_message():
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = 'qwen3-8b-instruct'
+    manager.model_profile = {'provider': 'qwen', 'thinking_mode': 'disabled'}
+    manager.runtime.create_chat_completion = lambda **kwargs: {
+        'choices': [{'message': {'content': 'role omitted ok'}}]
+    }
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id='req-qwen-role-omitted',
+        model_id='qwen3-8b-instruct',
+        messages=[{'role': 'user', 'content': 'hello'}],
+        options={'max_tokens': 5},
+        requested_context_tier='8k-fast',
+    )
+
+    assert envelope['api_v1_response']['message'] == {
+        'role': 'assistant',
+        'content': 'role omitted ok',
+    }
+
+
+def test_qwen_think_output_error_includes_safe_reason_and_request_id():
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = 'qwen3-8b-instruct'
+    manager.model_profile = {'provider': 'qwen', 'thinking_mode': 'disabled'}
+    manager.runtime.create_chat_completion = lambda **kwargs: {
+        'choices': [{'message': {'role': 'assistant', 'content': '<think>secret</think>answer'}}]
+    }
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id='req-qwen-think-safe',
+        model_id='qwen3-8b-instruct',
+        messages=[{'role': 'user', 'content': 'hello'}],
+        options={'max_tokens': 5},
+        requested_context_tier='8k-fast',
+    )
+
+    error = envelope['api_v1_response']['error']
+    assert error['code'] == 'compute_node_invalid_model_output'
+    assert error['request_id'] == 'req-qwen-think-safe'
+    assert error['internal_reason'] == 'qwen_thinking_output_leaked'
+    assert error['prompt_tokens'] is not None
+    assert error['requested_output_tokens'] == 5
+    assert error['runtime_healthy'] is True
+    assert 'secret' not in json.dumps(error)
+
+
+def test_runtime_unsupported_option_exception_is_safe_structured_error():
+    from utils.llm.model_manager import LlamaCppInferenceRequestError
+
+    manager = _AdmissionManager(window=128)
+    manager.runtime.create_chat_completion = MagicMock(
+        side_effect=LlamaCppInferenceRequestError(
+            'unsupported kwarg: top_k',
+            diagnostics={'reason': 'unsupported_option', 'option': 'top_k'},
+        )
+    )
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id='req-unsupported-runtime-option',
+        model_id='llama-3-8b-instruct',
+        messages=[{'role': 'user', 'content': 'hello'}],
+        options={'max_tokens': 5},
+        requested_context_tier='8k-fast',
+    )
+
+    error = envelope['api_v1_response']['error']
+    assert error['code'] == 'compute_node_options_unsupported'
+    assert error['request_id'] == 'req-unsupported-runtime-option'
+    assert error['internal_reason'] == 'runtime_options_unsupported'

--- a/tests/unit/test_touch_ui.py
+++ b/tests/unit/test_touch_ui.py
@@ -159,6 +159,12 @@ def test_landing_chat_js_maps_structured_api_v1_errors_to_user_messages():
     assert "The LLM server returned an invalid response. Please try again." in chat_js
     assert "This request exceeds the current API size limit. Please shorten it and try again." in chat_js
     assert "This prompt exceeds the selected LLM server's context window." in chat_js
+    assert "API v1 structured error rendered:" in chat_js
+    assert "request_id" in chat_js
+    assert "internal_reason" in chat_js
+    assert "active_context_tier" in chat_js
+    assert "requested_context_tier" in chat_js
+    assert "retryable" in chat_js
     assert "distributed provider timed out contacting relay bridge" not in chat_js
     assert "distributed provider request failed" not in chat_js
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1737,13 +1737,15 @@ class RelayClient:
         request_id: str,
         *,
         message: Optional[Dict[str, Any]] = None,
-        error: Optional[Dict[str, str]] = None,
+        error: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Build an encrypted API v1 relay response envelope body."""
 
         api_v1_response: Dict[str, Any]
         if error is not None:
-            api_v1_response = {"error": error}
+            safe_error = dict(error)
+            safe_error.setdefault("request_id", request_id)
+            api_v1_response = {"error": safe_error}
         else:
             api_v1_response = {"message": message}
         return {
@@ -2883,9 +2885,15 @@ class RelayClient:
             and completion["choices"]
             and isinstance(completion["choices"][0], dict)
         ):
-            message = self._valid_api_v1_assistant_message(
-                completion["choices"][0].get("message")
-            )
+            choice = completion["choices"][0]
+            raw_message = choice.get("message")
+            if isinstance(raw_message, dict) and "role" not in raw_message:
+                raw_message = {**raw_message, "role": "assistant"}
+            message = self._valid_api_v1_assistant_message(raw_message)
+            if message is None and isinstance(choice.get("text"), str):
+                message = self._valid_api_v1_assistant_message(
+                    {"role": "assistant", "content": choice.get("text")}
+                )
             model_profile = getattr(self.model_manager, "model_profile", {}) or {}
             if (
                 message is not None
@@ -2896,11 +2904,13 @@ class RelayClient:
             ):
                 # Fail closed instead of stripping so no hidden reasoning can be
                 # partially leaked or mis-accounted in API v1 relay responses.
+                self._last_api_v1_invalid_output_reason = "qwen_thinking_output_leaked"
                 return None
             return message
 
         # API v1 relay inference is explicitly non-streaming; runtimes must return
         # a complete chat completion object for this path.
+        self._last_api_v1_invalid_output_reason = "malformed_completion"
         return None
 
     def _generate_api_v1_response_with_runtime_model(
@@ -2919,6 +2929,7 @@ class RelayClient:
             "recovery_attempted": False,
             "recovery_succeeded": False,
         }
+        self._last_api_v1_invalid_output_reason = None
 
         validation_result = self._validate_api_v1_chat_messages(messages)
         if not validation_result.valid:
@@ -3072,11 +3083,24 @@ class RelayClient:
 
             if assistant_message is None:
                 log_error("Desktop runtime returned invalid API v1 assistant output")
+                invalid_reason = self._last_api_v1_invalid_output_reason or "malformed_completion"
                 return self._api_v1_response_envelope(
                     request_id,
                     error={
                         "code": "compute_node_invalid_model_output",
                         "message": "Desktop runtime returned invalid assistant output",
+                        "internal_reason": invalid_reason,
+                        "active_context_tier": normalize_context_tier(
+                            getattr(
+                                self.model_manager,
+                                "context_tier",
+                                DEFAULT_CONTEXT_TIER,
+                            )
+                        ),
+                        "requested_context_tier": requested_context_tier,
+                        "prompt_tokens": prompt_tokens,
+                        "requested_output_tokens": completion_kwargs["max_tokens"],
+                        **self._last_api_v1_runtime_health,
                     },
                 )
 
@@ -3088,6 +3112,12 @@ class RelayClient:
                     "recovery_attempted": False,
                     "recovery_succeeded": False,
                 }
+                diagnostics = getattr(exc, "diagnostics", {})
+                unsupported_option = (
+                    isinstance(diagnostics, dict)
+                    and isinstance(diagnostics.get("option"), str)
+                    and diagnostics.get("option")
+                )
                 log_error(
                     "Desktop runtime rejected API v1 relay inference request",
                     exc_info=True,
@@ -3095,8 +3125,19 @@ class RelayClient:
                 return self._api_v1_response_envelope(
                     request_id,
                     error={
-                        "code": "compute_node_internal_error",
+                        "code": "compute_node_options_unsupported"
+                        if unsupported_option
+                        else "compute_node_internal_error",
                         "message": "Desktop runtime rejected the inference request",
+                        "internal_reason": "runtime_options_unsupported"
+                        if unsupported_option
+                        else "runtime_inference_request_rejected",
+                        **(
+                            {"rejected_option": diagnostics["option"]}
+                            if unsupported_option
+                            else {}
+                        ),
+                        **self._last_api_v1_runtime_health,
                     },
                 )
             recovery_attempted = (


### PR DESCRIPTION
### Motivation
- Qwen-based packaged runtimes can return valid but variant llama-cpp-python completion shapes that previously produced opaque post-registration failures. 
- Landing-page console warnings collapsed structured errors into an unhelpful `{ Object }` view, making safe triage of remaining failures difficult. 
- Error envelopes submitted through the relay needed to preserve non-sensitive diagnostic fields so clients and operators can see safe codes and request ids without leaking plaintext.

### Description
- Preserve safe structured diagnostics in encrypted relay responses by copying and defaulting `request_id` into `api_v1_response.error` in `utils/networking/relay_client.py` and keeping error shape relay/E2EE-compatible. 
- Normalize runtime completion shapes in `_assistant_message_from_runtime_completion` to accept `choices[0].message.content`, `choices[0].text` fallbacks, and message objects missing a `role`, converting to an assistant message only when safe. 
- Detect and fail closed on disabled-thinking Qwen leakage by rejecting content containing `<think` and setting an internal-safe `internal_reason: "qwen_thinking_output_leaked"` rather than stripping content. 
- When invalid assistant output occurs, return `compute_node_invalid_model_output` with safe diagnostics (`internal_reason`, `request_id`, `active_context_tier`, `requested_context_tier`, `prompt_tokens`, `requested_output_tokens`, and runtime health flags) while explicitly avoiding any plaintext prompts, ciphertext, keys, or decrypted payloads. 
- Map request-scoped llama-cpp runtime request errors that include an unsupported `option` diagnostic into a safe `compute_node_options_unsupported` envelope exposing `rejected_option` and `internal_reason`, otherwise keep `compute_node_internal_error`. 
- Improve landing-page diagnostics in `static/chat.js` by returning a sanitized structured error object from `normalizeApiV1ResponseError(response)` and logging only a sanitized object containing `code`, `request_id`, `internal_reason`, tier fields, and `retryable` (never logging prompts or ciphertext). 
- Add focused unit tests covering Qwen-shaped runtime outputs, conversion of `choices[0].text`, omitted-role messages, `<think>` leakage handling, unsupported-option diagnostics, and that the landing-page JS references the new sanitized fields (`tests/unit/test_relay_client.py` and `tests/unit/test_touch_ui.py`). 

### Testing
- Ran focused Python unit suites: `python -m pytest tests/unit/test_model_manager.py -q` (passed), `python -m pytest tests/unit/test_relay_client.py -q` (passed), `python -m pytest tests/unit/test_compute_node_runtime.py -q` (passed), `python -m pytest tests/unit/test_context_profiles.py -q` (passed), and `python -m pytest tests/unit/test_touch_ui.py -q` (passed). 
- Ran integration tests: `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (passed). 
- Ran repository checks: `pre-commit run --all-files` (passed) and `git diff --check` (no problems).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a444c7746ac832fbebc21f252bfd0fc)