### PR TITLE
Fix Qwen 64K YaRN/RoPE runtime support

### DIFF
--- a/config/requirements_server.txt
+++ b/config/requirements_server.txt
@@ -8,7 +8,7 @@ Flask==3.1.2
 idna==3.7
 itsdangerous==2.2.0
 Jinja2==3.1.6
-llama_cpp_python==0.3.16
+llama_cpp_python==0.3.32
 MarkupSafe==3.0.3
 numpy==2.3.4
 requests==2.32.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask==3.1.2
 idna==3.7
 itsdangerous==2.2.0
 Jinja2==3.1.6
-llama_cpp_python==0.3.16
+llama_cpp_python==0.3.32
 MarkupSafe==3.0.3
 numpy==2.3.4
 Pillow==10.4.0

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -346,6 +346,7 @@ def test_compute_node_runtime_qwen_64k_readiness_reports_yarn_rope():
     model_manager.context_window_tokens = 65536
     model_manager.api_model_id = "qwen3-8b-instruct"
     model_manager.last_compute_diagnostics = {}
+    model_manager.last_yarn_rope_diagnostics = {"supported": True, "missing_reason": None}
     model_manager.get_llm_instance.return_value = ReadyRuntime()
     relay_client = SimpleNamespace(
         _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)
@@ -364,6 +365,86 @@ def test_compute_node_runtime_qwen_64k_readiness_reports_yarn_rope():
     assert diagnostics["api_v1_readiness_yarn_original_context_tokens"] == 32768
     assert diagnostics["api_v1_readiness_tokenizer_render_bridge_available"] is True
 
+
+def test_compute_node_runtime_qwen_64k_readiness_rejects_missing_yarn_rope():
+    class ReadyRuntime:
+        def create_chat_completion(self, **_kwargs):
+            return {"choices": [{"message": {"role": "assistant", "content": "ready"}}]}
+
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "rope_scaling_policy": {
+            "type": "yarn",
+            "factor": 2.0,
+            "original_context_tokens": 32768,
+            "required_for_tier": "64k-full",
+        },
+    }
+    model_manager.context_tier = "64k-full"
+    model_manager.context_window_tokens = 65536
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.last_yarn_rope_diagnostics = {
+        "supported": False,
+        "missing_reason": "missing LLAMA_ROPE_SCALING_TYPE_YARN enum constant",
+    }
+    model_manager.get_llm_instance.return_value = ReadyRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=_ready_relay_client(),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_yarn_rope_enabled"] is False
+    assert diagnostics["api_v1_readiness_error_code"] == "compute_node_yarn_rope_unsupported"
+    assert diagnostics["api_v1_readiness_error_reason"] == (
+        "missing LLAMA_ROPE_SCALING_TYPE_YARN enum constant"
+    )
+
+
+def test_compute_node_runtime_qwen_8k_readiness_ignores_missing_yarn_rope_support():
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "rope_scaling_policy": {
+            "type": "yarn",
+            "factor": 2.0,
+            "original_context_tokens": 32768,
+            "required_for_tier": "64k-full",
+        },
+    }
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.last_yarn_rope_diagnostics = {
+        "supported": False,
+        "required": False,
+        "missing_reason": "not_required_for_active_profile_or_tier",
+    }
+    model_manager.get_llm_instance.return_value = _ReadyRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=_ready_relay_client(),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_context_tier"] == "8k-fast"
+    assert diagnostics["api_v1_runtime_ready"] is True
 
 def test_compute_node_runtime_readiness_smoke_completion_passes(monkeypatch):
     class SmokeRuntime:

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -88,11 +88,11 @@ def test_requirement_spec_parses_comments_and_blank_lines(tmp_path):
     requirements.write_text(
         "# comment\n\n"
         "numpy==2.0.0\n"
-        "llama-cpp-python==0.3.16\n",
+        "llama-cpp-python==0.3.32\n",
         encoding="utf-8",
     )
 
-    assert llama_cpp_requirement_spec(requirements) == "llama-cpp-python==0.3.16"
+    assert llama_cpp_requirement_spec(requirements) == "llama-cpp-python==0.3.32"
 
 
 def test_requirement_spec_accepts_underscore_package_name(tmp_path):
