### PR TITLE
Fix Qwen API v1 response handling and add safe relay error diagnostics

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -1211,10 +1211,30 @@ new Vue({
             }
 
             const code = typeof error.code === 'string' && error.code.trim() ? error.code.trim() : '';
+            const safeDiagnosticKeys = [
+                'request_id',
+                'internal_reason',
+                'active_context_tier',
+                'requested_context_tier',
+                'retryable'
+            ];
+            const diagnostics = {};
+            if (code) {
+                diagnostics.code = code;
+            }
+            safeDiagnosticKeys.forEach((key) => {
+                if (Object.prototype.hasOwnProperty.call(error, key)) {
+                    const value = error[key];
+                    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+                        diagnostics[key] = value;
+                    }
+                }
+            });
             return {
                 userMessage: this.getUserFacingApiError(response),
                 terminalSelectedServer: error.terminalSelectedServer === true,
-                code
+                code,
+                diagnostics
             };
         },
 
@@ -1255,7 +1275,7 @@ new Vue({
                     const normalizedError = this.normalizeApiV1ResponseError(response);
                     if (normalizedError) {
                         if (normalizedError.code) {
-                            console.warn('API v1 structured error rendered:', { code: normalizedError.code });
+                            console.warn('API v1 structured error rendered:', normalizedError.diagnostics);
                         }
                         this.chatHistory.push({
                             role: 'assistant',

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -1380,6 +1380,11 @@ def test_landing_chat_structured_compute_error_renders_safe_message(
                 "error": {
                     "code": "compute_node_model_unsupported",
                     "message": "Requested model is not available in the desktop runtime",
+                    "request_id": "req-safe-diag",
+                    "internal_reason": "model_id_unavailable",
+                    "active_context_tier": "8k-fast",
+                    "requested_context_tier": "64k-full",
+                    "retryable": False,
                 }
             }
         ],
@@ -1408,7 +1413,12 @@ def test_landing_chat_structured_compute_error_renders_safe_message(
     body_text = page.locator("body").inner_text()
     assert "hello structured error" in body_text
     assert not any("Unexpected response format" in message for message in console_errors)
-    assert any("compute_node_model_unsupported" in message for message in console_warnings)
+    warning_text = "\n".join(console_warnings)
+    assert "compute_node_model_unsupported" in warning_text
+    assert "req-safe-diag" in warning_text
+    assert "model_id_unavailable" in warning_text
+    assert "8k-fast" in warning_text
+    assert "64k-full" in warning_text
     assert state["relay_requests"], "expected the landing chat to POST an API v1 relay payload"
     assert state["chat_completions"] == []
     assert state["v2_requests"] == []

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5141,3 +5141,103 @@ def test_render_tokenize_success_clears_stale_worker_diagnostics():
 
     assert prompt_tokens == 3
     assert not hasattr(runtime, "_token_place_last_render_tokenize_error")
+
+
+def test_qwen_completion_text_fallback_converts_to_assistant_message():
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = 'qwen3-8b-instruct'
+    manager.model_profile = {'provider': 'qwen', 'thinking_mode': 'disabled'}
+    manager.runtime.create_chat_completion = lambda **kwargs: {
+        'choices': [{'text': 'text fallback ok'}]
+    }
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id='req-qwen-text',
+        model_id='qwen3-8b-instruct',
+        messages=[{'role': 'user', 'content': 'hello'}],
+        options={'max_tokens': 5},
+        requested_context_tier='8k-fast',
+    )
+
+    assert envelope['api_v1_response']['message'] == {
+        'role': 'assistant',
+        'content': 'text fallback ok',
+    }
+
+
+def test_qwen_completion_message_without_role_converts_to_assistant_message():
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = 'qwen3-8b-instruct'
+    manager.model_profile = {'provider': 'qwen', 'thinking_mode': 'disabled'}
+    manager.runtime.create_chat_completion = lambda **kwargs: {
+        'choices': [{'message': {'content': 'role omitted ok'}}]
+    }
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id='req-qwen-role-omitted',
+        model_id='qwen3-8b-instruct',
+        messages=[{'role': 'user', 'content': 'hello'}],
+        options={'max_tokens': 5},
+        requested_context_tier='8k-fast',
+    )
+
+    assert envelope['api_v1_response']['message'] == {
+        'role': 'assistant',
+        'content': 'role omitted ok',
+    }
+
+
+def test_qwen_think_output_error_includes_safe_reason_and_request_id():
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = 'qwen3-8b-instruct'
+    manager.model_profile = {'provider': 'qwen', 'thinking_mode': 'disabled'}
+    manager.runtime.create_chat_completion = lambda **kwargs: {
+        'choices': [{'message': {'role': 'assistant', 'content': '<think>secret</think>answer'}}]
+    }
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id='req-qwen-think-safe',
+        model_id='qwen3-8b-instruct',
+        messages=[{'role': 'user', 'content': 'hello'}],
+        options={'max_tokens': 5},
+        requested_context_tier='8k-fast',
+    )
+
+    error = envelope['api_v1_response']['error']
+    assert error['code'] == 'compute_node_invalid_model_output'
+    assert error['request_id'] == 'req-qwen-think-safe'
+    assert error['internal_reason'] == 'qwen_thinking_output_leaked'
+    assert 'secret' not in json.dumps(error)
+
+
+def test_qwen_unsupported_generation_option_surfaces_specific_safe_error():
+    from utils.llm.model_manager import LlamaCppInferenceRequestError
+
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = 'qwen3-8b-instruct'
+    manager.model_profile = {'provider': 'qwen', 'thinking_mode': 'disabled'}
+
+    def reject_option(**kwargs):
+        raise LlamaCppInferenceRequestError(
+            'bad option contains no prompt',
+            diagnostics={'rejected_option': 'top_k'},
+        )
+
+    manager.runtime.create_chat_completion = reject_option
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id='req-qwen-option',
+        model_id='qwen3-8b-instruct',
+        messages=[{'role': 'user', 'content': 'hello'}],
+        options={'max_tokens': 5},
+        requested_context_tier='8k-fast',
+    )
+
+    error = envelope['api_v1_response']['error']
+    assert error['code'] == 'compute_node_options_unsupported'
+    assert error['internal_reason'] == 'unsupported_generation_option'
+    assert error['rejected_option'] == 'top_k'

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1737,13 +1737,15 @@ class RelayClient:
         request_id: str,
         *,
         message: Optional[Dict[str, Any]] = None,
-        error: Optional[Dict[str, str]] = None,
+        error: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Build an encrypted API v1 relay response envelope body."""
 
         api_v1_response: Dict[str, Any]
         if error is not None:
-            api_v1_response = {"error": error}
+            safe_error = dict(error)
+            safe_error.setdefault("request_id", request_id)
+            api_v1_response = {"error": safe_error}
         else:
             api_v1_response = {"message": message}
         return {
@@ -2877,31 +2879,41 @@ class RelayClient:
     ) -> Optional[Dict[str, Any]]:
         """Extract an API v1 assistant message from direct llama.cpp output."""
 
-        if (
+        self._last_api_v1_invalid_model_output_reason = None
+        if not (
             isinstance(completion, dict)
             and isinstance(completion.get("choices"), list)
             and completion["choices"]
             and isinstance(completion["choices"][0], dict)
         ):
-            message = self._valid_api_v1_assistant_message(
-                completion["choices"][0].get("message")
-            )
-            model_profile = getattr(self.model_manager, "model_profile", {}) or {}
-            if (
-                message is not None
-                and model_profile.get("provider") == "qwen"
-                and model_profile.get("thinking_mode") == "disabled"
-                and isinstance(message.get("content"), str)
-                and "<think" in message["content"].lower()
-            ):
-                # Fail closed instead of stripping so no hidden reasoning can be
-                # partially leaked or mis-accounted in API v1 relay responses.
-                return None
-            return message
+            self._last_api_v1_invalid_model_output_reason = "completion_shape_invalid"
+            return None
 
-        # API v1 relay inference is explicitly non-streaming; runtimes must return
-        # a complete chat completion object for this path.
-        return None
+        choice = completion["choices"][0]
+        raw_message = choice.get("message")
+        if isinstance(raw_message, dict):
+            message = dict(raw_message)
+            if "role" not in message and "content" in message:
+                message["role"] = "assistant"
+        elif "text" in choice:
+            message = {"role": "assistant", "content": choice.get("text")}
+        else:
+            message = None
+
+        assistant_message = self._valid_api_v1_assistant_message(message)
+        model_profile = getattr(self.model_manager, "model_profile", {}) or {}
+        if (
+            assistant_message is not None
+            and model_profile.get("provider") == "qwen"
+            and model_profile.get("thinking_mode") == "disabled"
+            and isinstance(assistant_message.get("content"), str)
+            and "<think" in assistant_message["content"].lower()
+        ):
+            self._last_api_v1_invalid_model_output_reason = "qwen_thinking_output_leaked"
+            return None
+        if assistant_message is None:
+            self._last_api_v1_invalid_model_output_reason = "assistant_message_invalid"
+        return assistant_message
 
     def _generate_api_v1_response_with_runtime_model(
         self,
@@ -3071,12 +3083,21 @@ class RelayClient:
                 )
 
             if assistant_message is None:
-                log_error("Desktop runtime returned invalid API v1 assistant output")
+                invalid_reason = getattr(
+                    self,
+                    "_last_api_v1_invalid_model_output_reason",
+                    "assistant_message_invalid",
+                ) or "assistant_message_invalid"
+                log_error(
+                    "Desktop runtime returned invalid API v1 assistant output reason={}",
+                    invalid_reason,
+                )
                 return self._api_v1_response_envelope(
                     request_id,
                     error={
                         "code": "compute_node_invalid_model_output",
                         "message": "Desktop runtime returned invalid assistant output",
+                        "internal_reason": invalid_reason,
                     },
                 )
 
@@ -3088,17 +3109,30 @@ class RelayClient:
                     "recovery_attempted": False,
                     "recovery_succeeded": False,
                 }
+                rejected_option = getattr(exc, "option", None)
+                diagnostics = getattr(exc, "diagnostics", None)
+                if not isinstance(rejected_option, str) and isinstance(diagnostics, dict):
+                    maybe_option = diagnostics.get("option") or diagnostics.get("rejected_option")
+                    if isinstance(maybe_option, str):
+                        rejected_option = maybe_option
                 log_error(
-                    "Desktop runtime rejected API v1 relay inference request",
-                    exc_info=True,
+                    "Desktop runtime rejected API v1 relay inference request safe_error_code={} rejected_option={}",
+                    "compute_node_options_unsupported" if rejected_option else "compute_node_internal_error",
+                    rejected_option or "unknown",
                 )
-                return self._api_v1_response_envelope(
-                    request_id,
-                    error={
+                if rejected_option:
+                    error = {
+                        "code": "compute_node_options_unsupported",
+                        "message": "Desktop runtime rejected an inference option",
+                        "internal_reason": "unsupported_generation_option",
+                        "rejected_option": rejected_option,
+                    }
+                else:
+                    error = {
                         "code": "compute_node_internal_error",
                         "message": "Desktop runtime rejected the inference request",
-                    },
-                )
+                    }
+                return self._api_v1_response_envelope(request_id, error=error)
             recovery_attempted = (
                 "replacement" in str(exc).lower()
                 or "restart" in str(exc).lower()
@@ -3180,6 +3214,10 @@ class RelayClient:
                         "compute_node_process_failed",
                     }:
                         runtime_healthy = True
+                    if isinstance(error, dict):
+                        error.setdefault("runtime_healthy", runtime_healthy)
+                        error.setdefault("recovery_attempted", recovery_attempted)
+                        error.setdefault("recovery_succeeded", recovery_succeeded)
                     submitted = self._post_api_v1_response(
                         response_envelope,
                         client_pub_key_b64=client_pub_key_b64,


### PR DESCRIPTION
### Motivation
- Packaged Qwen nodes register successfully but post-registration API v1 failures produced opaque/collapsed diagnostics in the browser, impeding debugging and masking safe failure reasons.
- The runtime completion path needed to accept realistic llama-cpp-python / Qwen completion shapes (including `choices[0].text` and messages missing `role`) and to first-class detect `<think>` leakage when thinking is disabled.

### Description
- Added safe browser diagnostics in `static/chat.js` so `normalizeApiV1ResponseError` returns a sanitized `diagnostics` object containing only scalar safe fields (`code`, `request_id`, `internal_reason`, `active_context_tier`, `requested_context_tier`, `retryable`) and the landing page now logs that sanitized object instead of an opaque collapsed `Object` while leaving user-facing messages unchanged.
- Preserved safe diagnostics inside encrypted API v1 error envelopes in `utils/networking/relay_client.py` by copying the error dict into a `safe_error`, setting `request_id` when missing, and ensuring runtime health/recovery metadata (`runtime_healthy`, `recovery_attempted`, `recovery_succeeded`) is attached to error objects before submission.
- Normalized runtime completion shapes in `utils/networking/relay_client.py` by accepting `choices[0].message.content`, falling back to `choices[0].text` when appropriate, and accepting message objects missing `role` by setting `role: 'assistant'` when safe; added request-scoped tracking (`_last_api_v1_invalid_model_output_reason`) and surfaced `internal_reason` on invalid outputs.
- Added first-class handling of llama-cpp-python request-scoped option rejection: if a `LlamaCppInferenceRequestError` indicates a rejected generation option, return `compute_node_options_unsupported` with `internal_reason: 'unsupported_generation_option'` and a `rejected_option` diagnostic rather than collapsing to a generic internal error.
- If Qwen produces `<think>` despite thinking being disabled, reject as `compute_node_invalid_model_output` and annotate `internal_reason: 'qwen_thinking_output_leaked'` while ensuring no model content or prompts are logged.
- Added focused tests in `tests/unit/test_relay_client.py` covering `choices[0].text` fallback, message-without-role conversion, `<think>` leakage safe diagnostics, and unsupported-option surfacing, and updated `tests/e2e/test_ui.py` to assert the browser console warning contains safe diagnostic fields.

### Testing
- Ran unit, integration, and pre-commit checks locally: `python -m pytest tests/unit/test_relay_client.py -q` (246 passed), `python -m pytest tests/unit/test_model_manager.py -q` (169 passed), `python -m pytest tests/unit/test_compute_node_runtime.py -q` (58 passed), `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (10 passed), `python -m pytest tests/unit/test_context_profiles.py -q` (3 passed), and `python -m pytest tests/unit/test_touch_ui.py -q` (13 passed); all listed runs passed.
- Ran `pre-commit run --all-files` and `git diff --check`, both passed with no reported issues.
- Playwright E2E selection for the landing structured-error check was exercised but the container lacks the Playwright Chromium executable (Playwright reported `playwright install` needed), so full browser e2e verification is blocked in this environment; the e2e test expectations were added/updated in `tests/e2e/test_ui.py` to assert safe diagnostic fields when Playwright is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a444c80f8d4832fbe4e53fe1066bf96)