### PR TITLE
Normalize empty Qwen think wrappers while rejecting real reasoning content

### DIFF
--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -480,6 +480,106 @@ def test_compute_node_runtime_readiness_smoke_completion_empty_after_strip(monke
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_empty_after_think_strip"
 
+
+def test_compute_node_runtime_readiness_smoke_completion_rejects_empty_output(monkeypatch):
+    class EmptyRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **_kwargs):
+            return {"choices": [{"message": {"role": "assistant", "content": "   "}}]}
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", "1")
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "local", "thinking_mode": "n/a"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "local-model"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = EmptyRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(
+            _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+        ),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
+    assert diagnostics["api_v1_readiness_completion_smoke_failure_reason"] == "runtime_completion_smoke_empty_output"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_empty_output"
+
+
+def test_compute_node_runtime_readiness_smoke_completion_rejects_malformed_shape(monkeypatch):
+    class MalformedRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **_kwargs):
+            return {"choices": []}
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", "1")
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "local", "thinking_mode": "n/a"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "local-model"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = MalformedRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(
+            _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+        ),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
+    assert diagnostics["api_v1_readiness_completion_smoke_failure_reason"] == "runtime_completion_smoke_malformed_completion"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_malformed_completion"
+
+
+def test_compute_node_runtime_readiness_smoke_completion_rejects_missing_content(monkeypatch):
+    class MissingContentRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **_kwargs):
+            return {"choices": [{"message": {"role": "assistant"}}]}
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", "1")
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "local", "thinking_mode": "n/a"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "local-model"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = MissingContentRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(
+            _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+        ),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
+    assert diagnostics["api_v1_readiness_completion_smoke_failure_reason"] == "runtime_completion_smoke_malformed_completion"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_malformed_completion"
+
+
 def test_compute_node_runtime_qwen_readiness_smoke_completion_is_required_without_env(monkeypatch):
     class ThinkRuntime:
         def render_and_tokenize_chat(self, *_args, **_kwargs):

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -202,7 +202,11 @@ def test_compute_node_runtime_readiness_admission_exception_is_generic_not_bridg
 
     model_manager = MagicMock()
     model_manager.use_mock_llm = True
-    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "profile_id": "qwen3-8b-q4-k-m",
+    }
     model_manager.context_tier = "8k-fast"
     model_manager.context_window_tokens = 8192
     model_manager.api_model_id = "qwen3-8b-instruct"
@@ -376,7 +380,11 @@ def test_compute_node_runtime_readiness_smoke_completion_passes(monkeypatch):
     monkeypatch.setenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", "1")
     model_manager = MagicMock()
     model_manager.use_mock_llm = True
-    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "profile_id": "qwen3-8b-q4-k-m",
+    }
     model_manager.context_tier = "8k-fast"
     model_manager.context_window_tokens = 8192
     model_manager.api_model_id = "qwen3-8b-instruct"
@@ -397,8 +405,9 @@ def test_compute_node_runtime_readiness_smoke_completion_passes(monkeypatch):
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert diagnostics["api_v1_readiness_result"] == "passed"
+    assert diagnostics["api_v1_readiness_model_profile_id"] == "qwen3-8b-q4-k-m"
     assert llm_runtime.completion_kwargs["stream"] is False
-    assert llm_runtime.completion_kwargs["max_tokens"] >= 32
+    assert llm_runtime.completion_kwargs["max_tokens"] == 64
     assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
 
 
@@ -438,7 +447,7 @@ def test_compute_node_runtime_readiness_smoke_completion_accepts_empty_qwen_thin
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert diagnostics["api_v1_readiness_completion_smoke_shape"] == "choices_message_content"
-    assert llm_runtime.completion_kwargs["max_tokens"] >= 32
+    assert llm_runtime.completion_kwargs["max_tokens"] == 64
     assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
 
 

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -398,9 +398,78 @@ def test_compute_node_runtime_readiness_smoke_completion_passes(monkeypatch):
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert diagnostics["api_v1_readiness_result"] == "passed"
     assert llm_runtime.completion_kwargs["stream"] is False
-    assert llm_runtime.completion_kwargs["max_tokens"] == 4
+    assert llm_runtime.completion_kwargs["max_tokens"] >= 32
     assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
 
