### PR TITLE
Enforce Qwen API v1 non-thinking readiness and E2EE-safe checks

### DIFF
--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import call, MagicMock
 
@@ -464,6 +465,49 @@ def test_compute_node_runtime_readiness_smoke_completion_rejects_think_output(mo
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
     assert diagnostics["api_v1_readiness_result"] == "failed"
     assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+
+
+def test_compute_node_runtime_readiness_smoke_completion_rejects_reasoning_content(monkeypatch):
+    class ReasoningRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **_kwargs):
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "ready",
+                            "reasoning_content": "secret hidden reasoning",
+                        }
+                    }
+                ]
+            }
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = ReasoningRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(
+            _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+        ),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
+    assert diagnostics["api_v1_readiness_result"] == "failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+    assert "secret hidden reasoning" not in json.dumps(diagnostics)
 
 
 def test_compute_node_runtime_readiness_smoke_completion_accepts_text_choice(monkeypatch):

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -321,7 +321,7 @@ def test_compute_node_runtime_qwen_generic_admission_failure_keeps_safe_reason()
 def test_compute_node_runtime_qwen_64k_readiness_reports_yarn_rope():
     class ReadyRuntime:
         def create_chat_completion(self, **_kwargs):
-            return {}
+            return {"choices": [{"message": {"role": "assistant", "content": "ready"}}]}
 
         def render_and_tokenize_chat(self, *_args, **_kwargs):
             return {"prompt_tokens": 2}
@@ -399,6 +399,38 @@ def test_compute_node_runtime_readiness_smoke_completion_passes(monkeypatch):
     assert llm_runtime.completion_kwargs["stream"] is False
     assert llm_runtime.completion_kwargs["max_tokens"] == 4
     assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
+
+
+def test_compute_node_runtime_qwen_readiness_smoke_completion_is_required_without_env(monkeypatch):
+    class ThinkRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **_kwargs):
+            return {"choices": [{"message": {"role": "assistant", "content": "<THINK>no"}}]}
+
+    monkeypatch.delenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", raising=False)
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = ThinkRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(
+            _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+        ),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
 
 
 def test_compute_node_runtime_readiness_smoke_completion_rejects_think_output(monkeypatch):

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -466,6 +466,38 @@ def test_compute_node_runtime_readiness_smoke_completion_rejects_think_output(mo
     assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
 
 
+def test_compute_node_runtime_readiness_smoke_completion_accepts_text_choice(monkeypatch):
+    class TextRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **_kwargs):
+            return {"choices": [{"text": "ready"}]}
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", "1")
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "local", "thinking_mode": "n/a"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "local-model"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = TextRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(
+            _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+        ),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
+    assert diagnostics["api_v1_readiness_result"] == "passed"
+
+
 def test_compute_node_runtime_readiness_smoke_completion_records_safe_exception(monkeypatch):
     class RaisingRuntime:
         def render_and_tokenize_chat(self, *_args, **_kwargs):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5066,6 +5066,7 @@ def test_qwen_think_output_is_rejected():
         "<think>secret</think>answer",
         "<THINK>secret</THINK>answer",
         "   <think>secret</think>answer",
+        "< think>secret</ think>answer",
         "<think secret partial",
     ],
 )
@@ -5090,6 +5091,37 @@ def test_qwen_think_output_variants_are_rejected_with_safe_reason(leaked_content
     assert error["code"] == "compute_node_invalid_model_output"
     assert error["internal_reason"] == "qwen_thinking_output_leaked"
     assert "secret" not in json.dumps(error)
+
+
+def test_qwen_reasoning_content_field_is_rejected_with_safe_reason():
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = "qwen3-8b-instruct"
+    manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    manager.runtime.create_chat_completion = lambda **kwargs: {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "final answer",
+                    "reasoning_content": "secret hidden reasoning",
+                }
+            }
+        ]
+    }
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-reasoning-content",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5},
+        requested_context_tier="8k-fast",
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_invalid_model_output"
+    assert error["internal_reason"] == "qwen_reasoning_content_leaked"
+    assert "secret hidden reasoning" not in json.dumps(error)
 
 
 def test_api_v1_qwen_non_thinking_policy_is_single_source_of_truth():

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5060,6 +5060,50 @@ def test_qwen_think_output_is_rejected():
     assert 'secret' not in json.dumps(error)
 
 
