### PR TITLE
Normalize Qwen empty <think> wrappers and hard-fail real reasoning leaks

### DIFF
--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -398,7 +398,48 @@ def test_compute_node_runtime_readiness_smoke_completion_passes(monkeypatch):
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert diagnostics["api_v1_readiness_result"] == "passed"
     assert llm_runtime.completion_kwargs["stream"] is False
-    assert llm_runtime.completion_kwargs["max_tokens"] == 4
+    assert llm_runtime.completion_kwargs["max_tokens"] >= 32
+    assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
+
+
+def test_compute_node_runtime_readiness_smoke_completion_strips_empty_qwen_wrapper(monkeypatch):
+    class EmptyThinkRuntime:
+        def __init__(self):
+            self.completion_kwargs = None
+
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **kwargs):
+            self.completion_kwargs = kwargs
+            return {"choices": [{"message": {"role": "assistant", "content": "<think>\n\n</think>\n\nok"}}]}
+
+    monkeypatch.delenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", raising=False)
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    llm_runtime = EmptyThinkRuntime()
+    model_manager.get_llm_instance.return_value = llm_runtime
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(
+            _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+        ),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
+    assert diagnostics["api_v1_readiness_completion_smoke_failure_reason"] is None
+    assert diagnostics["api_v1_readiness_completion_smoke_shape_category"] == "choices_message_content"
+    assert diagnostics["api_v1_readiness_completion_smoke_max_tokens"] >= 32
+    assert "<think" not in json.dumps(diagnostics).lower()
     assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
 
 
@@ -431,7 +472,7 @@ def test_compute_node_runtime_qwen_readiness_smoke_completion_is_required_withou
     assert runtime.ensure_api_v1_runtime_ready() is False
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
-    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_thinking_leaked"
 
 
 def test_compute_node_runtime_readiness_smoke_completion_rejects_think_output(monkeypatch):
@@ -464,7 +505,7 @@ def test_compute_node_runtime_readiness_smoke_completion_rejects_think_output(mo
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
     assert diagnostics["api_v1_readiness_result"] == "failed"
-    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_thinking_leaked"
 
 
 def test_compute_node_runtime_readiness_smoke_completion_rejects_reasoning_content(monkeypatch):
@@ -506,7 +547,7 @@ def test_compute_node_runtime_readiness_smoke_completion_rejects_reasoning_conte
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
     assert diagnostics["api_v1_readiness_result"] == "failed"
-    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_thinking_leaked"
     assert "secret hidden reasoning" not in json.dumps(diagnostics)
 
 
@@ -572,6 +613,7 @@ def test_compute_node_runtime_readiness_smoke_completion_records_safe_exception(
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
     assert diagnostics["api_v1_readiness_completion_smoke_exception_type"] == "RuntimeError"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_exception"
     assert "prompt text" not in str(diagnostics)
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5027,6 +5027,47 @@ def test_qwen_context_admission_unavailable_when_template_missing_no_llama_fallb
     assert envelope['api_v1_response']['error']['code'] == 'compute_node_context_admission_unavailable'
 
 
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("<think></think>ok", "ok"),
+        ("<think>\n\n</think>\n\nok", "ok"),
+        ("   <THINK>   </THINK> final answer  ", "final answer"),
+        ("<think></think><think> </think>ok", "ok"),
+        ("normal <xml>content</xml>", "normal <xml>content</xml>"),
+    ],
+)
+def test_qwen_non_thinking_normalizer_strips_only_empty_leading_wrappers(raw, expected):
+    cleaned, reason = RelayClient._api_v1_normalize_qwen_non_thinking_content(
+        {"provider": "qwen", "thinking_mode": "disabled"}, raw
+    )
+
+    assert reason is None
+    assert cleaned == expected
+
+
+@pytest.mark.parametrize(
+    "raw,reason",
+    [
+        ("<think>secret</think>answer", "qwen_thinking_output_leaked"),
+        ("<THINK>secret</THINK>answer", "qwen_thinking_output_leaked"),
+        ("<think secret partial", "qwen_thinking_output_leaked"),
+        ("<think></think>", "qwen_empty_after_think_wrapper_strip"),
+        ("<think></think>  ", "qwen_empty_after_think_wrapper_strip"),
+        ("answer <think></think>", "qwen_thinking_output_leaked"),
+    ],
+)
+def test_qwen_non_thinking_normalizer_rejects_reasoning_or_empty_output(raw, reason):
+    cleaned, actual_reason = RelayClient._api_v1_normalize_qwen_non_thinking_content(
+        {"provider": "qwen", "thinking_mode": "disabled"}, raw
+    )
+
+    assert cleaned is None
+    assert actual_reason == reason
+
+
 def test_qwen_think_output_is_rejected():
     manager = _AdmissionManager(window=128)
     manager.api_model_id = 'qwen3-8b-instruct'
