### PR TITLE
Normalize empty Qwen think wrappers while rejecting real reasoning content

### DIFF
--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -398,9 +398,47 @@ def test_compute_node_runtime_readiness_smoke_completion_passes(monkeypatch):
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert diagnostics["api_v1_readiness_result"] == "passed"
     assert llm_runtime.completion_kwargs["stream"] is False
-    assert llm_runtime.completion_kwargs["max_tokens"] == 4
+    assert llm_runtime.completion_kwargs["max_tokens"] == 32
+    assert diagnostics["api_v1_readiness_completion_smoke_max_tokens"] == 32
     assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
 
+
+def test_compute_node_runtime_readiness_smoke_completion_strips_empty_qwen_think_wrapper(monkeypatch):
+    class EmptyThinkRuntime:
+        def __init__(self):
+            self.completion_kwargs = None
+
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **kwargs):
+            self.completion_kwargs = kwargs
+            return {"choices": [{"message": {"role": "assistant", "content": "<think>\n\n</think>\n\nok"}}]}
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    llm_runtime = EmptyThinkRuntime()
+    model_manager.get_llm_instance.return_value = llm_runtime
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(
+            _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
+        ),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
+    assert diagnostics["api_v1_readiness_completion_smoke_shape"] == "choices_message_content"
+    assert diagnostics["api_v1_readiness_completion_smoke_max_tokens"] == 32
+    assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
 
 def test_compute_node_runtime_qwen_readiness_smoke_completion_is_required_without_env(monkeypatch):
     class ThinkRuntime:
@@ -431,7 +469,7 @@ def test_compute_node_runtime_qwen_readiness_smoke_completion_is_required_withou
     assert runtime.ensure_api_v1_runtime_ready() is False
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
-    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_thinking_leaked"
 
 
 def test_compute_node_runtime_readiness_smoke_completion_rejects_think_output(monkeypatch):
@@ -464,7 +502,7 @@ def test_compute_node_runtime_readiness_smoke_completion_rejects_think_output(mo
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
     assert diagnostics["api_v1_readiness_result"] == "failed"
-    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_thinking_leaked"
 
 
 def test_compute_node_runtime_readiness_smoke_completion_rejects_reasoning_content(monkeypatch):
@@ -506,7 +544,7 @@ def test_compute_node_runtime_readiness_smoke_completion_rejects_reasoning_conte
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
     assert diagnostics["api_v1_readiness_result"] == "failed"
-    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_thinking_leaked"
     assert "secret hidden reasoning" not in json.dumps(diagnostics)
 
 
@@ -571,6 +609,7 @@ def test_compute_node_runtime_readiness_smoke_completion_records_safe_exception(
     assert runtime.ensure_api_v1_runtime_ready() is False
     diagnostics = model_manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_exception"
     assert diagnostics["api_v1_readiness_completion_smoke_exception_type"] == "RuntimeError"
     assert "prompt text" not in str(diagnostics)
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5124,6 +5124,65 @@ def test_qwen_reasoning_content_field_is_rejected_with_safe_reason():
     assert "secret hidden reasoning" not in json.dumps(error)
 
 
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("answer", "answer"),
+        ("  <think></think>  answer  ", "answer"),
+        ("<think>\n\n</think>\n\nok", "ok"),
+        ("<THINK>   </THINK>\nFinal", "Final"),
+        ("<think></think><think> </think> final", "final"),
+        ("<xml>not think</xml>", "<xml>not think</xml>"),
+    ],
+)
+def test_api_v1_normalize_qwen_non_thinking_content_strips_only_empty_leading_wrappers(raw, expected):
+    cleaned, reason = RelayClient._api_v1_normalize_qwen_non_thinking_content(
+        {"provider": "qwen", "thinking_mode": "disabled"}, raw
+    )
+
+    assert cleaned == expected
+    assert reason is None
+    assert "<think" not in cleaned.lower()
+
+
+@pytest.mark.parametrize(
+    "raw,reason",
+    [
+        ("<think>reasoning</think> answer", "qwen_thinking_output_leaked"),
+        ("<think></think><think>reasoning</think> answer", "qwen_thinking_output_leaked"),
+        ("answer <think>later</think>", "qwen_thinking_output_leaked"),
+        ("<think partial", "qwen_thinking_output_leaked"),
+        ("<think></think>", "qwen_empty_after_think_wrapper_strip"),
+    ],
+)
+def test_api_v1_normalize_qwen_non_thinking_content_rejects_reasoning_or_empty(raw, reason):
+    cleaned, actual_reason = RelayClient._api_v1_normalize_qwen_non_thinking_content(
+        {"provider": "qwen", "thinking_mode": "disabled"}, raw
+    )
+
+    assert cleaned is None
+    assert actual_reason == reason
+
+
+def test_api_v1_qwen_empty_think_wrapper_is_stripped_from_runtime_response_and_history():
+    manager = _ApiV1RuntimeManager()
+    manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    manager.runtime.create_chat_completion.return_value = {
+        "choices": [{"message": {"role": "assistant", "content": "<think>\n\n</think>\n\nQwen ok"}}]
+    }
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-empty-think",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hi"}],
+        options={},
+    )
+
+    assert envelope["api_v1_response"]["message"] == {"role": "assistant", "content": "Qwen ok"}
+    assert "<think" not in json.dumps(envelope).lower()
+
+
 def test_api_v1_qwen_non_thinking_policy_is_single_source_of_truth():
     policy = RelayClient._API_V1_QWEN_NON_THINKING_POLICY
 

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -468,14 +468,22 @@ class ComputeNodeRuntime:
         )
         if admitted and completion_smoke_required:
             try:
+                smoke_max_tokens = 32
+                diagnostics["api_v1_readiness_completion_smoke_max_tokens"] = smoke_max_tokens
                 smoke_completion = create_chat_completion(
                     messages=smoke_messages,
-                    max_tokens=4,
+                    max_tokens=smoke_max_tokens,
                     stream=False,
                 )
-                smoke_message = None
+                smoke_shape = RelayClient._api_v1_runtime_completion_shape_category(
+                    smoke_completion, model_profile
+                )
+                diagnostics["api_v1_readiness_completion_smoke_shape"] = smoke_shape
                 smoke_content = None
-                if (
+                smoke_failure_reason = None
+                if RelayClient._api_v1_qwen_reasoning_content_leaked(model_profile, smoke_completion):
+                    smoke_failure_reason = "runtime_completion_smoke_thinking_leaked"
+                elif (
                     isinstance(smoke_completion, dict)
                     and isinstance(smoke_completion.get("choices"), list)
                     and smoke_completion["choices"]
@@ -487,30 +495,43 @@ class ComputeNodeRuntime:
                         smoke_content = smoke_message.get("content")
                     elif "text" in smoke_choice:
                         smoke_content = smoke_choice.get("text")
-                smoke_ok = (
-                    isinstance(smoke_content, str)
-                    and bool(smoke_content.strip())
-                    and not RelayClient._api_v1_qwen_thinking_leaked(
-                        model_profile, smoke_content
+                    cleaned_smoke_content, normalize_reason = (
+                        RelayClient._api_v1_normalize_qwen_non_thinking_content(
+                            model_profile, smoke_content
+                        )
                     )
-                    and not RelayClient._api_v1_qwen_reasoning_content_leaked(
-                        model_profile, smoke_choice
-                    )
-                )
+                    if normalize_reason == "qwen_empty_after_think_wrapper_strip":
+                        smoke_failure_reason = "runtime_completion_smoke_empty_after_think_strip"
+                    elif normalize_reason == "qwen_thinking_output_leaked":
+                        smoke_failure_reason = "runtime_completion_smoke_thinking_leaked"
+                    elif normalize_reason is not None:
+                        smoke_failure_reason = (
+                            "runtime_completion_smoke_empty_output"
+                            if smoke_shape == "empty_content"
+                            else "runtime_completion_smoke_malformed_completion"
+                        )
+                    elif not cleaned_smoke_content:
+                        smoke_failure_reason = "runtime_completion_smoke_empty_output"
+                else:
+                    smoke_failure_reason = "runtime_completion_smoke_malformed_completion"
+                smoke_ok = smoke_failure_reason is None
                 diagnostics["api_v1_readiness_completion_smoke_result"] = "passed" if smoke_ok else "failed"
+                diagnostics["api_v1_readiness_completion_smoke_failure_reason"] = smoke_failure_reason
                 if not smoke_ok:
                     admitted = False
                     admission_error = {
                         "code": "compute_node_context_admission_unavailable",
-                        "internal_reason": "runtime_completion_smoke_failed",
+                        "internal_reason": smoke_failure_reason or "runtime_completion_smoke_failed",
                     }
             except Exception as exc:
                 admitted = False
                 admission_error = {
                     "code": "compute_node_context_admission_unavailable",
-                    "internal_reason": "runtime_completion_smoke_failed",
+                    "internal_reason": "runtime_completion_smoke_exception",
                 }
                 diagnostics["api_v1_readiness_completion_smoke_result"] = "failed"
+                diagnostics["api_v1_readiness_completion_smoke_failure_reason"] = "runtime_completion_smoke_exception"
+                diagnostics["api_v1_readiness_completion_smoke_shape"] = "exception"
                 diagnostics["api_v1_readiness_completion_smoke_exception_type"] = type(exc).__name__
             diagnostics["api_v1_runtime_ready"] = bool(admitted)
             diagnostics["api_v1_readiness_result"] = "passed" if admitted else "failed"

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2161,6 +2161,79 @@ class RelayClient:
         )
 
     @classmethod
+    def _api_v1_normalize_qwen_non_thinking_content(
+        cls, model_profile: Dict[str, Any], content: Any
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Strip Qwen's empty leading think artifact while rejecting reasoning.
+
+        Returns ``(cleaned_content, None)`` when the content is valid, otherwise
+        ``(None, safe_internal_reason)``.  The rejected content is never included
+        in the reason so callers can safely surface diagnostics.
+        """
+
+        if not isinstance(content, str):
+            return None, "unsupported_completion_shape"
+        if not cls._api_v1_qwen_non_thinking_required(model_profile):
+            cleaned = content.strip()
+            if not cleaned:
+                return None, "unsupported_completion_shape"
+            return cleaned, None
+
+        remaining = content.lstrip()
+        stripped_empty_wrapper = False
+        empty_wrapper_pattern = re.compile(
+            r"^<\s*think\s*>\s*<\s*/\s*think\s*>",
+            flags=re.IGNORECASE,
+        )
+        while True:
+            match = empty_wrapper_pattern.match(remaining)
+            if not match:
+                break
+            stripped_empty_wrapper = True
+            remaining = remaining[match.end():].lstrip()
+
+        cleaned = remaining.strip()
+        if re.search(r"<\s*think", cleaned, flags=re.IGNORECASE):
+            return None, "qwen_thinking_output_leaked"
+        if not cleaned:
+            return (
+                None,
+                "qwen_empty_after_think_wrapper_strip"
+                if stripped_empty_wrapper
+                else "unsupported_completion_shape",
+            )
+        return cleaned, None
+
+    @classmethod
+    def _api_v1_runtime_completion_shape_category(
+        cls, completion: Any, model_profile: Optional[Dict[str, Any]] = None
+    ) -> str:
+        if not (
+            isinstance(completion, dict)
+            and isinstance(completion.get("choices"), list)
+            and completion["choices"]
+            and isinstance(completion["choices"][0], dict)
+        ):
+            return "missing_choices"
+        choice = completion["choices"][0]
+        if cls._api_v1_qwen_reasoning_content_leaked(model_profile or {}, choice):
+            return "reasoning_field_present"
+        message = choice.get("message")
+        if isinstance(message, dict) and isinstance(message.get("content"), str):
+            return (
+                "choices_message_content"
+                if message.get("content").strip()
+                else "empty_content"
+            )
+        if "text" in choice:
+            return (
+                "choices_text"
+                if isinstance(choice.get("text"), str) and choice.get("text").strip()
+                else "empty_content"
+            )
+        return "missing_choices"
+
+    @classmethod
     def _api_v1_qwen_reasoning_content_leaked(
         cls, model_profile: Dict[str, Any], payload: Any
     ) -> bool:
@@ -3010,7 +3083,7 @@ class RelayClient:
         ):
             choice = completion["choices"][0]
             if self._api_v1_qwen_reasoning_content_leaked(
-                getattr(self.model_manager, "model_profile", {}) or {}, choice
+                getattr(self.model_manager, "model_profile", {}) or {}, completion
             ):
                 # Fail closed before normalizing the runtime choice so hidden
                 # reasoning fields are never forwarded or echoed.
@@ -3025,13 +3098,18 @@ class RelayClient:
                 if isinstance(text, str) and text.strip():
                     message = {"role": "assistant", "content": text}
             model_profile = getattr(self.model_manager, "model_profile", {}) or {}
-            if message is not None and self._api_v1_qwen_thinking_leaked(
-                model_profile, message.get("content")
-            ):
-                # Fail closed instead of stripping so no hidden reasoning can be
-                # partially leaked or mis-accounted in API v1 relay responses.
-                self._last_api_v1_invalid_model_output_reason = "qwen_thinking_output_leaked"
-                return None
+            if message is not None:
+                cleaned_content, invalid_reason = self._api_v1_normalize_qwen_non_thinking_content(
+                    model_profile, message.get("content")
+                )
+                if invalid_reason is not None:
+                    # Fail closed if hidden/visible reasoning appears, but allow
+                    # Qwen's documented empty leading think-wrapper artifact to
+                    # be stripped before any API v1 client-visible response or
+                    # chat-history persistence.
+                    self._last_api_v1_invalid_model_output_reason = invalid_reason
+                    return None
+                message = {**message, "content": cleaned_content}
             if message is None:
                 self._last_api_v1_invalid_model_output_reason = "unsupported_completion_shape"
             return message


### PR DESCRIPTION
### Motivation
- Qwen non-thinking mode can emit an empty leading `<think></think>` artifact that must be removed for API v1 without permitting any real/partial reasoning to reach clients or be persisted in history.\
- The readiness completion smoke was failing when Qwen returned the empty wrapper before the final answer because the smoke budget and normalization were too strict.\

### Description
- Added a focused normalizer `RelayClient._api_v1_normalize_qwen_non_thinking_content(model_profile, content)` that strips one-or-more leading empty Qwen `<think></think>` wrappers (case-insensitive, allowing whitespace) and returns `(cleaned_content, None)` for valid content or `(None, safe_internal_reason)` for invalid outputs.\
- Updated `_assistant_message_from_runtime_completion()` to run Qwen non-thinking outputs through the normalizer and fail-closed for any non-empty/partial `<think>` leakage or `reasoning*` fields, returning only `{ role: "assistant", content: cleanedContent }`.\
- Introduced a safe completion shape helper `RelayClient._api_v1_runtime_completion_shape_category()` to categorize runtime shapes for diagnostics without logging assistant text.\
- Increased the Qwen readiness completion smoke token budget to `32`, applied the same normalizer to smoke output, and added precise smoke failure reasons and diagnostics keys such as `api_v1_readiness_completion_smoke_max_tokens`, `api_v1_readiness_completion_smoke_shape`, and `api_v1_readiness_completion_smoke_failure_reason`.\
- Added unit tests covering the normalizer (strip-only-empty-wrappers, rejection cases), that stripped wrappers do not persist to the client or history, and readiness-smoke behavior; updated readiness smoke tests to expect the new diagnostics and token budget.\

### Testing
- Ran focused unit/integration suites: `python -m pytest tests/unit/test_relay_client.py -q`, `python -m pytest tests/unit/test_compute_node_runtime.py -q`, `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, and `python -m pytest tests/unit/test_touch_ui.py -q`; all listed test runs passed.\
- Ran repository checks: `pre-commit run --all-files` and `git diff --check`; `pre-commit` hooks and `git diff --check` succeeded.\
- New/updated tests exercised: Qwen normalizer unit tests, `_assistant_message_from_runtime_completion()` behavior tests, readiness smoke passing for `"<think>\n\n</think>\n\nok"` and failing for non-empty thinking, and smoke max token assertions; all succeeded in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a455c4bc380832f9fee677580251f21)