+@pytest.mark.parametrize(
+    "leaked_content",
+    [
+        "<think>secret</think>answer",
+        "<THINK>secret</THINK>answer",
+        "   <think>secret</think>answer",
+        "<think secret partial",
+    ],
+)
+def test_qwen_think_output_variants_are_rejected_with_safe_reason(leaked_content):
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = "qwen3-8b-instruct"
+    manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    manager.runtime.create_chat_completion = lambda **kwargs: {
+        "choices": [{"message": {"role": "assistant", "content": leaked_content}}]
+    }
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-think-variant",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5},
+        requested_context_tier="8k-fast",
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_invalid_model_output"
+    assert error["internal_reason"] == "qwen_thinking_output_leaked"
+    assert "secret" not in json.dumps(error)
+
+
+def test_api_v1_qwen_non_thinking_policy_is_single_source_of_truth():
+    policy = RelayClient._API_V1_QWEN_NON_THINKING_POLICY
+
+    assert policy["thinking_mode"] == "disabled"
+    assert policy["message_control"] == "/no_think"
+    assert policy["visible_think_output_forbidden"] is True
+    assert policy["reasoning_content_forbidden"] is True
+    assert RelayClient._api_v1_qwen_non_thinking_required(
+        {"provider": "qwen", "thinking_mode": "disabled"}
+    )
+
+
 def test_qwen_profile_generation_defaults_include_top_k():
     manager = _AdmissionManager()
     manager.model_profile = {'generation_defaults': {'temperature': 0.7, 'top_p': 0.8, 'top_k': 20}}

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -493,6 +493,9 @@ class ComputeNodeRuntime:
                     and not RelayClient._api_v1_qwen_thinking_leaked(
                         model_profile, smoke_content
                     )
+                    and not RelayClient._api_v1_qwen_reasoning_content_leaked(
+                        model_profile, smoke_choice
+                    )
                 )
                 diagnostics["api_v1_readiness_completion_smoke_result"] = "passed" if smoke_ok else "failed"
                 if not smoke_ok:

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -401,6 +401,12 @@ class ComputeNodeRuntime:
         )
         legacy_template_available = callable(getattr(llm_runtime, "apply_chat_template", None))
         legacy_tokenizer_available = callable(getattr(llm_runtime, "tokenize", None))
+        from utils.networking.relay_client import RelayClient
+
+        qwen_non_thinking_enforced = RelayClient._api_v1_qwen_non_thinking_required(
+            model_profile
+        )
+
         diagnostics.update({
             "api_v1_readiness_model_id": getattr(self.model_manager, "api_model_id", None),
             "api_v1_readiness_context_tier": context_tier,
@@ -414,10 +420,7 @@ class ComputeNodeRuntime:
                 or (legacy_template_available and legacy_tokenizer_available)
             ),
             "api_v1_readiness_tokenizer_render_bridge_available": False,
-            "api_v1_readiness_non_thinking_enforced": (
-                model_profile.get("provider") == "qwen"
-                and model_profile.get("thinking_mode") == "disabled"
-            ),
+            "api_v1_readiness_non_thinking_enforced": qwen_non_thinking_enforced,
             "api_v1_readiness_yarn_rope_enabled": bool(rope_policy.get("type") == "yarn"),
             "api_v1_readiness_yarn_rope_factor": rope_policy.get("factor"),
             "api_v1_readiness_yarn_original_context_tokens": rope_policy.get(
@@ -426,8 +429,6 @@ class ComputeNodeRuntime:
         })
 
         try:
-            from utils.networking.relay_client import RelayClient
-
             smoke_messages = [{"role": "system", "content": "ok"}, {"role": "user", "content": "hi"}]
             smoke_messages = RelayClient._api_v1_prepare_qwen_non_thinking_messages(
                 smoke_messages, model_profile
@@ -473,14 +474,19 @@ class ComputeNodeRuntime:
                     stream=False,
                 )
                 smoke_message = None
+                smoke_content = None
                 if (
                     isinstance(smoke_completion, dict)
                     and isinstance(smoke_completion.get("choices"), list)
                     and smoke_completion["choices"]
                     and isinstance(smoke_completion["choices"][0], dict)
                 ):