@@ -5120,8 +5161,30 @@ def test_qwen_reasoning_content_field_is_rejected_with_safe_reason():
 
     error = envelope["api_v1_response"]["error"]
     assert error["code"] == "compute_node_invalid_model_output"
-    assert error["internal_reason"] == "qwen_reasoning_content_leaked"
+    assert error["internal_reason"] == "qwen_thinking_output_leaked"
     assert "secret hidden reasoning" not in json.dumps(error)
+
+
+def test_qwen_empty_leading_think_wrapper_is_stripped_from_runtime_response():
+    manager = _AdmissionManager(window=128)
+    manager.api_model_id = "qwen3-8b-instruct"
+    manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    manager.runtime.create_chat_completion = lambda **kwargs: {
+        "choices": [{"message": {"role": "assistant", "content": "<think>\n\n</think>\n\nok"}}]
+    }
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-empty-wrapper",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5},
+        requested_context_tier="8k-fast",
+    )
+
+    message = envelope["api_v1_response"]["message"]
+    assert message == {"role": "assistant", "content": "ok"}
+    assert "<think" not in json.dumps(envelope).lower()
 
 
 def test_api_v1_qwen_non_thinking_policy_is_single_source_of_truth():

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -467,15 +467,21 @@ class ComputeNodeRuntime:
             or os.getenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION") == "1"
         )
         if admitted and completion_smoke_required:
+            smoke_max_tokens = 32 if qwen_non_thinking_enforced else 4
+            diagnostics["api_v1_readiness_completion_smoke_max_tokens"] = smoke_max_tokens
             try:
                 smoke_completion = create_chat_completion(
                     messages=smoke_messages,
-                    max_tokens=4,
+                    max_tokens=smoke_max_tokens,
                     stream=False,
                 )
-                smoke_message = None
+                smoke_choice = None
                 smoke_content = None