+
+
+
+def test_compute_node_runtime_readiness_smoke_completion_accepts_empty_qwen_think_wrapper(monkeypatch):
+    class SmokeRuntime:
+        def __init__(self):
+            self.completion_kwargs = None
+
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **kwargs):
+            self.completion_kwargs = kwargs
+            return {"choices": [{"message": {"role": "assistant", "content": "<think>\n\n</think>\n\nok"}}]}
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    llm_runtime = SmokeRuntime()
+    model_manager.get_llm_instance.return_value = llm_runtime
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(
+            _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+        ),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
+    assert diagnostics["api_v1_readiness_completion_smoke_shape"] == "choices_message_content"
+    assert llm_runtime.completion_kwargs["max_tokens"] >= 32
+    assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
+
+
+def test_compute_node_runtime_readiness_smoke_completion_empty_after_strip(monkeypatch):
+    class SmokeRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **_kwargs):
+            return {"choices": [{"message": {"role": "assistant", "content": "<think></think>"}}]}
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = SmokeRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(
+            _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+        ),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_empty_after_think_strip"
 
 def test_compute_node_runtime_qwen_readiness_smoke_completion_is_required_without_env(monkeypatch):
     class ThinkRuntime:
@@ -431,7 +500,7 @@ def test_compute_node_runtime_qwen_readiness_smoke_completion_is_required_withou
     assert runtime.ensure_api_v1_runtime_ready() is False
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
-    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_thinking_leaked"
 
 
 def test_compute_node_runtime_readiness_smoke_completion_rejects_think_output(monkeypatch):
@@ -464,7 +533,7 @@ def test_compute_node_runtime_readiness_smoke_completion_rejects_think_output(mo
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
     assert diagnostics["api_v1_readiness_result"] == "failed"
-    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_thinking_leaked"
 
 
 def test_compute_node_runtime_readiness_smoke_completion_rejects_reasoning_content(monkeypatch):
@@ -506,7 +575,8 @@ def test_compute_node_runtime_readiness_smoke_completion_rejects_reasoning_conte
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
     assert diagnostics["api_v1_readiness_result"] == "failed"
-    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_thinking_leaked"
+    assert diagnostics["api_v1_readiness_completion_smoke_shape"] == "reasoning_field_present"
     assert "secret hidden reasoning" not in json.dumps(diagnostics)
 
 
@@ -571,6 +641,7 @@ def test_compute_node_runtime_readiness_smoke_completion_records_safe_exception(
     assert runtime.ensure_api_v1_runtime_ready() is False
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_exception"
     assert diagnostics["api_v1_readiness_completion_smoke_exception_type"] == "RuntimeError"
     assert "prompt text" not in str(diagnostics)
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5027,6 +5027,66 @@ def test_qwen_context_admission_unavailable_when_template_missing_no_llama_fallb
     assert envelope['api_v1_response']['error']['code'] == 'compute_node_context_admission_unavailable'
 
 
+
+
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        ("ready", "ready"),
+        (" <think></think> ready ", "ready"),
+        ("<think>\n\n</think>\n\nok", "ok"),
+        ("<THINK>   </THINK> final", "final"),
+        ("<think></think><think> </think> answer", "answer"),
+    ],
+)
+def test_qwen_non_thinking_normalizer_strips_only_empty_leading_wrappers(content, expected):
+    cleaned, reason = RelayClient._api_v1_normalize_qwen_non_thinking_content(
+        {"provider": "qwen", "thinking_mode": "disabled"}, content
+    )
+    assert cleaned == expected
+    assert reason is None
+
+
+@pytest.mark.parametrize(
+    "content,reason",
+    [
+        ("<think>I am reasoning</think> answer", "qwen_thinking_output_leaked"),
+        ("answer <think></think>", "qwen_thinking_output_leaked"),
+        ("<think partial", "qwen_thinking_output_leaked"),
+        ("<think></think>", "qwen_empty_after_think_wrapper_strip"),
+    ],
+)
+def test_qwen_non_thinking_normalizer_rejects_reasoning_and_empty_output(content, reason):
+    cleaned, actual_reason = RelayClient._api_v1_normalize_qwen_non_thinking_content(
+        {"provider": "qwen", "thinking_mode": "disabled"}, content
+    )
+    assert cleaned is None
+    assert actual_reason == reason
+
+
+def test_assistant_message_extraction_strips_empty_qwen_think_wrapper_from_message():
+    manager = _AdmissionManager(window=128)
+    manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    client = _api_v1_validation_client(manager)
+
+    message = client._assistant_message_from_runtime_completion(
+        {"choices": [{"message": {"content": "<think>\n\n</think>\n\nok"}}]}
+    )
+
+    assert message == {"role": "assistant", "content": "ok"}
+
+
+def test_assistant_message_extraction_strips_empty_qwen_think_wrapper_from_text_choice():
+    manager = _AdmissionManager(window=128)
+    manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    client = _api_v1_validation_client(manager)
+
+    message = client._assistant_message_from_runtime_completion(
+        {"choices": [{"text": "<think></think> final"}]}
+    )
+
+    assert message == {"role": "assistant", "content": "final"}
+
 def test_qwen_think_output_is_rejected():
     manager = _AdmissionManager(window=128)
     manager.api_model_id = 'qwen3-8b-instruct'