@@ -117,7 +117,7 @@ def test_pip_install_args_include_index_and_binary_flags():
     plan = LlamaCppInstallPlan(
         platform="darwin",
         backend="metal",
-        package_spec="llama-cpp-python==0.3.16",
+        package_spec="llama-cpp-python==0.3.32",
         cmake_args=None,
         force_cmake=False,
         index_url="https://example.invalid/simple",
@@ -246,7 +246,7 @@ def test_pip_env_omits_force_cmake_when_disabled():
     plan = LlamaCppInstallPlan(
         platform="darwin",
         backend="metal",
-        package_spec="llama-cpp-python==0.3.16",
+        package_spec="llama-cpp-python==0.3.32",
         cmake_args="-DGGML_METAL=on",
         force_cmake=False,
     )
@@ -256,16 +256,16 @@ def test_pip_env_omits_force_cmake_when_disabled():
 
 def test_requirement_spec_strips_spaces_around_version_pin(tmp_path):
     requirements = tmp_path / "requirements.txt"
-    requirements.write_text("llama-cpp-python== 0.3.16 \n", encoding="utf-8")
+    requirements.write_text("llama-cpp-python== 0.3.32 \n", encoding="utf-8")
 
-    assert llama_cpp_requirement_spec(requirements) == "llama-cpp-python==0.3.16"
+    assert llama_cpp_requirement_spec(requirements) == "llama-cpp-python==0.3.32"
 
 
 def test_backend_probe_satisfies_plan_for_matching_backend():
     plan = LlamaCppInstallPlan(
         platform="win32",
         backend="cuda",
-        package_spec="llama-cpp-python==0.3.16",
+        package_spec="llama-cpp-python==0.3.32",
         cmake_args="-DGGML_CUDA=on",
         force_cmake=True,
     )
@@ -278,7 +278,7 @@ def test_backend_probe_rejects_mismatched_cuda_backend():
     plan = LlamaCppInstallPlan(
         platform="win32",
         backend="cuda",
-        package_spec="llama-cpp-python==0.3.16",
+        package_spec="llama-cpp-python==0.3.32",
         cmake_args="-DGGML_CUDA=on",
         force_cmake=True,
     )
@@ -291,7 +291,7 @@ def test_backend_probe_accepts_macos_metal_source_build_with_clean_import_probe(
     plan = LlamaCppInstallPlan(
         platform="darwin",
         backend="metal",
-        package_spec="llama-cpp-python==0.3.16",
+        package_spec="llama-cpp-python==0.3.32",
         cmake_args="-DGGML_METAL=on -DGGML_NATIVE=off",
         force_cmake=True,
     )
@@ -304,7 +304,7 @@ def test_backend_probe_rejects_macos_metal_source_build_when_probe_errors():
     plan = LlamaCppInstallPlan(
         platform="darwin",
         backend="metal",
-        package_spec="llama-cpp-python==0.3.16",
+        package_spec="llama-cpp-python==0.3.32",
         cmake_args="-DGGML_METAL=on -DGGML_NATIVE=off",
         force_cmake=True,
     )

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -102,6 +102,13 @@ def test_requirement_spec_accepts_underscore_package_name(tmp_path):
     assert llama_cpp_requirement_spec(requirements) == "llama-cpp-python==0.2.90"
 
 
+def test_server_llama_cpp_pin_matches_root_requirements():
+    root_spec = llama_cpp_requirement_spec(ROOT / "requirements.txt")
+    server_spec = llama_cpp_requirement_spec(ROOT / "config" / "requirements_server.txt")
+
+    assert server_spec == root_spec
+
+
 def test_requirement_spec_raises_when_pin_missing(tmp_path):
     requirements = tmp_path / "requirements.txt"
     requirements.write_text("numpy==2.0.0\n", encoding="utf-8")

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -170,7 +170,7 @@ def test_macos_missing_metal_runtime_bootstrap_attempts_metal_plan(monkeypatch):
     plan = desktop_runtime_setup.LlamaCppInstallPlan(
         platform='darwin',
         backend='metal',
-        package_spec='llama-cpp-python==0.3.16',
+        package_spec='llama-cpp-python==0.3.32',
         cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off',
         force_cmake=True,
         index_url='https://pypi.org/simple',
@@ -210,12 +210,12 @@ def test_macos_metal_source_install_clean_cpu_probe_reexecs_auto(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
     plans = [
         desktop_runtime_setup.LlamaCppInstallPlan(
-            platform='darwin', backend='metal', package_spec='llama-cpp-python==0.3.16',
+            platform='darwin', backend='metal', package_spec='llama-cpp-python==0.3.32',
             cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off', force_cmake=True,
             index_url='https://pypi.org/simple', only_binary=False, no_binary=True,
         ),
         desktop_runtime_setup.LlamaCppInstallPlan(
-            platform='darwin', backend='cpu', package_spec='llama-cpp-python==0.3.16',
+            platform='darwin', backend='cpu', package_spec='llama-cpp-python==0.3.32',
             cmake_args=None, force_cmake=False, index_url='https://pypi.org/simple',
             only_binary=True, no_binary=False,
         ),
@@ -253,12 +253,12 @@ def test_macos_metal_source_install_clean_cpu_probe_fails_explicit_gpu_before_re
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
     plans = [
         desktop_runtime_setup.LlamaCppInstallPlan(
-            platform='darwin', backend='metal', package_spec='llama-cpp-python==0.3.16',
+            platform='darwin', backend='metal', package_spec='llama-cpp-python==0.3.32',
             cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off', force_cmake=True,
             index_url='https://pypi.org/simple', only_binary=False, no_binary=True,
         ),
         desktop_runtime_setup.LlamaCppInstallPlan(
-            platform='darwin', backend='cpu', package_spec='llama-cpp-python==0.3.16',
+            platform='darwin', backend='cpu', package_spec='llama-cpp-python==0.3.32',
             cmake_args=None, force_cmake=False, index_url='https://pypi.org/simple',
             only_binary=True, no_binary=False,
         ),
@@ -294,7 +294,7 @@ def test_macos_metal_install_unsatisfied_cpu_probe_falls_back_to_cpu_in_auto(mon
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
     plans = [
         desktop_runtime_setup.LlamaCppInstallPlan(
-            platform='darwin', backend='metal', package_spec='llama-cpp-python==0.3.16',
+            platform='darwin', backend='metal', package_spec='llama-cpp-python==0.3.32',
             cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off', force_cmake=True,
             index_url='https://pypi.org/simple', only_binary=False, no_binary=True,
         ),
@@ -329,7 +329,7 @@ def test_macos_cpu_fallback_fails_when_follow_up_probe_is_not_importable(monkeyp
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
     plans = [
         desktop_runtime_setup.LlamaCppInstallPlan(
-            platform='darwin', backend='metal', package_spec='llama-cpp-python==0.3.16',
+            platform='darwin', backend='metal', package_spec='llama-cpp-python==0.3.32',
             cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off', force_cmake=True,
             index_url='https://pypi.org/simple', only_binary=False, no_binary=True,
         ),
@@ -368,7 +368,7 @@ def test_macos_runtime_install_uses_writable_dependency_target(monkeypatch, tmp_
     ])
     monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
     plan = desktop_runtime_setup.LlamaCppInstallPlan(
-        platform='darwin', backend='metal', package_spec='llama-cpp-python==0.3.16',
+        platform='darwin', backend='metal', package_spec='llama-cpp-python==0.3.32',
         cmake_args='-DGGML_METAL=on -DGGML_NATIVE=off', force_cmake=True,
         index_url='https://pypi.org/simple', only_binary=False, no_binary=True,
     )
@@ -969,7 +969,7 @@ def test_fallback_unpinned_plans_cover_win_darwin_and_other_platforms():
 def test_windows_source_repair_uses_dependency_target(monkeypatch, tmp_path):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
     requirements_path = tmp_path / 'requirements.txt'
-    requirements_path.write_text('llama_cpp_python==0.3.16\n', encoding='utf-8')
+    requirements_path.write_text('llama_cpp_python==0.3.32\n', encoding='utf-8')
     dependency_target = tmp_path / 'desktop deps'
     captured = {}
 
@@ -994,7 +994,7 @@ def test_windows_source_repair_uses_dependency_target(monkeypatch, tmp_path):
 def test_windows_source_repair_uses_active_interpreter(monkeypatch, tmp_path):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
     requirements_path = tmp_path / 'requirements.txt'
-    requirements_path.write_text('llama_cpp_python==0.3.16\n', encoding='utf-8')
+    requirements_path.write_text('llama_cpp_python==0.3.32\n', encoding='utf-8')
     captured = {}
 
     def fake_run(cmd, env, timeout_seconds):
@@ -1422,7 +1422,7 @@ def test_resolve_requirements_path_prefers_packaged_resources_when_repo_root_mis
     target_root = tmp_path / 'token-place-installed'
     packaged_requirements = target_root / 'resources' / 'requirements.txt'
     packaged_requirements.parent.mkdir(parents=True)
-    packaged_requirements.write_text('llama-cpp-python==0.3.16\n', encoding='utf-8')
+    packaged_requirements.write_text('llama-cpp-python==0.3.32\n', encoding='utf-8')
 
     resolved = desktop_runtime_setup._resolve_requirements_path(target_root)
 
@@ -1448,7 +1448,7 @@ def test_windows_runtime_bootstrap_passes_resolved_packaged_requirements_before_
     packaged_root = tmp_path / 'AppData' / 'Local' / 'token.place'
     packaged_requirements = packaged_root / 'resources' / 'requirements.txt'
     packaged_requirements.parent.mkdir(parents=True)
-    packaged_requirements.write_text('llama-cpp-python==0.3.16\n', encoding='utf-8')
+    packaged_requirements.write_text('llama-cpp-python==0.3.32\n', encoding='utf-8')
 
     result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=packaged_root)
 
@@ -1466,7 +1466,7 @@ def test_windows_wheel_install_path_force_reinstalls_existing_same_version(monke
         desktop_runtime_setup.LlamaCppInstallPlan(
             platform='win32',
             backend='cuda',
-            package_spec='llama-cpp-python==0.3.16',
+            package_spec='llama-cpp-python==0.3.32',
             cmake_args='-DGGML_CUDA=on',
             force_cmake=True,
             index_url='https://pypi.org/simple',

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4555,6 +4555,8 @@ def test_qwen_8k_runtime_omits_llama_chat_format_and_yarn(tmp_path):
     assert manager.last_compute_diagnostics['chat_template_mode'] == 'gguf-jinja'
     assert manager.last_compute_diagnostics['thinking_mode_disabled'] is True
     assert manager.last_compute_diagnostics['rope_yarn_enabled'] is False
+    assert manager.last_yarn_rope_diagnostics['active'] is False
+    assert manager.last_yarn_rope_diagnostics['required'] is False
 
 
 def test_qwen_64k_runtime_enables_yarn_kwargs(tmp_path):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4679,6 +4679,10 @@ def test_qwen_64k_runtime_fails_when_yarn_kwargs_unsupported(tmp_path):
         assert manager.get_llm_instance() is None
 
     assert 'Qwen 64K requires YaRN/RoPE support in llama-cpp-python' in manager.last_runtime_init_error
+    assert 'active_profile_id=qwen3-8b-q4-k-m' in manager.last_runtime_init_error
+    assert 'active_context_tier=64k-full' in manager.last_runtime_init_error
+    assert 'llama_module_path=unknown' in manager.last_runtime_init_error
+    assert 'llama_cpp_python_version=unknown' in manager.last_runtime_init_error
     assert 'missing constructor kwargs' in manager.last_runtime_init_error
 
 
@@ -4756,8 +4760,16 @@ def test_runtime_signature_helpers_cover_constructor_variants():
         def __init__(self, model_path, **kwargs):
             pass
 
+    class InitKwargsCallRestrictedLlama:
+        def __init__(self, model_path, **kwargs):
+            pass
+
+        def __call__(self, model_path):
+            return None
+
     assert manager._llama_constructor_accepts(ExplicitLlama, 'rope_scaling_type') is True
     assert manager._llama_constructor_accepts(KwargsLlama, 'yarn_ext_factor') is True
+    assert manager._llama_constructor_accepts(InitKwargsCallRestrictedLlama, 'future_yarn_kwarg') is True
     assert manager._llama_constructor_accepts(ExplicitLlama, 'yarn_ext_factor') is False
     assert manager._llama_constructor_accepts(42, 'rope_scaling_type') is False
 

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4576,8 +4576,6 @@ def test_qwen_64k_runtime_enables_yarn_kwargs(tmp_path):
     Path(manager.model_path).write_text('fake')
 
     class FakeLlama:
-        LLAMA_ROPE_SCALING_TYPE_YARN = 2
-
         def __init__(self, model_path, n_gpu_layers, n_ctx, verbose, rope_scaling_type, yarn_ext_factor, yarn_orig_ctx):
             captured.update({
                 'model_path': model_path,
@@ -4591,7 +4589,13 @@ def test_qwen_64k_runtime_enables_yarn_kwargs(tmp_path):
         def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
             return '<qwen>'
 
-    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=FakeLlama)), \
+    fake_llama_cpp = SimpleNamespace(
+        Llama=FakeLlama,
+        LLAMA_ROPE_SCALING_TYPE_YARN=2,
+        __file__='/opt/token.place/llama_cpp/__init__.py',
+        __version__='0.3.32',
+    )
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama_cpp), \
          patch.object(manager, '_runtime_capabilities', return_value={'backend': 'cpu', 'gpu_offload_supported': False, 'error': None}):
         assert manager.get_llm_instance() is not None
 
@@ -4601,6 +4605,50 @@ def test_qwen_64k_runtime_enables_yarn_kwargs(tmp_path):
     assert captured['yarn_orig_ctx'] == 32768
     assert manager.last_compute_diagnostics['rope_yarn_enabled'] is True
     assert manager.last_compute_diagnostics['rope_yarn_factor'] == 2.0
+    assert manager.last_compute_diagnostics['yarn_rope_enum_location'] == (
+        'llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN'
+    )
+
+
+def test_qwen_64k_runtime_resolves_nested_yarn_enum(tmp_path):
+    from utils.context_profiles import apply_context_profile
+    captured = {}
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': 0,
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    class FakeLlama:
+        def __init__(self, model_path, n_gpu_layers, n_ctx, verbose, rope_scaling_type, yarn_ext_factor, yarn_orig_ctx):
+            captured['rope_scaling_type'] = rope_scaling_type
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+            return '<qwen>'
+
+    fake_llama_cpp = SimpleNamespace(
+        Llama=FakeLlama,
+        llama_cpp=SimpleNamespace(LLAMA_ROPE_SCALING_TYPE_YARN=2),
+        __file__='/opt/token.place/llama_cpp/__init__.py',
+        __version__='0.3.32',
+    )
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama_cpp), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'cpu', 'gpu_offload_supported': False, 'error': None}):
+        assert manager.get_llm_instance() is not None
+
+    assert captured['rope_scaling_type'] == 2
+    assert manager.last_compute_diagnostics['yarn_rope_enum_location'] == (
+        'llama_cpp.llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN'
+    )
 
 
 def test_qwen_64k_runtime_fails_when_yarn_kwargs_unsupported(tmp_path):
@@ -4628,7 +4676,8 @@ def test_qwen_64k_runtime_fails_when_yarn_kwargs_unsupported(tmp_path):
          patch.object(manager, '_runtime_capabilities', return_value={'backend': 'cpu', 'gpu_offload_supported': False, 'error': None}):
         assert manager.get_llm_instance() is None
 
-    assert 'Qwen 64K YaRN/RoPE is unsupported' in manager.last_runtime_init_error
+    assert 'Qwen 64K requires YaRN/RoPE support in llama-cpp-python' in manager.last_runtime_init_error
+    assert 'missing constructor kwargs' in manager.last_runtime_init_error
 
 
 def test_qwen_64k_runtime_fails_when_yarn_enum_constant_missing(tmp_path):
@@ -4658,6 +4707,7 @@ def test_qwen_64k_runtime_fails_when_yarn_enum_constant_missing(tmp_path):
          patch.object(manager, '_runtime_capabilities', return_value={'backend': 'cpu', 'gpu_offload_supported': False, 'error': None}):
         assert manager.get_llm_instance() is None
 
+    assert 'Qwen 64K requires YaRN/RoPE support in llama-cpp-python' in manager.last_runtime_init_error
     assert 'missing LLAMA_ROPE_SCALING_TYPE_YARN enum constant' in manager.last_runtime_init_error
 
 

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -407,6 +407,10 @@ class ComputeNodeRuntime:
             model_profile
         )
 
+        yarn_diagnostics = getattr(self.model_manager, "last_yarn_rope_diagnostics", None)
+        if not isinstance(yarn_diagnostics, dict):
+            yarn_diagnostics = {}
+
         diagnostics.update({
             "api_v1_readiness_model_id": getattr(self.model_manager, "api_model_id", None),
             "api_v1_readiness_model_profile_provider": model_profile.get("provider"),
@@ -427,12 +431,39 @@ class ComputeNodeRuntime:
             ),
             "api_v1_readiness_tokenizer_render_bridge_available": False,
             "api_v1_readiness_non_thinking_enforced": qwen_non_thinking_enforced,
-            "api_v1_readiness_yarn_rope_enabled": bool(rope_policy.get("type") == "yarn"),
+            "api_v1_readiness_yarn_rope_enabled": bool(
+                rope_policy.get("type") == "yarn" and yarn_diagnostics.get("supported") is True
+            ),
+            "api_v1_readiness_yarn_rope_supported": yarn_diagnostics.get("supported"),
+            "api_v1_readiness_yarn_rope_missing_reason": yarn_diagnostics.get("missing_reason"),
             "api_v1_readiness_yarn_rope_factor": rope_policy.get("factor"),
             "api_v1_readiness_yarn_original_context_tokens": rope_policy.get(
                 "original_context_tokens"
             ),
         })
+
+        yarn_required_for_active_tier = (
+            model_profile.get("provider") == "qwen"
+            and rope_policy.get("type") == "yarn"
+            and context_tier == rope_policy.get("required_for_tier", "64k-full")
+        )
+        if yarn_required_for_active_tier and yarn_diagnostics.get("supported") is not True:
+            diagnostics.update({
+                "api_v1_runtime_ready": False,
+                "api_v1_readiness_result": "failed",
+                "api_v1_readiness_error_code": "compute_node_yarn_rope_unsupported",
+                "api_v1_readiness_error_reason": (
+                    yarn_diagnostics.get("missing_reason") or "missing_yarn_rope_runtime_support"
+                ),
+            })
+            self.model_manager.last_compute_diagnostics = diagnostics
+            setattr(
+                self.model_manager,
+                'last_runtime_init_error',
+                "API v1 runtime readiness failed: Qwen 64K YaRN/RoPE support missing",
+            )
+            _log_error("API v1 runtime readiness failed: Qwen 64K YaRN/RoPE support missing")
+            return False
 
         try:
             smoke_messages = [{"role": "system", "content": "ok"}, {"role": "user", "content": "hi"}]

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -29,7 +29,7 @@ REPO_LLAMA_CPP_SHIM = (REPO_ROOT / 'llama_cpp.py').resolve()
 DEFAULT_LLAMA_CPP_RUNTIME_STAGE_TIMEOUT_SECONDS = 30.0
 QWEN_64K_YARN_UNSUPPORTED_MESSAGE = (
     'Qwen 64K requires YaRN/RoPE support in llama-cpp-python; '
-    'update or rebuild the desktop runtime'
+    'update or rebuild the runtime'
 )
 
 CRITICAL_STDLIB_IMPORT_MODULES = (
@@ -61,8 +61,8 @@ def _constructor_accepts_kwarg(callable_obj: Any, kwarg: str) -> bool:
 def _resolve_llama_cpp_rope_scaling_type_yarn(llama_cpp_module: Any, llama_cls: Any = None) -> tuple[Any, Optional[str]]:
     """Resolve llama-cpp-python's YaRN enum from known safe exports.
 
-    Runtime inspection for the packaged path checks ``inspect.signature(Llama.__init__)``
-    and both top-level and nested ``llama_cpp.llama_cpp`` constants.  Older
+    Runtime inspection checks the supplied Llama callable signature and both
+    top-level and nested ``llama_cpp.llama_cpp`` constants.  Older
     llama-cpp-python builds may not re-export the enum at the top level, while
     newer generated bindings can expose it from the nested ctypes module.
     """
@@ -2277,6 +2277,8 @@ class ModelManager:
         else:
             self.last_yarn_rope_diagnostics = {
                 'supported': False,
+                'active': False,
+                'required': False,
                 'active_context_tier': context_tier,
                 'requested_n_ctx': n_ctx,
                 'missing_reason': 'not_required_for_active_profile_or_tier',

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -27,6 +27,10 @@ logger = logging.getLogger('model_manager')
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REPO_LLAMA_CPP_SHIM = (REPO_ROOT / 'llama_cpp.py').resolve()
 DEFAULT_LLAMA_CPP_RUNTIME_STAGE_TIMEOUT_SECONDS = 30.0
+QWEN_64K_YARN_UNSUPPORTED_MESSAGE = (
+    'Qwen 64K requires YaRN/RoPE support in llama-cpp-python; '
+    'update or rebuild the desktop runtime'
+)
 
 CRITICAL_STDLIB_IMPORT_MODULES = (
     'collections',
@@ -37,6 +41,78 @@ CRITICAL_STDLIB_IMPORT_MODULES = (
     'importlib',
     'pathlib',
 )
+
+
+def _safe_signature_parameters(callable_obj: Any) -> Dict[str, inspect.Parameter]:
+    try:
+        return dict(inspect.signature(callable_obj).parameters)
+    except (TypeError, ValueError):
+        return {}
+
+
+def _constructor_accepts_kwarg(callable_obj: Any, kwarg: str) -> bool:
+    parameters = _safe_signature_parameters(callable_obj)
+    return kwarg in parameters or any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    )
+
+
+def _resolve_llama_cpp_rope_scaling_type_yarn(llama_cpp_module: Any, llama_cls: Any = None) -> tuple[Any, Optional[str]]:
+    """Resolve llama-cpp-python's YaRN enum from known safe exports.
+
+    Runtime inspection for the packaged path checks ``inspect.signature(Llama.__init__)``
+    and both top-level and nested ``llama_cpp.llama_cpp`` constants.  Older
+    llama-cpp-python builds may not re-export the enum at the top level, while
+    newer generated bindings can expose it from the nested ctypes module.
+    """
+
+    locations = (
+        (llama_cpp_module, 'llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN'),
+        (getattr(llama_cpp_module, 'llama_cpp', None), 'llama_cpp.llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN'),
+        (llama_cls, 'Llama.LLAMA_ROPE_SCALING_TYPE_YARN'),
+    )
+    for owner, location in locations:
+        if owner is None:
+            continue
+        value = getattr(owner, 'LLAMA_ROPE_SCALING_TYPE_YARN', None)
+        if value is not None:
+            return value, location
+    return None, None
+
+
+def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> Dict[str, Any]:
+    accepted_kwargs = sorted(
+        name for name in (
+            'rope_scaling_type',
+            'yarn_ext_factor',
+            'yarn_attn_factor',
+            'yarn_beta_fast',
+            'yarn_beta_slow',
+            'yarn_orig_ctx',
+            'rope_freq_base',
+            'rope_freq_scale',
+        )
+        if _constructor_accepts_kwarg(llama_cls, name)
+    )
+    yarn_value, yarn_location = _resolve_llama_cpp_rope_scaling_type_yarn(llama_cpp_module, llama_cls)
+    required_kwargs = ('rope_scaling_type', 'yarn_ext_factor', 'yarn_orig_ctx')
+    missing_kwargs = [name for name in required_kwargs if name not in accepted_kwargs]
+    missing_reasons = []
+    if yarn_location is None:
+        missing_reasons.append('missing LLAMA_ROPE_SCALING_TYPE_YARN enum constant')
+    if missing_kwargs:
+        missing_reasons.append(f'missing constructor kwargs: {", ".join(missing_kwargs)}')
+    return {
+        'supported': not missing_reasons,
+        'yarn_enum_value': yarn_value,
+        'yarn_enum_location': yarn_location,
+        'accepted_constructor_kwargs': accepted_kwargs,
+        'missing_required_kwargs': missing_kwargs,
+        'missing_reason': '; '.join(missing_reasons) if missing_reasons else None,
+        'llama_module_path': getattr(llama_cpp_module, '__file__', None),
+        'llama_cpp_python_version': getattr(llama_cpp_module, '__version__', None),
+    }
 
 
 def _is_site_packages_path(path_text: Any) -> bool:
@@ -2106,15 +2182,7 @@ class ModelManager:
     def _llama_constructor_accepts(self, llama_cls: Any, kwarg: str) -> bool:
         """Return whether the imported llama-cpp-python Llama constructor accepts a kwarg."""
 
-        try:
-            signature = inspect.signature(llama_cls)
-        except (TypeError, ValueError):
-            return False
-        parameters = signature.parameters
-        return kwarg in parameters or any(
-            parameter.kind == inspect.Parameter.VAR_KEYWORD
-            for parameter in parameters.values()
-        )
+        return _constructor_accepts_kwarg(llama_cls, kwarg)
 
     def _apply_chat_template_accepts(self, llm: Any, kwarg: str) -> bool:
         """Return whether runtime chat-template rendering accepts a kwarg."""
@@ -2148,7 +2216,7 @@ class ModelManager:
     def _qwen_non_thinking_required(self) -> bool:
         return self.model_profile.get('provider') == 'qwen' and self.model_profile.get('thinking_mode') == 'disabled'
 
-    def _runtime_init_kwargs(self, llama_cls: Any, n_gpu_layers: int) -> Dict[str, Any]:
+    def _runtime_init_kwargs(self, llama_cls: Any, n_gpu_layers: int, llama_cpp_module: Any = None) -> Dict[str, Any]:
         """Build verified llama-cpp-python runtime kwargs for the selected profile.
 
         llama-cpp-python uses the GGUF/Jinja chat template when ``chat_format`` is
@@ -2183,34 +2251,36 @@ class ModelManager:
             and n_ctx > native_context
         )
         if needs_yarn:
-            required_kwargs = ('rope_scaling_type', 'yarn_ext_factor', 'yarn_orig_ctx')
-            unsupported = [
-                name for name in required_kwargs
-                if not self._llama_constructor_accepts(llama_cls, name)
-            ]
-            if unsupported:
+            llama_module = llama_cpp_module or inspect.getmodule(llama_cls)
+            yarn_probe = _runtime_supports_qwen_yarn_rope(llama_module, llama_cls)
+            self.last_yarn_rope_diagnostics = {
+                'supported': yarn_probe['supported'],
+                'yarn_enum_location': yarn_probe['yarn_enum_location'],
+                'accepted_constructor_kwargs': yarn_probe['accepted_constructor_kwargs'],
+                'active_context_tier': context_tier,
+                'requested_n_ctx': n_ctx,
+                'llama_module_path': yarn_probe['llama_module_path'],
+                'llama_cpp_python_version': yarn_probe['llama_cpp_python_version'],
+                'missing_reason': yarn_probe['missing_reason'],
+            }
+            if not yarn_probe['supported']:
                 raise RuntimeError(
-                    'Qwen 64K YaRN/RoPE is unsupported by this llama-cpp-python '
-                    f'runtime; missing constructor kwargs: {", ".join(unsupported)}'
-                )
-            llama_module = inspect.getmodule(llama_cls)
-            yarn_scaling_type = getattr(
-                llama_module,
-                'LLAMA_ROPE_SCALING_TYPE_YARN',
-                getattr(llama_cls, 'LLAMA_ROPE_SCALING_TYPE_YARN', None),
-            )
-            if yarn_scaling_type is None:
-                raise RuntimeError(
-                    'Qwen 64K YaRN/RoPE is unsupported by this llama-cpp-python '
-                    'runtime; missing LLAMA_ROPE_SCALING_TYPE_YARN enum constant'
+                    f'{QWEN_64K_YARN_UNSUPPORTED_MESSAGE}; {yarn_probe["missing_reason"]}'
                 )
             kwargs.update(
                 {
-                    'rope_scaling_type': yarn_scaling_type,
+                    'rope_scaling_type': yarn_probe['yarn_enum_value'],
                     'yarn_ext_factor': float(rope_policy.get('factor', 2.0)),
                     'yarn_orig_ctx': int(rope_policy.get('original_context_tokens', native_context)),
                 }
             )
+        else:
+            self.last_yarn_rope_diagnostics = {
+                'supported': False,
+                'active_context_tier': context_tier,
+                'requested_n_ctx': n_ctx,
+                'missing_reason': 'not_required_for_active_profile_or_tier',
+            }
         return kwargs
 
     def get_model_artifact_metadata(self) -> Dict[str, Any]:
@@ -2494,7 +2564,7 @@ class ModelManager:
 
                             self.log_info(f"About to instantiate Llama model from {self.model_path}...")
                             self.log_info(f"Llama init started for {self.model_path}.")
-                            runtime_kwargs = self._runtime_init_kwargs(Llama, n_gpu_layers)
+                            runtime_kwargs = self._runtime_init_kwargs(Llama, n_gpu_layers, llama_cpp)
                             llm_instance = Llama(**runtime_kwargs)
                             if self.model_profile.get('provider') == 'qwen':
                                 llm_type_module = type(llm_instance).__module__
@@ -2539,6 +2609,11 @@ class ModelManager:
                                 'rope_yarn_factor': runtime_kwargs.get('yarn_ext_factor'),
                                 'yarn_original_context': runtime_kwargs.get('yarn_orig_ctx') or rope_policy.get('original_context_tokens'),
                             })
+                            yarn_diagnostics = getattr(self, 'last_yarn_rope_diagnostics', None)
+                            if isinstance(yarn_diagnostics, dict):
+                                compute_plan['yarn_rope_diagnostics'] = dict(yarn_diagnostics)
+                                compute_plan['yarn_rope_enum_location'] = yarn_diagnostics.get('yarn_enum_location')
+                                compute_plan['yarn_rope_accepted_constructor_kwargs'] = yarn_diagnostics.get('accepted_constructor_kwargs')
                             self.last_compute_diagnostics = compute_plan
                             if compute_plan['requested_mode'] == 'cpu':
                                 runtime_identity = {

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -51,7 +51,10 @@ def _safe_signature_parameters(callable_obj: Any) -> Dict[str, inspect.Parameter
 
 
 def _constructor_accepts_kwarg(callable_obj: Any, kwarg: str) -> bool:
-    parameters = _safe_signature_parameters(callable_obj)
+    if not callable(callable_obj):
+        return False
+    constructor = getattr(callable_obj, '__init__', callable_obj)
+    parameters = _safe_signature_parameters(constructor)
     return kwarg in parameters or any(
         parameter.kind == inspect.Parameter.VAR_KEYWORD
         for parameter in parameters.values()
@@ -61,7 +64,7 @@ def _constructor_accepts_kwarg(callable_obj: Any, kwarg: str) -> bool:
 def _resolve_llama_cpp_rope_scaling_type_yarn(llama_cpp_module: Any, llama_cls: Any = None) -> tuple[Any, Optional[str]]:
     """Resolve llama-cpp-python's YaRN enum from known safe exports.
 
-    Runtime inspection checks the supplied Llama callable signature and both
+    Runtime inspection checks the supplied ``Llama.__init__`` signature and both
     top-level and nested ``llama_cpp.llama_cpp`` constants.  Older
     llama-cpp-python builds may not re-export the enum at the top level, while
     newer generated bindings can expose it from the nested ctypes module.
@@ -79,6 +82,20 @@ def _resolve_llama_cpp_rope_scaling_type_yarn(llama_cpp_module: Any, llama_cls: 
         if value is not None:
             return value, location
     return None, None
+
+
+def _format_qwen_yarn_unsupported_diagnostics(diagnostics: Dict[str, Any]) -> str:
+    safe_fields = (
+        'active_profile_id',
+        'active_context_tier',
+        'llama_module_path',
+        'llama_cpp_python_version',
+        'missing_reason',
+    )
+    return ', '.join(
+        f'{field}={diagnostics.get(field) or "unknown"}'
+        for field in safe_fields
+    )
 
 
 def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> Dict[str, Any]:
@@ -2257,6 +2274,7 @@ class ModelManager:
                 'supported': yarn_probe['supported'],
                 'yarn_enum_location': yarn_probe['yarn_enum_location'],
                 'accepted_constructor_kwargs': yarn_probe['accepted_constructor_kwargs'],
+                'active_profile_id': self.profile_id,
                 'active_context_tier': context_tier,
                 'requested_n_ctx': n_ctx,
                 'llama_module_path': yarn_probe['llama_module_path'],
@@ -2264,8 +2282,11 @@ class ModelManager:
                 'missing_reason': yarn_probe['missing_reason'],
             }
             if not yarn_probe['supported']:
+                safe_diagnostics = _format_qwen_yarn_unsupported_diagnostics(
+                    self.last_yarn_rope_diagnostics
+                )
                 raise RuntimeError(
-                    f'{QWEN_64K_YARN_UNSUPPORTED_MESSAGE}; {yarn_probe["missing_reason"]}'
+                    f'{QWEN_64K_YARN_UNSUPPORTED_MESSAGE}; {safe_diagnostics}'
                 )
             kwargs.update(
                 {
@@ -2279,6 +2300,7 @@ class ModelManager:
                 'supported': False,
                 'active': False,
                 'required': False,
+                'active_profile_id': self.profile_id,
                 'active_context_tier': context_tier,
                 'requested_n_ctx': n_ctx,
                 'missing_reason': 'not_required_for_active_profile_or_tier',


### PR DESCRIPTION
### Motivation
- Qwen3 64K Full model startup on packaged desktop runtimes failed because the llama-cpp-python runtime did not reliably expose the YaRN/RoPE enum or required constructor kwargs, causing nodes to fail before registration.  
- The runtime must robustly detect YaRN support (top-level, nested, or on the `Llama` class), apply exact YaRN kwargs for 64K, and fail closed with an actionable error if support is missing.  
- The packaged macOS wheel pin needed to be updated to a minimal runtime release that exposes the required symbols to enable Qwen 64K Full on desktop builds.

### Description
- Added robust runtime inspection helpers: `_safe_signature_parameters`, `_constructor_accepts_kwarg`, `_resolve_llama_cpp_rope_scaling_type_yarn`, and `_runtime_supports_qwen_yarn_rope` to detect the Yarn enum and accepted YaRN kwargs from `llama_cpp` and the `Llama` class.  
- Reworked YaRN gating in `ModelManager._runtime_init_kwargs` to probe the runtime (using the installed `llama_cpp` module), populate `last_yarn_rope_diagnostics`, apply `rope_scaling_type`, `yarn_ext_factor`, and `yarn_orig_ctx` only when fully supported, and otherwise raise a clear fail‑closed error using a new `QWEN_64K_YARN_UNSUPPORTED_MESSAGE`.  
- Propagated safe YaRN diagnostics into compute-plan metadata so readiness logs/reporting include `yarn_rope_enum_location`, accepted constructor kwargs, requested `n_ctx`, and runtime module/version info.  
- Bumped the packaged `llama-cpp-python` pin in `requirements.txt` from `0.3.16` to `0.3.32` and updated desktop packaging/install-plan tests to assert the new pin and install-plan expectations.  
- Added/updated unit tests to cover: top-level Yarn enum resolution, nested `llama_cpp.llama_cpp` enum resolution, constructor-kwarg acceptance probing, failing-fast when YaRN support is missing, correct Qwen 64K and Qwen 8K runtime kwargs, and desktop packaging install-plan parsing.

### Testing
- Ran targeted unit and integration test suites: `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, `python -m pytest tests/unit/test_compute_node_runtime.py -q`, `python -m pytest tests/unit/test_desktop_gpu_packaging.py -q`, `python -m pytest tests/unit/test_desktop_runtime_setup.py -q`, and `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, and all executed tests passed.  
- Ran repository checks `pre-commit run --all-files` and `git diff --check` and they passed with no blocking issues.  
- Tests added or updated include assertions that Qwen 64K sets `n_ctx=65536`, Yarn scaling is enabled with factor `2.0` and `yarn_orig_ctx=32768`, and that missing enum/kwargs produce the actionable desktop error described in the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45e937eb78832fb709675e5baa10ce)