-                if (
+                smoke_shape_category = "missing_choices"
+                if RelayClient._api_v1_qwen_reasoning_content_leaked(model_profile, smoke_completion):
+                    smoke_shape_category = "reasoning_field_present"
+                    smoke_failure_reason = "runtime_completion_smoke_thinking_leaked"
+                elif (
                     isinstance(smoke_completion, dict)
                     and isinstance(smoke_completion.get("choices"), list)
                     and smoke_completion["choices"]
@@ -483,34 +489,46 @@ class ComputeNodeRuntime:
                 ):
                     smoke_choice = smoke_completion["choices"][0]
                     smoke_message = smoke_choice.get("message")
-                    if isinstance(smoke_message, dict):
+                    if isinstance(smoke_message, dict) and isinstance(smoke_message.get("content"), str):
                         smoke_content = smoke_message.get("content")
-                    elif "text" in smoke_choice:
+                        smoke_shape_category = "choices_message_content"
+                    elif isinstance(smoke_choice.get("text"), str):
                         smoke_content = smoke_choice.get("text")
-                smoke_ok = (
-                    isinstance(smoke_content, str)
-                    and bool(smoke_content.strip())
-                    and not RelayClient._api_v1_qwen_thinking_leaked(
+                        smoke_shape_category = "choices_text"
+                    else:
+                        smoke_shape_category = "empty_content"
+                    cleaned_smoke, invalid_reason = RelayClient._api_v1_normalize_qwen_non_thinking_content(
                         model_profile, smoke_content
                     )
-                    and not RelayClient._api_v1_qwen_reasoning_content_leaked(
-                        model_profile, smoke_choice
-                    )
-                )
+                    if invalid_reason == "qwen_empty_after_think_wrapper_strip":
+                        smoke_failure_reason = "runtime_completion_smoke_empty_after_think_strip"
+                    elif invalid_reason == "qwen_thinking_output_leaked":
+                        smoke_failure_reason = "runtime_completion_smoke_thinking_leaked"
+                    elif invalid_reason is not None:
+                        smoke_failure_reason = "runtime_completion_smoke_empty_output"
+                    else:
+                        smoke_failure_reason = None if cleaned_smoke else "runtime_completion_smoke_empty_output"
+                else:
+                    smoke_failure_reason = "runtime_completion_smoke_malformed_completion"
+                smoke_ok = smoke_failure_reason is None
                 diagnostics["api_v1_readiness_completion_smoke_result"] = "passed" if smoke_ok else "failed"
+                diagnostics["api_v1_readiness_completion_smoke_failure_reason"] = smoke_failure_reason
+                diagnostics["api_v1_readiness_completion_smoke_shape_category"] = smoke_shape_category
                 if not smoke_ok:
                     admitted = False
                     admission_error = {
                         "code": "compute_node_context_admission_unavailable",
-                        "internal_reason": "runtime_completion_smoke_failed",
+                        "internal_reason": smoke_failure_reason or "runtime_completion_smoke_failed",
                     }
             except Exception as exc:
                 admitted = False
                 admission_error = {
                     "code": "compute_node_context_admission_unavailable",
-                    "internal_reason": "runtime_completion_smoke_failed",
+                    "internal_reason": "runtime_completion_smoke_exception",
                 }
                 diagnostics["api_v1_readiness_completion_smoke_result"] = "failed"
+                diagnostics["api_v1_readiness_completion_smoke_failure_reason"] = "runtime_completion_smoke_exception"
+                diagnostics["api_v1_readiness_completion_smoke_shape_category"] = "exception"
                 diagnostics["api_v1_readiness_completion_smoke_exception_type"] = type(exc).__name__
             diagnostics["api_v1_runtime_ready"] = bool(admitted)
             diagnostics["api_v1_readiness_result"] = "passed" if admitted else "failed"

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2151,13 +2151,58 @@ class RelayClient:
         return messages
 
     @classmethod
+    def _api_v1_normalize_qwen_non_thinking_content(
+        cls, model_profile: Dict[str, Any], content: Any
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Strip empty leading Qwen think wrappers while rejecting reasoning leaks.
+
+        Returns ``(cleaned_content, safe_internal_reason)``.  A non-``None``
+        reason means the content must fail closed and must not be forwarded.
+        """
+
+        if not isinstance(content, str):
+            return None, "unsupported_completion_shape"
+        if not cls._api_v1_qwen_non_thinking_required(model_profile):
+            cleaned = content.strip()
+            return (cleaned, None) if cleaned else (None, "unsupported_completion_shape")
+
+        remaining = content.lstrip()
+        stripped_any = False
+        while True:
+            match = re.match(
+                r"^<\s*think\s*>(?P<body>.*?)<\s*/\s*think\s*>",
+                remaining,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+            if not match:
+                break
+            if match.group("body").strip():
+                return None, "qwen_thinking_output_leaked"
+            stripped_any = True
+            remaining = remaining[match.end():].lstrip()
+
+        if re.search(r"<\s*/?\s*think\b|<\s*think", remaining, flags=re.IGNORECASE):
+            return None, "qwen_thinking_output_leaked"
+
+        cleaned = remaining.strip()
+        if not cleaned:
+            reason = (
+                "qwen_empty_after_think_wrapper_strip"
+                if stripped_any
+                else "unsupported_completion_shape"
+            )
+            return None, reason
+        return cleaned, None
+
+    @classmethod
     def _api_v1_qwen_thinking_leaked(
         cls, model_profile: Dict[str, Any], content: Any
     ) -> bool:
         return (
             cls._api_v1_qwen_non_thinking_required(model_profile)
             and isinstance(content, str)
-            and bool(re.search(r"<\s*think", content, flags=re.IGNORECASE))
+            and cls._api_v1_normalize_qwen_non_thinking_content(model_profile, content)[1]
+            in {"qwen_thinking_output_leaked", "qwen_empty_after_think_wrapper_strip"}
         )
 
     @classmethod
@@ -3014,7 +3059,7 @@ class RelayClient:
             ):
                 # Fail closed before normalizing the runtime choice so hidden
                 # reasoning fields are never forwarded or echoed.
-                self._last_api_v1_invalid_model_output_reason = "qwen_reasoning_content_leaked"
+                self._last_api_v1_invalid_model_output_reason = "qwen_thinking_output_leaked"
                 return None
             raw_message = choice.get("message")
             if isinstance(raw_message, dict) and "role" not in raw_message and "content" in raw_message:
@@ -3025,13 +3070,14 @@ class RelayClient:
                 if isinstance(text, str) and text.strip():
                     message = {"role": "assistant", "content": text}
             model_profile = getattr(self.model_manager, "model_profile", {}) or {}
-            if message is not None and self._api_v1_qwen_thinking_leaked(
-                model_profile, message.get("content")
-            ):
-                # Fail closed instead of stripping so no hidden reasoning can be
-                # partially leaked or mis-accounted in API v1 relay responses.
-                self._last_api_v1_invalid_model_output_reason = "qwen_thinking_output_leaked"
-                return None
+            if message is not None:
+                cleaned_content, invalid_reason = self._api_v1_normalize_qwen_non_thinking_content(
+                    model_profile, message.get("content")
+                )
+                if invalid_reason is not None:
+                    self._last_api_v1_invalid_model_output_reason = invalid_reason
+                    return None
+                message = {"role": "assistant", "content": cleaned_content}
             if message is None:
                 self._last_api_v1_invalid_model_output_reason = "unsupported_completion_shape"
             return message


### PR DESCRIPTION
### Motivation
- Qwen `non-thinking` outputs sometimes emit an empty leading `<think></think>` template artifact which causes the API v1 readiness completion smoke to fail despite there being a valid final answer. 
- API v1 must never expose thinking/reasoning to clients and must fail-closed on any non-empty/partial thinking content or `reasoning*` fields. 
- The readiness smoke used `max_tokens=4`, which is too small to allow an empty wrapper + final token sequence; the smoke must use a slightly larger budget while keeping strict normalization and safe diagnostics.

### Description
- Added a focused normalizer `RelayClient._api_v1_normalize_qwen_non_thinking_content(model_profile, content)` in `utils/networking/relay_client.py` that strips one or more leading empty `<think>...</think>` wrappers (case-insensitive, tolerates whitespace/newlines) and returns `(cleaned_content, invalid_reason)` where non-`None` `invalid_reason` indicates a fail-closed condition. 
- Reworked Qwen leak detection to rely on the normalizer (including `_api_v1_qwen_thinking_leaked`) and updated `_assistant_message_from_runtime_completion()` to run Qwen non-thinking responses through the normalizer and return `{ role: "assistant", content: cleanedContent }` or fail-closed with safe reasons. 
- Updated the readiness completion smoke in `utils/compute_node_runtime.py` to use a larger smoke budget when Qwen non-thinking is enforced (now `smoke_max_tokens = 32`), to invoke the same non-thinking normalization, and to emit non-sensitive diagnostics fields: `api_v1_readiness_completion_smoke_max_tokens`, `api_v1_readiness_completion_smoke_failure_reason`, and `api_v1_readiness_completion_smoke_shape_category`; internal error reasons map precisely to `runtime_completion_smoke_empty_output`, `runtime_completion_smoke_empty_after_think_strip`, `runtime_completion_smoke_thinking_leaked`, `runtime_completion_smoke_malformed_completion`, or `runtime_completion_smoke_exception`. 
- Added and adjusted unit tests to cover the new normalizer and smoke behavior in `tests/unit/test_relay_client.py` and `tests/unit/test_compute_node_runtime.py`, including cases for: empty leading think wrapper stripping, rejection of non-empty/partial think tags, rejection of `reasoning`/`reasoning_content` fields, readiness smoke acceptance of `<think>\n\n</think>\n\nok`, and that no `<think>` appears in client-visible output or diagnostics. 
- Preserved existing invariants: non-empty thinking still fails closed; no thinking content is persisted in chat history; API v2 and relay E2EE semantics unchanged; no prompt or assistant plaintext logged.

### Testing
- `python -m pytest tests/unit/test_relay_client.py tests/unit/test_compute_node_runtime.py -q` — all tests passed (unit suites exercised the new normalizer and readiness smoke). 
- `python -m pytest tests/unit/test_model_manager.py -q && python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q && python -m pytest tests/unit/test_context_profiles.py -q && python -m pytest tests/unit/test_touch_ui.py -q` — these suites passed (model manager, integration E2EE, context profiles, and touch UI checks). 
- `pre-commit run --all-files` and `git diff --check` — passed with no findings. 

If you'd like, I can split the normalizer/tests into a follow-up focused PR (smaller diff) or add a short note in the changelog about the readiness-smoke behavior; otherwise this PR is limited to the files and tests listed in the scope lock.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a455c43c648832faca50bec7c9e9540)