@@ -5120,7 +5180,7 @@ def test_qwen_reasoning_content_field_is_rejected_with_safe_reason():
 
     error = envelope["api_v1_response"]["error"]
     assert error["code"] == "compute_node_invalid_model_output"
-    assert error["internal_reason"] == "qwen_reasoning_content_leaked"
+    assert error["internal_reason"] == "qwen_thinking_output_leaked"
     assert "secret hidden reasoning" not in json.dumps(error)
 
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5087,6 +5087,67 @@ def test_assistant_message_extraction_strips_empty_qwen_think_wrapper_from_text_
 
     assert message == {"role": "assistant", "content": "final"}
 
+
+def test_assistant_message_extraction_preserves_tool_call_only_message():
+    manager = _AdmissionManager(window=128)
+    manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    client = _api_v1_validation_client(manager)
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": "{}"},
+        }
+    ]
+
+    message = client._assistant_message_from_runtime_completion(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": tool_calls,
+                    }
+                }
+            ]
+        }
+    )
+
+    assert message == {"role": "assistant", "content": None, "tool_calls": tool_calls}
+    assert client._last_api_v1_invalid_model_output_reason is None
+
+
+def test_assistant_message_extraction_preserves_tool_calls_when_normalizing_content():
+    manager = _AdmissionManager(window=128)
+    manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    client = _api_v1_validation_client(manager)
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": "{}"},
+        }
+    ]
+
+    message = client._assistant_message_from_runtime_completion(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "<think></think> final",
+                        "tool_calls": tool_calls,
+                    }
+                }
+            ]
+        }
+    )
+
+    assert message == {"role": "assistant", "content": "final", "tool_calls": tool_calls}
+    assert client._last_api_v1_invalid_model_output_reason is None
+
+
 def test_qwen_think_output_is_rejected():
     manager = _AdmissionManager(window=128)
     manager.api_model_id = 'qwen3-8b-instruct'

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5148,6 +5148,19 @@ def test_assistant_message_extraction_preserves_tool_calls_when_normalizing_cont
     assert client._last_api_v1_invalid_model_output_reason is None
 
 
+def test_assistant_message_extraction_allows_non_think_xml_like_content():
+    manager = _AdmissionManager(window=128)
+    manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    client = _api_v1_validation_client(manager)
+
+    message = client._assistant_message_from_runtime_completion(
+        {"choices": [{"message": {"role": "assistant", "content": "<note>ordinary</note>"}}]}
+    )
+
+    assert message == {"role": "assistant", "content": "<note>ordinary</note>"}
+    assert client._last_api_v1_invalid_model_output_reason is None
+
+
 def test_qwen_think_output_is_rejected():
     manager = _AdmissionManager(window=128)
     manager.api_model_id = 'qwen3-8b-instruct'
@@ -5189,6 +5202,7 @@ def test_qwen_think_output_is_rejected():
         "   <think>secret</think>answer",
         "< think>secret</ think>answer",
         "<think secret partial",
+        "</think>answer",
     ],
 )
 def test_qwen_think_output_variants_are_rejected_with_safe_reason(leaked_content):