-                    smoke_message = smoke_completion["choices"][0].get("message")
-                smoke_content = smoke_message.get("content") if isinstance(smoke_message, dict) else None
+                    smoke_choice = smoke_completion["choices"][0]
+                    smoke_message = smoke_choice.get("message")
+                    if isinstance(smoke_message, dict):
+                        smoke_content = smoke_message.get("content")
+                    elif "text" in smoke_choice:
+                        smoke_content = smoke_choice.get("text")
                 smoke_ok = (
                     isinstance(smoke_content, str)
                     and bool(smoke_content.strip())

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -429,8 +429,9 @@ class ComputeNodeRuntime:
             from utils.networking.relay_client import RelayClient
 
             smoke_messages = [{"role": "system", "content": "ok"}, {"role": "user", "content": "hi"}]
-            if diagnostics["api_v1_readiness_non_thinking_enforced"]:
-                smoke_messages = RelayClient._api_v1_qwen_no_think_messages(smoke_messages)
+            smoke_messages = RelayClient._api_v1_prepare_qwen_non_thinking_messages(
+                smoke_messages, model_profile
+            )
             admitted, admission_error, prompt_tokens = (
                 self.relay_client._api_v1_authoritative_context_admission(
                     llm_instance=llm_runtime,
@@ -460,7 +461,11 @@ class ComputeNodeRuntime:
             ) if not admitted else None,
         })
         self.model_manager.last_compute_diagnostics = diagnostics
-        if admitted and os.getenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION") == "1":
+        completion_smoke_required = bool(
+            diagnostics["api_v1_readiness_non_thinking_enforced"]
+            or os.getenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION") == "1"
+        )
+        if admitted and completion_smoke_required:
             try:
                 smoke_completion = create_chat_completion(
                     messages=smoke_messages,
@@ -476,7 +481,13 @@ class ComputeNodeRuntime:
                 ):
                     smoke_message = smoke_completion["choices"][0].get("message")
                 smoke_content = smoke_message.get("content") if isinstance(smoke_message, dict) else None
-                smoke_ok = isinstance(smoke_content, str) and bool(smoke_content.strip()) and "<think" not in smoke_content.lower()
+                smoke_ok = (
+                    isinstance(smoke_content, str)
+                    and bool(smoke_content.strip())
+                    and not RelayClient._api_v1_qwen_thinking_leaked(
+                        model_profile, smoke_content
+                    )
+                )
                 diagnostics["api_v1_readiness_completion_smoke_result"] = "passed" if smoke_ok else "failed"
                 if not smoke_ok:
                     admitted = False

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2162,16 +2162,27 @@ class RelayClient:
 
     @classmethod
     def _api_v1_qwen_reasoning_content_leaked(
-        cls, model_profile: Dict[str, Any], message: Any
+        cls, model_profile: Dict[str, Any], payload: Any
     ) -> bool:
         if not (
             cls._api_v1_qwen_non_thinking_required(model_profile)
             and cls._API_V1_QWEN_NON_THINKING_POLICY["reasoning_content_forbidden"]
-            and isinstance(message, dict)
         ):
             return False
         forbidden_reasoning_fields = {"reasoning_content", "reasoning"}
-        return any(message.get(field) not in (None, "") for field in forbidden_reasoning_fields)
+        if isinstance(payload, dict):
+            if any(payload.get(field) not in (None, "") for field in forbidden_reasoning_fields):
+                return True
+            return any(
+                cls._api_v1_qwen_reasoning_content_leaked(model_profile, value)
+                for value in payload.values()
+            )
+        if isinstance(payload, list):
+            return any(
+                cls._api_v1_qwen_reasoning_content_leaked(model_profile, item)
+                for item in payload
+            )
+        return False
 
     @staticmethod
     def _api_v1_models_module() -> Optional[Any]:
@@ -2998,6 +3009,13 @@ class RelayClient:
             and isinstance(completion["choices"][0], dict)
         ):
             choice = completion["choices"][0]
