### PR TITLE
Normalize empty Qwen think wrappers while rejecting real reasoning content

### DIFF
--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -398,7 +398,46 @@ def test_compute_node_runtime_readiness_smoke_completion_passes(monkeypatch):
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert diagnostics["api_v1_readiness_result"] == "passed"
     assert llm_runtime.completion_kwargs["stream"] is False
-    assert llm_runtime.completion_kwargs["max_tokens"] == 4
+    assert llm_runtime.completion_kwargs["max_tokens"] == 64
+    assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
+
+
+def test_compute_node_runtime_readiness_smoke_completion_accepts_empty_think_wrapper(monkeypatch):
+    class EmptyThinkRuntime:
+        def __init__(self):
+            self.completion_kwargs = None
+
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **kwargs):
+            self.completion_kwargs = kwargs
+            return {"choices": [{"message": {"role": "assistant", "content": "<think>\n\n</think>\n\nok"}}]}
+
+    monkeypatch.delenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", raising=False)
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    llm_runtime = EmptyThinkRuntime()
+    model_manager.get_llm_instance.return_value = llm_runtime
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(
+            _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+        ),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
+    assert diagnostics["api_v1_readiness_completion_smoke_shape"] == "choices_message_content"
+    assert diagnostics["api_v1_readiness_completion_smoke_max_tokens"] == 64
     assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
 
 
@@ -431,7 +470,7 @@ def test_compute_node_runtime_qwen_readiness_smoke_completion_is_required_withou
     assert runtime.ensure_api_v1_runtime_ready() is False
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
-    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_thinking_leaked"
 
 
 def test_compute_node_runtime_readiness_smoke_completion_rejects_think_output(monkeypatch):
@@ -464,7 +503,7 @@ def test_compute_node_runtime_readiness_smoke_completion_rejects_think_output(mo
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
     assert diagnostics["api_v1_readiness_result"] == "failed"
-    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_thinking_leaked"
 
 
 def test_compute_node_runtime_readiness_smoke_completion_rejects_reasoning_content(monkeypatch):
@@ -506,7 +545,8 @@ def test_compute_node_runtime_readiness_smoke_completion_rejects_reasoning_conte
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
     assert diagnostics["api_v1_readiness_result"] == "failed"
-    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_thinking_leaked"
+    assert diagnostics["api_v1_readiness_completion_smoke_shape"] == "reasoning_field_present"
     assert "secret hidden reasoning" not in json.dumps(diagnostics)
 
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -37,6 +37,43 @@ def test_api_v1_models_module_import_failure_does_not_capture_worker_diagnostics
 
     assert RelayClient._api_v1_models_module() is None
 
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("answer", "answer"),
+        (" <think></think> answer ", "answer"),
+        ("<think>\n\n</think>\n\nok", "ok"),
+        ("<THINK>   </THINK>\nAnswer", "Answer"),
+        ("<think></think><think> </think> final", "final"),
+    ],
+)
+def test_qwen_non_thinking_normalizer_strips_only_empty_leading_wrappers(raw, expected):
+    cleaned, reason = RelayClient._api_v1_normalize_qwen_non_thinking_content(
+        {"provider": "qwen", "thinking_mode": "disabled"}, raw
+    )
+
+    assert cleaned == expected
+    assert reason is None
+
+
+@pytest.mark.parametrize(
+    "raw, reason",
+    [
+        ("<think>I am reasoning</think>\nanswer", "qwen_thinking_output_leaked"),
+        ("<think secret partial", "qwen_thinking_output_leaked"),
+        ("answer <think></think>", "qwen_thinking_output_leaked"),
+        ("<think></think>", "qwen_empty_after_think_wrapper_strip"),
+    ],
+)
+def test_qwen_non_thinking_normalizer_rejects_reasoning_and_empty(raw, reason):
+    cleaned, observed_reason = RelayClient._api_v1_normalize_qwen_non_thinking_content(
+        {"provider": "qwen", "thinking_mode": "disabled"}, raw
+    )
+
+    assert cleaned is None
+    assert observed_reason == reason
+
 # Common test data
 TEST_VALID_RESPONSE = {
     'client_public_key': 'Y2xpZW50X2tleV9iNjQ=',  # Base64 encoded "client_key_b64"
@@ -5235,7 +5272,7 @@ def test_render_tokenize_success_clears_stale_worker_diagnostics():
 def test_api_v1_qwen_completion_text_fallback_converts_to_assistant_message():
     manager = _ApiV1RuntimeManager()
     manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
-    manager.runtime.create_chat_completion.return_value = {"choices": [{"text": "Qwen ok"}]}
+    manager.runtime.create_chat_completion.return_value = {"choices": [{"text": "<think>\n\n</think>\n\nQwen ok"}]}
     client = _api_v1_validation_client(manager)
 
     envelope = client._generate_api_v1_response_with_runtime_model(
@@ -5246,6 +5283,7 @@ def test_api_v1_qwen_completion_text_fallback_converts_to_assistant_message():
     )
 
     assert envelope["api_v1_response"]["message"] == {"role": "assistant", "content": "Qwen ok"}
+    assert "<think" not in envelope["api_v1_response"]["message"]["content"].lower()
 
 
 def test_api_v1_qwen_message_without_role_converts_to_assistant_message():

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -467,14 +467,24 @@ class ComputeNodeRuntime:
             or os.getenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION") == "1"
         )
         if admitted and completion_smoke_required:
+            smoke_max_tokens = 64 if diagnostics["api_v1_readiness_non_thinking_enforced"] else 4
+            diagnostics["api_v1_readiness_completion_smoke_max_tokens"] = smoke_max_tokens
+            diagnostics["api_v1_readiness_completion_smoke_model_id"] = getattr(
+                self.model_manager, "api_model_id", None
+            )
+            diagnostics["api_v1_readiness_completion_smoke_profile_id"] = (
+                model_profile.get("id") if isinstance(model_profile, dict) else None
+            )
+            diagnostics["api_v1_readiness_completion_smoke_context_tier"] = str(context_tier)
             try:
                 smoke_completion = create_chat_completion(
                     messages=smoke_messages,
-                    max_tokens=4,
+                    max_tokens=smoke_max_tokens,
                     stream=False,
                 )
-                smoke_message = None
+                smoke_choice = None
                 smoke_content = None
+                smoke_shape = "missing_choices"
                 if (
                     isinstance(smoke_completion, dict)
                     and isinstance(smoke_completion.get("choices"), list)
@@ -483,34 +493,64 @@ class ComputeNodeRuntime:
                 ):
                     smoke_choice = smoke_completion["choices"][0]
                     smoke_message = smoke_choice.get("message")
-                    if isinstance(smoke_message, dict):
+                    if RelayClient._api_v1_qwen_reasoning_content_leaked(model_profile, smoke_choice):
+                        smoke_shape = "reasoning_field_present"
+                    elif isinstance(smoke_message, dict):
                         smoke_content = smoke_message.get("content")
+                        smoke_shape = (
+                            "choices_message_content"
+                            if isinstance(smoke_content, str) and smoke_content.strip()
+                            else "empty_content"
+                        )
                     elif "text" in smoke_choice:
                         smoke_content = smoke_choice.get("text")