@@ -5243,6 +5257,57 @@ def test_qwen_reasoning_content_field_is_rejected_with_safe_reason():
     assert error["code"] == "compute_node_invalid_model_output"
     assert error["internal_reason"] == "qwen_thinking_output_leaked"
     assert "secret hidden reasoning" not in json.dumps(error)
+
+def test_qwen_top_level_reasoning_content_field_is_rejected_with_safe_reason():
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = "qwen3-8b-instruct"
+    manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    leaked_reasoning = "top level secret reasoning"
+    manager.runtime.create_chat_completion = lambda **kwargs: {
+        "reasoning_content": leaked_reasoning,
+        "choices": [{"message": {"role": "assistant", "content": "final answer"}}],
+    }
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-top-level-reasoning",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5},
+        requested_context_tier="8k-fast",
+    )
+
+    response_json = json.dumps(envelope["api_v1_response"], sort_keys=True)
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_invalid_model_output"
+    assert error["internal_reason"] == "qwen_thinking_output_leaked"
+    assert leaked_reasoning not in response_json
+
+
+def test_qwen_nested_reasoning_field_outside_first_choice_is_rejected_with_safe_reason():
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = "qwen3-8b-instruct"
+    manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    leaked_reasoning = "nested secret reasoning"
+    manager.runtime.create_chat_completion = lambda **kwargs: {
+        "choices": [{"message": {"role": "assistant", "content": "final answer"}}],
+        "usage": {"diagnostics": [{"reasoning": leaked_reasoning}]},
+    }
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-nested-reasoning",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5},
+        requested_context_tier="8k-fast",
+    )
+
+    response_json = json.dumps(envelope["api_v1_response"], sort_keys=True)
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_invalid_model_output"
+    assert error["internal_reason"] == "qwen_thinking_output_leaked"
+    assert leaked_reasoning not in response_json
 
 
 def test_api_v1_qwen_non_thinking_policy_is_single_source_of_truth():

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5310,6 +5310,75 @@ def test_qwen_nested_reasoning_field_outside_first_choice_is_rejected_with_safe_
     assert leaked_reasoning not in response_json
 
 