+            if self._api_v1_qwen_reasoning_content_leaked(
+                getattr(self.model_manager, "model_profile", {}) or {}, choice
+            ):
+                # Fail closed before normalizing the runtime choice so hidden
+                # reasoning fields are never forwarded or echoed.
+                self._last_api_v1_invalid_model_output_reason = "qwen_reasoning_content_leaked"
+                return None
             raw_message = choice.get("message")
             if isinstance(raw_message, dict) and "role" not in raw_message and "content" in raw_message:
                 raw_message = {**raw_message, "role": "assistant"}
@@ -3013,14 +3031,6 @@ class RelayClient:
                 # Fail closed instead of stripping so no hidden reasoning can be
                 # partially leaked or mis-accounted in API v1 relay responses.
                 self._last_api_v1_invalid_model_output_reason = "qwen_thinking_output_leaked"
-                return None
-            if message is not None and self._api_v1_qwen_reasoning_content_leaked(
-                model_profile, message
-            ):
-                # Fail closed instead of forwarding runtime-specific hidden
-                # reasoning fields alongside an otherwise valid assistant
-                # response.
-                self._last_api_v1_invalid_model_output_reason = "qwen_reasoning_content_leaked"
                 return None
             if message is None:
                 self._last_api_v1_invalid_model_output_reason = "unsupported_completion_shape"

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -530,6 +530,17 @@ class RelayClient:
     _API_V1_MAX_STOP_CHARS = 256
     _API_V1_MAX_TOKENS_LIMIT = 8192
     _API_V1_MAX_SEED = 2**32 - 1