-                smoke_ok = (
-                    isinstance(smoke_content, str)
-                    and bool(smoke_content.strip())
-                    and not RelayClient._api_v1_qwen_thinking_leaked(
-                        model_profile, smoke_content
+                        smoke_shape = (
+                            "choices_text"
+                            if isinstance(smoke_content, str) and smoke_content.strip()
+                            else "empty_content"
+                        )
+                diagnostics["api_v1_readiness_completion_smoke_shape"] = smoke_shape
+
+                if smoke_shape == "reasoning_field_present":
+                    smoke_failure_reason = "runtime_completion_smoke_thinking_leaked"
+                elif not isinstance(smoke_content, str) or not smoke_content.strip():
+                    smoke_failure_reason = (
+                        "runtime_completion_smoke_empty_output"
+                        if smoke_shape != "missing_choices"
+                        else "runtime_completion_smoke_malformed_completion"
                     )
-                    and not RelayClient._api_v1_qwen_reasoning_content_leaked(
-                        model_profile, smoke_choice
+                else:
+                    cleaned_smoke, normalize_reason = (
+                        RelayClient._api_v1_normalize_qwen_non_thinking_content(
+                            model_profile, smoke_content
+                        )
                     )
-                )
+                    if normalize_reason == "qwen_empty_after_think_wrapper_strip":
+                        smoke_failure_reason = "runtime_completion_smoke_empty_after_think_strip"
+                    elif normalize_reason == "qwen_thinking_output_leaked":
+                        smoke_failure_reason = "runtime_completion_smoke_thinking_leaked"
+                    elif normalize_reason is not None:
+                        smoke_failure_reason = "runtime_completion_smoke_malformed_completion"
+                    else:
+                        smoke_failure_reason = None
+                smoke_ok = smoke_failure_reason is None
                 diagnostics["api_v1_readiness_completion_smoke_result"] = "passed" if smoke_ok else "failed"
+                diagnostics["api_v1_readiness_completion_smoke_failure_reason"] = smoke_failure_reason
                 if not smoke_ok:
                     admitted = False
                     admission_error = {
                         "code": "compute_node_context_admission_unavailable",
-                        "internal_reason": "runtime_completion_smoke_failed",
+                        "internal_reason": smoke_failure_reason,
                     }
             except Exception as exc:
                 admitted = False
                 admission_error = {
                     "code": "compute_node_context_admission_unavailable",
-                    "internal_reason": "runtime_completion_smoke_failed",
+                    "internal_reason": "runtime_completion_smoke_exception",
                 }
                 diagnostics["api_v1_readiness_completion_smoke_result"] = "failed"
+                diagnostics["api_v1_readiness_completion_smoke_failure_reason"] = "runtime_completion_smoke_exception"
+                diagnostics["api_v1_readiness_completion_smoke_shape"] = "exception"
                 diagnostics["api_v1_readiness_completion_smoke_exception_type"] = type(exc).__name__
             diagnostics["api_v1_runtime_ready"] = bool(admitted)
             diagnostics["api_v1_readiness_result"] = "passed" if admitted else "failed"

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2161,6 +2161,43 @@ class RelayClient:
         )
 
     @classmethod
+    def _api_v1_normalize_qwen_non_thinking_content(
+        cls, model_profile: Dict[str, Any], content: Any
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Strip empty leading Qwen think wrappers while rejecting reasoning."""
+
+        if not isinstance(content, str):
+            return None, "unsupported_completion_shape"
+
+        if not cls._api_v1_qwen_non_thinking_required(model_profile):
+            cleaned = content.strip()
+            return (cleaned, None) if cleaned else (None, "empty_content")
+
+        remaining = content.lstrip()
+        empty_wrapper_pattern = re.compile(
+            r"^<\s*think\s*>\s*</\s*think\s*>",
+            flags=re.IGNORECASE,
+        )
+        stripped_wrapper = False
+        while True:
+            match = empty_wrapper_pattern.match(remaining)
+            if not match:
+                break
+            stripped_wrapper = True
+            remaining = remaining[match.end():].lstrip()
+
+        if re.search(r"<\s*/?\s*think\b|<\s*think", remaining, flags=re.IGNORECASE):
+            return None, "qwen_thinking_output_leaked"
+
+        cleaned = remaining.strip()
+        if not cleaned:
+            if stripped_wrapper:
+                return None, "qwen_empty_after_think_wrapper_strip"
+            return None, "empty_content"
+
+        return cleaned, None
+
+    @classmethod
     def _api_v1_qwen_reasoning_content_leaked(
         cls, model_profile: Dict[str, Any], payload: Any
     ) -> bool:
@@ -3025,13 +3062,16 @@ class RelayClient:
                 if isinstance(text, str) and text.strip():
                     message = {"role": "assistant", "content": text}
             model_profile = getattr(self.model_manager, "model_profile", {}) or {}
-            if message is not None and self._api_v1_qwen_thinking_leaked(
-                model_profile, message.get("content")
-            ):
-                # Fail closed instead of stripping so no hidden reasoning can be
-                # partially leaked or mis-accounted in API v1 relay responses.
-                self._last_api_v1_invalid_model_output_reason = "qwen_thinking_output_leaked"
-                return None
+            if message is not None:
+                cleaned_content, invalid_reason = (
+                    self._api_v1_normalize_qwen_non_thinking_content(
+                        model_profile, message.get("content")
+                    )
+                )
+                if invalid_reason is not None:
+                    self._last_api_v1_invalid_model_output_reason = invalid_reason
+                    return None
+                message = {"role": "assistant", "content": cleaned_content}
             if message is None:
                 self._last_api_v1_invalid_model_output_reason = "unsupported_completion_shape"
             return message


### PR DESCRIPTION
### Motivation

- Qwen API v1 non-thinking outputs can include an empty leading `<think></think>` template artifact that should not block readiness or be exposed to clients, while any non-empty/partial thinking must still fail closed.

### Description

- Add `RelayClient._api_v1_normalize_qwen_non_thinking_content(model_profile, content)` to strip one-or-more leading empty Qwen `<think></think>` wrappers (case-insensitive, with surrounding whitespace) and return a cleaned string or a safe failure reason when reasoning is detected or output is empty after stripping.
- Wire the normalizer into runtime extraction in `RelayClient._assistant_message_from_runtime_completion()` so assistant messages returned to clients (and persisted to history) use the cleaned content and never contain `<think>` artifacts, and fail closed for reasoning leaks.
- Update the readiness completion smoke in `ComputeNodeRuntime.ensure_api_v1_runtime_ready()` to use a larger Qwen smoke budget (`64` tokens when non-thinking enforced), run the same normalizer against generated content, and emit safe, non-sensitive diagnostics and precise smoke failure reasons (e.g. `runtime_completion_smoke_empty_after_think_strip`, `runtime_completion_smoke_thinking_leaked`, `runtime_completion_smoke_malformed_completion`, `runtime_completion_smoke_exception`).
- Add/update focused unit tests to cover the normalizer, assistant extraction, readiness smoke acceptance of empty-wrapper+answer, and rejection of non-empty/partial think output; also ensure text fallback cleaning and that no `<think>` appears in client-visible messages.

### Testing

- Ran unit and integration suites: `python -m pytest tests/unit/test_relay_client.py -q`, `python -m pytest tests/unit/test_compute_node_runtime.py -q`, `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, and `python -m pytest tests/unit/test_touch_ui.py -q`, and all tests passed.</json>

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a455c1b1d84832fbe38e30045670b65)