+@pytest.mark.parametrize(
+    ("field_name", "field_value", "completion_patch"),
+    [
+        ("reasoning_content", "", {"reasoning_content": ""}),
+        ("reasoning", None, {"reasoning": None}),
+        (
+            "reasoning_content",
+            "",
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "final answer",
+                            "reasoning_content": "",
+                        }
+                    }
+                ]
+            },
+        ),
+        (
+            "reasoning",
+            None,
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "final answer",
+                            "reasoning": None,
+                        }
+                    }
+                ]
+            },
+        ),
+        ("reasoning_content", "", {"usage": {"details": [{"reasoning_content": ""}]}}),
+        ("reasoning", None, {"usage": {"details": [{"reasoning": None}]}}),
+    ],
+)
+def test_qwen_reasoning_field_presence_is_rejected_even_when_empty_or_none(
+    field_name, field_value, completion_patch
+):
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = "qwen3-8b-instruct"
+    manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_text = "final answer"
+    base_completion = {"choices": [{"message": {"role": "assistant", "content": model_text}}]}
+    completion = {**base_completion, **completion_patch}
+    manager.runtime.create_chat_completion = lambda **kwargs: completion
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-field-present",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5},
+        requested_context_tier="8k-fast",
+    )
+
+    response_json = json.dumps(envelope["api_v1_response"], sort_keys=True)
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_invalid_model_output"
+    assert error["internal_reason"] == "qwen_thinking_output_leaked"
+    assert model_text not in response_json
+    assert field_name not in response_json
+    if field_value not in (None, ""):
+        assert str(field_value) not in response_json
+
+
 def test_api_v1_qwen_non_thinking_policy_is_single_source_of_truth():
     policy = RelayClient._API_V1_QWEN_NON_THINKING_POLICY
 

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -410,7 +410,11 @@ class ComputeNodeRuntime:
         diagnostics.update({
             "api_v1_readiness_model_id": getattr(self.model_manager, "api_model_id", None),
             "api_v1_readiness_model_profile_provider": model_profile.get("provider"),
-            "api_v1_readiness_model_profile_id": model_profile.get("id") or model_profile.get("name"),
+            "api_v1_readiness_model_profile_id": (
+                model_profile.get("profile_id")
+                or model_profile.get("id")
+                or model_profile.get("name")
+            ),
             "api_v1_readiness_context_tier": context_tier,
             "api_v1_readiness_context_window_tokens": context_window_tokens,
             "api_v1_readiness_template_mode": model_profile.get("chat_template_policy") or "llama-3",

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -409,6 +409,8 @@ class ComputeNodeRuntime:
 
         diagnostics.update({
             "api_v1_readiness_model_id": getattr(self.model_manager, "api_model_id", None),
+            "api_v1_readiness_model_profile_provider": model_profile.get("provider"),
+            "api_v1_readiness_model_profile_id": model_profile.get("id") or model_profile.get("name"),
             "api_v1_readiness_context_tier": context_tier,
             "api_v1_readiness_context_window_tokens": context_window_tokens,
             "api_v1_readiness_template_mode": model_profile.get("chat_template_policy") or "llama-3",
@@ -467,15 +469,23 @@ class ComputeNodeRuntime:
             or os.getenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION") == "1"
         )
         if admitted and completion_smoke_required:
+            smoke_max_tokens = 64 if qwen_non_thinking_enforced else 4
+            diagnostics["api_v1_readiness_completion_smoke_max_tokens"] = smoke_max_tokens
             try:
                 smoke_completion = create_chat_completion(
                     messages=smoke_messages,
-                    max_tokens=4,
+                    max_tokens=smoke_max_tokens,
                     stream=False,
                 )
-                smoke_message = None
+                shape_category = RelayClient._api_v1_completion_shape_category(
+                    model_profile, smoke_completion
+                )
+                diagnostics["api_v1_readiness_completion_smoke_shape"] = shape_category
                 smoke_content = None
-                if (
+                smoke_invalid_reason: Optional[str] = None
+                if shape_category == "reasoning_field_present":
+                    smoke_invalid_reason = "runtime_completion_smoke_thinking_leaked"
+                elif (
                     isinstance(smoke_completion, dict)
                     and isinstance(smoke_completion.get("choices"), list)
                     and smoke_completion["choices"]
@@ -487,30 +497,42 @@ class ComputeNodeRuntime:
                         smoke_content = smoke_message.get("content")
                     elif "text" in smoke_choice:
                         smoke_content = smoke_choice.get("text")
-                smoke_ok = (
-                    isinstance(smoke_content, str)
-                    and bool(smoke_content.strip())
-                    and not RelayClient._api_v1_qwen_thinking_leaked(
-                        model_profile, smoke_content
+                    cleaned_content, normalize_reason = (
+                        RelayClient._api_v1_normalize_qwen_non_thinking_content(
+                            model_profile, smoke_content
+                        )
                     )
-                    and not RelayClient._api_v1_qwen_reasoning_content_leaked(
-                        model_profile, smoke_choice
-                    )
-                )
+                    if cleaned_content:
+                        smoke_content = cleaned_content
+                    elif normalize_reason == "qwen_empty_after_think_wrapper_strip":
+                        smoke_invalid_reason = "runtime_completion_smoke_empty_after_think_strip"
+                    elif normalize_reason == "qwen_thinking_output_leaked":
+                        smoke_invalid_reason = "runtime_completion_smoke_thinking_leaked"
+                    elif isinstance(smoke_content, str) and not smoke_content.strip():
+                        smoke_invalid_reason = "runtime_completion_smoke_empty_output"
+                    else:
+                        smoke_invalid_reason = "runtime_completion_smoke_malformed_completion"
+                else:
+                    smoke_invalid_reason = "runtime_completion_smoke_malformed_completion"
+
+                smoke_ok = smoke_invalid_reason is None and isinstance(smoke_content, str) and bool(smoke_content.strip())
                 diagnostics["api_v1_readiness_completion_smoke_result"] = "passed" if smoke_ok else "failed"
                 if not smoke_ok:
                     admitted = False
+                    diagnostics["api_v1_readiness_completion_smoke_failure_reason"] = smoke_invalid_reason
                     admission_error = {
                         "code": "compute_node_context_admission_unavailable",
-                        "internal_reason": "runtime_completion_smoke_failed",
+                        "internal_reason": smoke_invalid_reason or "runtime_completion_smoke_malformed_completion",
                     }
             except Exception as exc:
                 admitted = False
                 admission_error = {
                     "code": "compute_node_context_admission_unavailable",
-                    "internal_reason": "runtime_completion_smoke_failed",
+                    "internal_reason": "runtime_completion_smoke_exception",
                 }
                 diagnostics["api_v1_readiness_completion_smoke_result"] = "failed"
+                diagnostics["api_v1_readiness_completion_smoke_failure_reason"] = "runtime_completion_smoke_exception"
+                diagnostics["api_v1_readiness_completion_smoke_shape"] = "exception"
                 diagnostics["api_v1_readiness_completion_smoke_exception_type"] = type(exc).__name__
             diagnostics["api_v1_runtime_ready"] = bool(admitted)
             diagnostics["api_v1_readiness_result"] = "passed" if admitted else "failed"

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2190,17 +2190,6 @@ class RelayClient:
         return cleaned, None
 
     @classmethod
-    def _api_v1_qwen_thinking_leaked(
-        cls, model_profile: Dict[str, Any], content: Any
-    ) -> bool:
-        return (
-            cls._api_v1_qwen_non_thinking_required(model_profile)
-            and isinstance(content, str)
-            and cls._api_v1_normalize_qwen_non_thinking_content(model_profile, content)[1]
-            in {"qwen_thinking_output_leaked", "qwen_empty_after_think_wrapper_strip"}
-        )
-
-    @classmethod
     def _api_v1_qwen_reasoning_content_leaked(
         cls, model_profile: Dict[str, Any], payload: Any
     ) -> bool:
@@ -3087,14 +3076,18 @@ class RelayClient:
                 if isinstance(text, str) and text.strip():
                     message = {"role": "assistant", "content": text}
             model_profile = getattr(self.model_manager, "model_profile", {}) or {}
-            if message is not None:
+            if (
+                message is not None
+                and isinstance(message.get("content"), str)
+                and message["content"].strip()
+            ):
                 cleaned_content, invalid_reason = self._api_v1_normalize_qwen_non_thinking_content(
-                    model_profile, message.get("content")
+                    model_profile, message["content"]
                 )
                 if invalid_reason is not None:
                     self._last_api_v1_invalid_model_output_reason = invalid_reason
                     return None
-                message = {"role": "assistant", "content": cleaned_content}
+                message = {**message, "content": cleaned_content}
             if message is None:
                 self._last_api_v1_invalid_model_output_reason = "unsupported_completion_shape"
             return message

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2151,13 +2151,53 @@ class RelayClient:
         return messages
 
     @classmethod
+    def _api_v1_normalize_qwen_non_thinking_content(
+        cls, model_profile: Dict[str, Any], content: Any
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Strip empty leading Qwen think wrappers while failing closed on reasoning.
+
+        Returns ``(cleaned_content, None)`` for valid output or ``(None, reason)``
+        with a safe reason that never includes model text.
+        """
+
+        if not cls._api_v1_qwen_non_thinking_required(model_profile):
+            if isinstance(content, str) and content.strip():
+                return content, None
+            return None, "unsupported_completion_shape"
+        if not isinstance(content, str):
+            return None, "unsupported_completion_shape"
+
+        cleaned = content.lstrip()
+        empty_wrapper = re.compile(r"^<\s*think\s*>\s*<\s*/\s*think\s*>", re.IGNORECASE)
+        stripped_any = False
+        while True:
+            match = empty_wrapper.match(cleaned)
+            if not match:
+                break
+            stripped_any = True
+            cleaned = cleaned[match.end():].lstrip()
+
+        cleaned = cleaned.strip()
+        if not cleaned:
+            return (
+                None,
+                "qwen_empty_after_think_wrapper_strip"
+                if stripped_any
+                else "unsupported_completion_shape",
+            )
+        if re.search(r"<\s*think", cleaned, flags=re.IGNORECASE):
+            return None, "qwen_thinking_output_leaked"
+        return cleaned, None
+
+    @classmethod
     def _api_v1_qwen_thinking_leaked(
         cls, model_profile: Dict[str, Any], content: Any
     ) -> bool:
         return (
             cls._api_v1_qwen_non_thinking_required(model_profile)
             and isinstance(content, str)
-            and bool(re.search(r"<\s*think", content, flags=re.IGNORECASE))
+            and cls._api_v1_normalize_qwen_non_thinking_content(model_profile, content)[1]
+            in {"qwen_thinking_output_leaked", "qwen_empty_after_think_wrapper_strip"}
         )
 
     @classmethod
@@ -2183,6 +2223,28 @@ class RelayClient:
                 for item in payload
             )
         return False
+
+
+    @classmethod
+    def _api_v1_completion_shape_category(
+        cls, model_profile: Dict[str, Any], completion: Any
+    ) -> str:
+        if cls._api_v1_qwen_reasoning_content_leaked(model_profile, completion):
+            return "reasoning_field_present"
+        if not (
+            isinstance(completion, dict)
+            and isinstance(completion.get("choices"), list)
+            and completion["choices"]
+            and isinstance(completion["choices"][0], dict)
+        ):
+            return "missing_choices"
+        choice = completion["choices"][0]
+        message = choice.get("message")
+        if isinstance(message, dict) and isinstance(message.get("content"), str):
+            return "choices_message_content" if message.get("content", "").strip() else "empty_content"
+        if isinstance(choice.get("text"), str):
+            return "choices_text" if choice.get("text", "").strip() else "empty_content"
+        return "missing_choices"
 
     @staticmethod
     def _api_v1_models_module() -> Optional[Any]:
@@ -3014,7 +3076,7 @@ class RelayClient:
             ):
                 # Fail closed before normalizing the runtime choice so hidden
                 # reasoning fields are never forwarded or echoed.
-                self._last_api_v1_invalid_model_output_reason = "qwen_reasoning_content_leaked"
+                self._last_api_v1_invalid_model_output_reason = "qwen_thinking_output_leaked"
                 return None
             raw_message = choice.get("message")
             if isinstance(raw_message, dict) and "role" not in raw_message and "content" in raw_message:
@@ -3025,13 +3087,14 @@ class RelayClient:
                 if isinstance(text, str) and text.strip():
                     message = {"role": "assistant", "content": text}
             model_profile = getattr(self.model_manager, "model_profile", {}) or {}
-            if message is not None and self._api_v1_qwen_thinking_leaked(
-                model_profile, message.get("content")
-            ):
-                # Fail closed instead of stripping so no hidden reasoning can be
-                # partially leaked or mis-accounted in API v1 relay responses.
-                self._last_api_v1_invalid_model_output_reason = "qwen_thinking_output_leaked"
-                return None
+            if message is not None:
+                cleaned_content, invalid_reason = self._api_v1_normalize_qwen_non_thinking_content(
+                    model_profile, message.get("content")
+                )
+                if invalid_reason is not None:
+                    self._last_api_v1_invalid_model_output_reason = invalid_reason
+                    return None
+                message = {"role": "assistant", "content": cleaned_content}
             if message is None:
                 self._last_api_v1_invalid_model_output_reason = "unsupported_completion_shape"
             return message

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2185,7 +2185,7 @@ class RelayClient:
                 if stripped_any
                 else "unsupported_completion_shape",
             )
-        if re.search(r"<\s*think", cleaned, flags=re.IGNORECASE):
+        if re.search(r"<\s*/?\s*think\b", cleaned, flags=re.IGNORECASE):
             return None, "qwen_thinking_output_leaked"
         return cleaned, None
 
@@ -3059,14 +3059,13 @@ class RelayClient:
             and completion["choices"]
             and isinstance(completion["choices"][0], dict)
         ):
-            choice = completion["choices"][0]
-            if self._api_v1_qwen_reasoning_content_leaked(
-                getattr(self.model_manager, "model_profile", {}) or {}, choice
-            ):
-                # Fail closed before normalizing the runtime choice so hidden
-                # reasoning fields are never forwarded or echoed.
+            model_profile = getattr(self.model_manager, "model_profile", {}) or {}
+            if self._api_v1_qwen_reasoning_content_leaked(model_profile, completion):
+                # Fail closed before normalizing the runtime completion so hidden
+                # reasoning fields anywhere in the response are never forwarded or echoed.
                 self._last_api_v1_invalid_model_output_reason = "qwen_thinking_output_leaked"
                 return None
+            choice = completion["choices"][0]
             raw_message = choice.get("message")
             if isinstance(raw_message, dict) and "role" not in raw_message and "content" in raw_message:
                 raw_message = {**raw_message, "role": "assistant"}
@@ -3075,7 +3074,6 @@ class RelayClient:
                 text = choice.get("text")
                 if isinstance(text, str) and text.strip():
                     message = {"role": "assistant", "content": text}
-            model_profile = getattr(self.model_manager, "model_profile", {}) or {}
             if (
                 message is not None
                 and isinstance(message.get("content"), str)

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2200,7 +2200,7 @@ class RelayClient:
             return False
         forbidden_reasoning_fields = {"reasoning_content", "reasoning"}
         if isinstance(payload, dict):
-            if any(payload.get(field) not in (None, "") for field in forbidden_reasoning_fields):
+            if any(field in payload for field in forbidden_reasoning_fields):
                 return True
             return any(
                 cls._api_v1_qwen_reasoning_content_leaked(model_profile, value)


### PR DESCRIPTION
### Motivation
- Qwen non-thinking mode can emit an empty leading `<think></think>` wrapper which should be removed for API v1 clients, while any real/partial thinking content must still fail closed.
- The packaged macOS node readiness smoke was failing because the smoke budget was too small to include an empty wrapper + final answer, so readiness must handle that artifact without relaxing reasoning safety.
- Improve readiness diagnostics and keep E2EE/privacy invariants by surfacing only safe metadata and never logging model text or leaked reasoning.

### Description
- Add a focused normalizer `RelayClient._api_v1_normalize_qwen_non_thinking_content(model_profile, content)` that strips one-or-more leading empty `<think></think>` wrappers (case-insensitive, tolerant of whitespace) and returns cleaned text or a safe rejection reason (`qwen_thinking_output_leaked` / `qwen_empty_after_think_wrapper_strip` / `unsupported_completion_shape`).
- Use the normalizer in assistant extraction (`_assistant_message_from_runtime_completion`) and replace prior ad-hoc thinking checks so runtime completions are normalized before returning `{ role: "assistant", content: cleaned }` or failing closed with safe reasons.
- Replace the simple thinking-detection predicate with a normalization-driven check and add `_api_v1_completion_shape_category()` to categorize completion shapes for safe diagnostics (e.g., `choices_message_content`, `choices_text`, `missing_choices`, `reasoning_field_present`).
- Update the readiness completion smoke in `ComputeNodeRuntime` to use a larger Qwen smoke budget when non-thinking enforcement is active (e.g., 64 tokens), run the same Qwen normalizer on smoke output, accept empty-wrapper-plus-answer responses, and fail with precise safe internal reasons (`runtime_completion_smoke_empty_output`, `runtime_completion_smoke_empty_after_think_strip`, `runtime_completion_smoke_thinking_leaked`, `runtime_completion_smoke_malformed_completion`, `runtime_completion_smoke_exception`).
- Enrich readiness diagnostics with safe metadata (`model_profile` provider/id, context tier, smoke max tokens, shape category, and non-sensitive failure reason) while ensuring no assistant/model content is logged or persisted.
- Add focused unit tests validating the normalizer, assistant extraction, and readiness-smoke behavior (accept empty-leading `<think>`+answer, reject non-empty thinking or partial tags, empty-after-strip failure, and shape/failure diagnostics), and update existing assertions to align with new behavior.

### Testing
- Ran the targeted test commands locally and they all passed: `python -m pytest tests/unit/test_relay_client.py -q` (passed), `python -m pytest tests/unit/test_compute_node_runtime.py -q` (passed), `python -m pytest tests/unit/test_model_manager.py -q` (passed), `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (passed), `python -m pytest tests/unit/test_context_profiles.py -q` (passed), and `python -m pytest tests/unit/test_touch_ui.py -q` (passed).
- Ran `pre-commit run --all-files` and repository checks (hook suite) which completed successfully.
- All automated checks and the focused test suite for Qwen non-thinking normalization/readiness passed locally; readiness smoke tests now accept empty leading `<think></think>` artifacts while still failing closed on non-empty or malformed thinking content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a455c0dc5a8832fb6d03768972917c8)