+    # Single source of truth for API v1 Qwen behavior. API v1 is a
+    # non-reasoning chat-completions surface: Qwen thinking is disabled via the
+    # documented message-level /no_think control because the packaged
+    # llama-cpp-python create_chat_completion path used here does not reliably
+    # expose chat-template kwargs such as enable_thinking/template_kwargs.
+    _API_V1_QWEN_NON_THINKING_POLICY = {
+        "thinking_mode": "disabled",
+        "message_control": "/no_think",
+        "visible_think_output_forbidden": True,
+        "reasoning_content_forbidden": True,
+    }
 
     def __init__(
         self,
@@ -2121,6 +2132,33 @@ class RelayClient:
                 return prepared
         return prepared
 
+    @classmethod
+    def _api_v1_qwen_non_thinking_required(cls, model_profile: Dict[str, Any]) -> bool:
+        return (
+            isinstance(model_profile, dict)
+            and model_profile.get("provider") == "qwen"
+            and model_profile.get("thinking_mode")
+            == cls._API_V1_QWEN_NON_THINKING_POLICY["thinking_mode"]
+        )
+
+    @classmethod
+    def _api_v1_prepare_qwen_non_thinking_messages(
+        cls, messages: List[Dict[str, Any]], model_profile: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        if cls._api_v1_qwen_non_thinking_required(model_profile):
+            return cls._api_v1_qwen_no_think_messages(messages)
+        return messages
+
+    @classmethod
+    def _api_v1_qwen_thinking_leaked(
+        cls, model_profile: Dict[str, Any], content: Any
+    ) -> bool:
+        return (
+            cls._api_v1_qwen_non_thinking_required(model_profile)
+            and isinstance(content, str)
+            and "<think" in content.lower()
+        )
+
     @staticmethod
     def _api_v1_models_module() -> Optional[Any]:
         """Return the optional repo API v1 models module when it is importable."""
@@ -2735,8 +2773,7 @@ class RelayClient:
         )
         model_profile = getattr(self.model_manager, "model_profile", {}) or {}
         is_qwen_non_thinking = (
-            model_profile.get("provider") == "qwen"
-            and model_profile.get("thinking_mode") == "disabled"
+            self._api_v1_qwen_non_thinking_required(model_profile)
         )
         # Prefer a packaged-runtime bridge that renders and tokenizes inside the
         # loaded worker process. This keeps Qwen admission aligned with the same
@@ -2956,12 +2993,8 @@ class RelayClient:
                 if isinstance(text, str) and text.strip():
                     message = {"role": "assistant", "content": text}
             model_profile = getattr(self.model_manager, "model_profile", {}) or {}
-            if (
-                message is not None
-                and model_profile.get("provider") == "qwen"
-                and model_profile.get("thinking_mode") == "disabled"
-                and isinstance(message.get("content"), str)
-                and "<think" in message["content"].lower()
+            if message is not None and self._api_v1_qwen_thinking_leaked(
+                model_profile, message.get("content")
             ):
                 # Fail closed instead of stripping so no hidden reasoning can be
                 # partially leaked or mis-accounted in API v1 relay responses.
@@ -3105,10 +3138,7 @@ class RelayClient:
 
         runtime_messages = self._prepare_api_v1_runtime_messages(model_id, messages)
         model_profile = getattr(self.model_manager, "model_profile", {}) or {}
-        if (
-            model_profile.get("provider") == "qwen"
-            and model_profile.get("thinking_mode") == "disabled"
-        ):
+        if self._api_v1_qwen_non_thinking_required(model_profile):
             # Use Qwen's documented /no_think message-level control before
             # both admission and generation.  llama-cpp-python's
             # create_chat_completion does not expose template kwargs, so admission
@@ -3116,7 +3146,9 @@ class RelayClient:
             # admission-only enable_thinking=False assistant prefix.  Output
             # validation below still fails closed if a runtime returns a <think>
             # block.
-            runtime_messages = self._api_v1_qwen_no_think_messages(runtime_messages)
+            runtime_messages = self._api_v1_prepare_qwen_non_thinking_messages(
+                runtime_messages, model_profile
+            )
         try:
             assistant_message: Optional[Dict[str, Any]] = None
             completion = None

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2108,26 +2108,27 @@ class RelayClient:
             prepared.insert(0, adapter_message)
         return prepared
 
-    @staticmethod
-    def _api_v1_qwen_no_think_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    @classmethod
+    def _api_v1_qwen_no_think_messages(cls, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Inject Qwen's template-supported non-thinking control into user text."""
 
+        message_control = cls._API_V1_QWEN_NON_THINKING_POLICY["message_control"]
         prepared = [dict(message) for message in messages]
         for index in range(len(prepared) - 1, -1, -1):
             if prepared[index].get("role") != "user":
                 continue
             content = prepared[index].get("content")
             if isinstance(content, str):
-                prepared[index]["content"] = "/no_think\n" + content
+                prepared[index]["content"] = f"{message_control}\n{content}"
                 return prepared
             if isinstance(content, list):
                 copied_blocks = [dict(block) if isinstance(block, dict) else block for block in content]
                 for block in copied_blocks:
                     if isinstance(block, dict) and isinstance(block.get("text"), str):
-                        block["text"] = "/no_think\n" + block["text"]
+                        block["text"] = f"{message_control}\n{block['text']}"
                         prepared[index]["content"] = copied_blocks
                         return prepared
-                copied_blocks.insert(0, {"type": "text", "text": "/no_think\n"})
+                copied_blocks.insert(0, {"type": "text", "text": f"{message_control}\n"})
                 prepared[index]["content"] = copied_blocks
                 return prepared
         return prepared
@@ -2156,8 +2157,21 @@ class RelayClient:
         return (
             cls._api_v1_qwen_non_thinking_required(model_profile)
             and isinstance(content, str)
-            and "<think" in content.lower()
+            and bool(re.search(r"<\s*think", content, flags=re.IGNORECASE))
         )
+
+    @classmethod
+    def _api_v1_qwen_reasoning_content_leaked(
+        cls, model_profile: Dict[str, Any], message: Any
+    ) -> bool:
+        if not (
+            cls._api_v1_qwen_non_thinking_required(model_profile)
+            and cls._API_V1_QWEN_NON_THINKING_POLICY["reasoning_content_forbidden"]
+            and isinstance(message, dict)
+        ):
+            return False
+        forbidden_reasoning_fields = {"reasoning_content", "reasoning"}
+        return any(message.get(field) not in (None, "") for field in forbidden_reasoning_fields)
 
     @staticmethod
     def _api_v1_models_module() -> Optional[Any]:
@@ -3000,6 +3014,14 @@ class RelayClient:
                 # partially leaked or mis-accounted in API v1 relay responses.
                 self._last_api_v1_invalid_model_output_reason = "qwen_thinking_output_leaked"
                 return None
+            if message is not None and self._api_v1_qwen_reasoning_content_leaked(
+                model_profile, message
+            ):
+                # Fail closed instead of forwarding runtime-specific hidden
+                # reasoning fields alongside an otherwise valid assistant
+                # response.
+                self._last_api_v1_invalid_model_output_reason = "qwen_reasoning_content_leaked"
+                return None
             if message is None:
                 self._last_api_v1_invalid_model_output_reason = "unsupported_completion_shape"
             return message
@@ -3138,17 +3160,15 @@ class RelayClient:
 
         runtime_messages = self._prepare_api_v1_runtime_messages(model_id, messages)
         model_profile = getattr(self.model_manager, "model_profile", {}) or {}
-        if self._api_v1_qwen_non_thinking_required(model_profile):
-            # Use Qwen's documented /no_think message-level control before
-            # both admission and generation.  llama-cpp-python's
-            # create_chat_completion does not expose template kwargs, so admission
-            # intentionally renders the same message shape instead of adding an
-            # admission-only enable_thinking=False assistant prefix.  Output
-            # validation below still fails closed if a runtime returns a <think>
-            # block.
-            runtime_messages = self._api_v1_prepare_qwen_non_thinking_messages(
-                runtime_messages, model_profile
-            )
+        # Use Qwen's documented /no_think message-level control before both
+        # admission and generation.  llama-cpp-python's create_chat_completion
+        # does not expose template kwargs, so admission intentionally renders the
+        # same message shape instead of adding an admission-only
+        # enable_thinking=False assistant prefix.  Output validation below still
+        # fails closed if a runtime returns visible or hidden thinking output.
+        runtime_messages = self._api_v1_prepare_qwen_non_thinking_messages(
+            runtime_messages, model_profile
+        )
         try:
             assistant_message: Optional[Dict[str, Any]] = None
             completion = None


### PR DESCRIPTION
### Motivation
- Qwen API v1 nodes were leaking `<think>` thinking blocks despite earlier context-admission fixes, causing `compute_node_invalid_model_output` errors and plaintext reasoning exposure risks.
- API v1 must be explicitly non-reasoning: generation, admission, readiness smoke and validation must prevent any visible thinking output while preserving relay E2EE ciphertext-only boundaries.

### Description
- Add a single source-of-truth Qwen non-thinking policy (`_API_V1_QWEN_NON_THINKING_POLICY`) and helpers (`_api_v1_qwen_non_thinking_required`, `_api_v1_prepare_qwen_non_thinking_messages`, `_api_v1_qwen_thinking_leaked`) in `utils/networking/relay_client.py` to centralize the rule and detection logic. 
- Inject Qwen `/no_think` message-level control consistently for context admission and generation via the shared helpers, avoiding opportunistic admission-only template prefixes and keeping admission/generation shapes aligned. 
- Fail-closed output validation updated to use the leak detector so any runtime containing `<think` (case-insensitive / partial variants) returns `compute_node_invalid_model_output` with safe `internal_reason: qwen_thinking_output_leaked` and no leaked plaintext. 
- Require a non-thinking readiness generation smoke for Qwen at registration (use same message controls as admission/generation) by changing `utils/compute_node_runtime.py` to run the smoke when Qwen non-thinking enforcement is active (regardless of the previous opt-in env var), and to validate with the new leak detection helper. 
- Add and update focused tests to cover message injection, admission/generation alignment, readiness smoke behavior (including mandatory Qwen smoke), mixed-case/partial `<think` variants, and the new policy constant in `tests/unit/test_relay_client.py` and `tests/unit/test_compute_node_runtime.py`.

### Testing
- Ran the focused verification suite with these commands and all tests passed:
  - `python -m pytest tests/unit/test_model_manager.py -q` — passed
  - `python -m pytest tests/unit/test_relay_client.py -q` — passed
  - `python -m pytest tests/unit/test_compute_node_runtime.py -q` — passed
  - `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` — passed
  - `python -m pytest tests/unit/test_context_profiles.py -q` — passed
  - `python -m pytest tests/unit/test_touch_ui.py -q` — passed
- Pre-commit hooks were run with `pre-commit run --all-files` and passed, and `git diff --check` reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44bce5d6b0832f859012c9bcfa3fb2)