### PR TITLE
Fix Qwen 64K YaRN/RoPE runtime support detection

### DIFF
--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -95,6 +95,13 @@ def test_requirement_spec_parses_comments_and_blank_lines(tmp_path):
     assert llama_cpp_requirement_spec(requirements) == "llama-cpp-python==0.3.16"
 
 
+def test_repo_llama_cpp_pin_is_yarn_capable():
+    spec = llama_cpp_requirement_spec(ROOT / "requirements.txt")
+    version = tuple(int(part) for part in spec.split("==", 1)[1].split("."))
+
+    assert version >= (0, 3, 16)
+
+
 def test_requirement_spec_accepts_underscore_package_name(tmp_path):
     requirements = tmp_path / "requirements.txt"
     requirements.write_text("llama_cpp_python==0.2.90\n", encoding="utf-8")

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -20,7 +20,7 @@ from types import SimpleNamespace
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 # Import the module to test
-from utils.llm.model_manager import ModelManager
+from utils.llm.model_manager import ModelManager, _runtime_supports_qwen_yarn_rope
 
 
 class _ToDictOnly:
@@ -532,7 +532,7 @@ class TestModelManager:
             'model.chat_format': 'llama-3',
         }.get(key, self._mock_config_get(key, default))
 
-        with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=mock_llama)), \
+        with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=mock_llama, LLAMA_ROPE_SCALING_TYPE_YARN=2)), \
              patch('utils.llm.model_manager.resource_monitor.can_allocate_gpu_memory', return_value=True), \
              patch('utils.llm.model_manager.os.path.exists', return_value=True), \
              patch.object(model_manager, '_runtime_capabilities', return_value={
@@ -4601,6 +4601,47 @@ def test_qwen_64k_runtime_enables_yarn_kwargs(tmp_path):
     assert captured['yarn_orig_ctx'] == 32768
     assert manager.last_compute_diagnostics['rope_yarn_enabled'] is True
     assert manager.last_compute_diagnostics['rope_yarn_factor'] == 2.0
+    assert manager.last_compute_diagnostics['yarn_rope_enum_source'] == 'Llama.LLAMA_ROPE_SCALING_TYPE_YARN'
+
+
+def test_qwen_64k_runtime_resolves_nested_yarn_enum(tmp_path):
+    from utils.context_profiles import apply_context_profile
+    captured = {}
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': 0,
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    class FakeLlama:
+        def __init__(self, model_path, n_gpu_layers, n_ctx, verbose, rope_scaling_type, yarn_ext_factor, yarn_orig_ctx):
+            captured.update({'n_ctx': n_ctx, 'rope_scaling_type': rope_scaling_type})
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+            return '<qwen>'
+
+    fake_module = SimpleNamespace(
+        __file__='/site-packages/llama_cpp/__init__.py',
+        __version__='0.3.16',
+        llama_cpp=SimpleNamespace(LLAMA_ROPE_SCALING_TYPE_YARN=2),
+        Llama=FakeLlama,
+    )
+
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_module), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'cpu', 'gpu_offload_supported': False, 'error': None}):
+        assert manager.get_llm_instance() is not None
+
+    assert captured == {'n_ctx': 65536, 'rope_scaling_type': 2}
+    assert manager.last_compute_diagnostics['yarn_rope_enum_source'] == 'llama_cpp.llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN'
 
 
 def test_qwen_64k_runtime_fails_when_yarn_kwargs_unsupported(tmp_path):
@@ -4628,7 +4669,7 @@ def test_qwen_64k_runtime_fails_when_yarn_kwargs_unsupported(tmp_path):
          patch.object(manager, '_runtime_capabilities', return_value={'backend': 'cpu', 'gpu_offload_supported': False, 'error': None}):
         assert manager.get_llm_instance() is None
 
-    assert 'Qwen 64K YaRN/RoPE is unsupported' in manager.last_runtime_init_error
+    assert 'Qwen 64K requires YaRN/RoPE support in llama-cpp-python' in manager.last_runtime_init_error
 
 
 def test_qwen_64k_runtime_fails_when_yarn_enum_constant_missing(tmp_path):
@@ -4708,6 +4749,27 @@ def test_runtime_signature_helpers_cover_constructor_variants():
     assert manager._llama_constructor_accepts(KwargsLlama, 'yarn_ext_factor') is True
     assert manager._llama_constructor_accepts(ExplicitLlama, 'yarn_ext_factor') is False
     assert manager._llama_constructor_accepts(42, 'rope_scaling_type') is False
+
+
+def test_qwen_yarn_runtime_probe_reports_constructor_kwargs_and_enum():
+    class FakeLlama:
+        def __init__(self, model_path, rope_scaling_type, yarn_ext_factor, yarn_orig_ctx):
+            pass
+
+    probe = _runtime_supports_qwen_yarn_rope(
+        SimpleNamespace(
+            __file__='/runtime/llama_cpp/__init__.py',
+            __version__='0.3.16',
+            LLAMA_ROPE_SCALING_TYPE_YARN=2,
+        ),
+        FakeLlama,
+    )
+
+    assert probe['supported'] is True
+    assert probe['yarn_enum_source'] == 'llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN'
+    assert probe['yarn_enum_value'] == 2
+    assert 'rope_scaling_type' in probe['accepted_constructor_kwargs']
+    assert probe['llama_module_path'] == '/runtime/llama_cpp/__init__.py'
 
 
 def test_apply_chat_template_accepts_direct_runtime_and_tokenizer_paths():

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -432,6 +432,8 @@ class ComputeNodeRuntime:
             "api_v1_readiness_yarn_original_context_tokens": rope_policy.get(
                 "original_context_tokens"
             ),
+            "api_v1_readiness_yarn_rope_enum_source": diagnostics.get("yarn_rope_enum_source"),
+            "api_v1_readiness_yarn_rope_runtime_supported": diagnostics.get("yarn_rope_supported"),
         })
 
         try:

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -27,6 +27,22 @@ logger = logging.getLogger('model_manager')
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REPO_LLAMA_CPP_SHIM = (REPO_ROOT / 'llama_cpp.py').resolve()
 DEFAULT_LLAMA_CPP_RUNTIME_STAGE_TIMEOUT_SECONDS = 30.0
+QWEN_64K_YARN_UNSUPPORTED_ERROR = (
+    'Qwen 64K requires YaRN/RoPE support in llama-cpp-python; '
+    'update or rebuild the desktop runtime'
+)
+QWEN_YARN_REQUIRED_KWARGS = (
+    'rope_scaling_type',
+    'yarn_ext_factor',
+    'yarn_orig_ctx',
+)
+QWEN_YARN_OPTIONAL_KWARGS = (
+    'yarn_attn_factor',
+    'yarn_beta_fast',
+    'yarn_beta_slow',
+    'rope_freq_base',
+    'rope_freq_scale',
+)
 
 CRITICAL_STDLIB_IMPORT_MODULES = (
     'collections',
@@ -37,6 +53,82 @@ CRITICAL_STDLIB_IMPORT_MODULES = (
     'importlib',
     'pathlib',
 )
+
+
+def _resolve_llama_cpp_rope_scaling_type_yarn(
+    llama_cpp_module: Any,
+    llama_cls: Any = None,
+) -> tuple[Any, Optional[str]]:
+    """Resolve the llama-cpp-python YaRN RoPE enum from verified safe locations.
+
+    Verified against llama-cpp-python 0.3.16 in this repo's Codex runtime:
+    ``Llama.__init__`` accepts ``rope_scaling_type``, ``yarn_ext_factor``,
+    ``yarn_attn_factor``, ``yarn_beta_fast``, ``yarn_beta_slow``,
+    ``yarn_orig_ctx``, ``rope_freq_base``, and ``rope_freq_scale``. The YaRN
+    enum is exposed both as ``llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN`` and
+    ``llama_cpp.llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN`` with integer value 2.
+    """
+
+    candidates = (
+        ('llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN', llama_cpp_module),
+        ('llama_cpp.llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN', getattr(llama_cpp_module, 'llama_cpp', None)),
+        ('Llama.LLAMA_ROPE_SCALING_TYPE_YARN', llama_cls),
+    )
+    for source, module in candidates:
+        if module is None:
+            continue
+        value = getattr(module, 'LLAMA_ROPE_SCALING_TYPE_YARN', None)
+        if value is not None:
+            return value, source
+
+    # Some bindings expose enum wrappers rather than the legacy constant. Keep
+    # this conservative: only accept named members whose name is exactly YARN.
+    for container_name in ('llama_rope_scaling_type', 'LlamaRopeScalingType'):
+        container = getattr(llama_cpp_module, container_name, None)
+        member = getattr(container, 'YARN', None) if container is not None else None
+        if member is not None:
+            return member, f'llama_cpp.{container_name}.YARN'
+    nested = getattr(llama_cpp_module, 'llama_cpp', None)
+    if nested is not None:
+        for container_name in ('llama_rope_scaling_type', 'LlamaRopeScalingType'):
+            container = getattr(nested, container_name, None)
+            member = getattr(container, 'YARN', None) if container is not None else None
+            if member is not None:
+                return member, f'llama_cpp.llama_cpp.{container_name}.YARN'
+
+    return None, None
+
+
+def _llama_constructor_accepted_kwargs(llama_cls: Any) -> set[str]:
+    try:
+        signature = inspect.signature(llama_cls.__init__)
+    except (TypeError, ValueError, AttributeError):
+        return set()
+    parameters = signature.parameters
+    if any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()):
+        return set(QWEN_YARN_REQUIRED_KWARGS + QWEN_YARN_OPTIONAL_KWARGS)
+    return set(parameters)
+
+
+def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> Dict[str, Any]:
+    accepted = _llama_constructor_accepted_kwargs(llama_cls)
+    missing = [name for name in QWEN_YARN_REQUIRED_KWARGS if name not in accepted]
+    yarn_value, yarn_source = _resolve_llama_cpp_rope_scaling_type_yarn(llama_cpp_module, llama_cls)
+    supported = yarn_value is not None and not missing
+    reason = None
+    if missing:
+        reason = f'missing constructor kwargs: {", ".join(missing)}'
+    elif yarn_value is None:
+        reason = 'missing LLAMA_ROPE_SCALING_TYPE_YARN enum constant'
+    return {
+        'supported': supported,
+        'yarn_enum_value': yarn_value,
+        'yarn_enum_source': yarn_source,
+        'accepted_constructor_kwargs': sorted(accepted),
+        'missing_reason': reason,
+        'llama_module_path': getattr(llama_cpp_module, '__file__', 'unknown'),
+        'llama_cpp_python_version': getattr(llama_cpp_module, '__version__', None),
+    }
 
 
 def _is_site_packages_path(path_text: Any) -> bool:
@@ -2148,7 +2240,12 @@ class ModelManager:
     def _qwen_non_thinking_required(self) -> bool:
         return self.model_profile.get('provider') == 'qwen' and self.model_profile.get('thinking_mode') == 'disabled'
 
-    def _runtime_init_kwargs(self, llama_cls: Any, n_gpu_layers: int) -> Dict[str, Any]:
+    def _runtime_init_kwargs(
+        self,
+        llama_cls: Any,
+        n_gpu_layers: int,
+        llama_cpp_module: Any = None,
+    ) -> Dict[str, Any]:
         """Build verified llama-cpp-python runtime kwargs for the selected profile.
 
         llama-cpp-python uses the GGUF/Jinja chat template when ``chat_format`` is
@@ -2183,27 +2280,22 @@ class ModelManager:
             and n_ctx > native_context
         )
         if needs_yarn:
-            required_kwargs = ('rope_scaling_type', 'yarn_ext_factor', 'yarn_orig_ctx')
-            unsupported = [
-                name for name in required_kwargs
-                if not self._llama_constructor_accepts(llama_cls, name)
-            ]
-            if unsupported:
+            llama_module = llama_cpp_module or inspect.getmodule(llama_cls) or llama_cls
+            yarn_support = _runtime_supports_qwen_yarn_rope(llama_module, llama_cls)
+            self.last_yarn_rope_runtime_probe = {
+                **yarn_support,
+                'active_context_tier': context_tier,
+                'requested_n_ctx': n_ctx,
+            }
+            if not yarn_support['supported']:
+                reason = yarn_support.get('missing_reason') or 'unsupported runtime'
                 raise RuntimeError(
-                    'Qwen 64K YaRN/RoPE is unsupported by this llama-cpp-python '
-                    f'runtime; missing constructor kwargs: {", ".join(unsupported)}'
+                    f'{QWEN_64K_YARN_UNSUPPORTED_ERROR}; {reason}; '
+                    f'active_profile_id={self.profile_id}; context_tier={context_tier}; '
+                    f"llama_module_path={yarn_support.get('llama_module_path') or 'unknown'}; "
+                    f"llama_cpp_python_version={yarn_support.get('llama_cpp_python_version') or 'unknown'}"
                 )
-            llama_module = inspect.getmodule(llama_cls)
-            yarn_scaling_type = getattr(
-                llama_module,
-                'LLAMA_ROPE_SCALING_TYPE_YARN',
-                getattr(llama_cls, 'LLAMA_ROPE_SCALING_TYPE_YARN', None),
-            )
-            if yarn_scaling_type is None:
-                raise RuntimeError(
-                    'Qwen 64K YaRN/RoPE is unsupported by this llama-cpp-python '
-                    'runtime; missing LLAMA_ROPE_SCALING_TYPE_YARN enum constant'
-                )
+            yarn_scaling_type = yarn_support['yarn_enum_value']
             kwargs.update(
                 {
                     'rope_scaling_type': yarn_scaling_type,
@@ -2494,7 +2586,7 @@ class ModelManager:
 
                             self.log_info(f"About to instantiate Llama model from {self.model_path}...")
                             self.log_info(f"Llama init started for {self.model_path}.")
-                            runtime_kwargs = self._runtime_init_kwargs(Llama, n_gpu_layers)
+                            runtime_kwargs = self._runtime_init_kwargs(Llama, n_gpu_layers, llama_cpp)
                             llm_instance = Llama(**runtime_kwargs)
                             if self.model_profile.get('provider') == 'qwen':
                                 llm_type_module = type(llm_instance).__module__
@@ -2539,6 +2631,15 @@ class ModelManager:
                                 'rope_yarn_factor': runtime_kwargs.get('yarn_ext_factor'),
                                 'yarn_original_context': runtime_kwargs.get('yarn_orig_ctx') or rope_policy.get('original_context_tokens'),
                             })
+                            yarn_probe = getattr(self, 'last_yarn_rope_runtime_probe', None)
+                            if isinstance(yarn_probe, dict):
+                                compute_plan.update({
+                                    'yarn_rope_supported': yarn_probe.get('supported'),
+                                    'yarn_rope_enum_source': yarn_probe.get('yarn_enum_source'),
+                                    'yarn_rope_accepted_constructor_kwargs': yarn_probe.get('accepted_constructor_kwargs'),
+                                    'yarn_rope_runtime_module_path': yarn_probe.get('llama_module_path'),
+                                    'yarn_rope_runtime_version': yarn_probe.get('llama_cpp_python_version'),
+                                })
                             self.last_compute_diagnostics = compute_plan
                             if compute_plan['requested_mode'] == 'cpu':
                                 runtime_identity = {


### PR DESCRIPTION
### Motivation
- Qwen3 64K failed to start on some packaged desktop runtimes because YaRN/RoPE enum/kwargs were resolved in a brittle top-level-only way, causing nodes to incorrectly attempt registration without true 64K support.
- The node must fail closed when YaRN is unavailable and must only apply 64K YaRN kwargs when the runtime genuinely supports them.
- Add robust runtime probing and diagnostics so failures are actionable and CI regresses on missing YaRN support.

### Description
- Added robust YaRN/RoPE resolution and probing helpers in `utils/llm/model_manager.py`: `_resolve_llama_cpp_rope_scaling_type_yarn`, `_llama_constructor_accepted_kwargs`, and `_runtime_supports_qwen_yarn_rope` to check multiple safe locations (top-level, nested `llama_cpp`, class-level, and enum-wrapper containers) and constructor kwarg acceptance before applying YaRN kwargs.
- Updated `_runtime_init_kwargs` to accept an optional `llama_cpp_module` probe, perform the YaRN runtime probe, save `last_yarn_rope_runtime_probe`, and fail closed with a clear actionable error when YaRN is unsupported; only then apply `n_ctx=65536`, `rope_scaling_type=YARN`, `yarn_ext_factor=2.0`, and `yarn_orig_ctx=32768` for Qwen 64K full.
- Propagated YaRN probe diagnostics into runtime/compute readiness and API v1 readiness diagnostics via `compute_plan` and `utils/compute_node_runtime.py` readiness fields (`api_v1_readiness_yarn_rope_enum_source`, `api_v1_readiness_yarn_rope_runtime_supported`, etc.).
- Added unit tests and small test adjustments in `tests/unit/test_model_manager.py` covering: top-level, nested and class-level enum resolution, constructor kwarg probing, Qwen 8K/64K runtime behavior, fail-closed error messages, and a runtime-probe helper assertion; and added a packaging regression test in `tests/unit/test_desktop_gpu_packaging.py` asserting the pinned `llama-cpp-python` version is a YaRN-capable baseline (>= 0.3.16).
- Minimal, scoped changes only to allowed files: `utils/llm/model_manager.py`, `utils/compute_node_runtime.py`, `desktop-tauri/src-tauri/python/desktop_gpu_packaging.py` tests, and related unit tests.

### Testing
- Ran focused unit tests and integration smoke used during development: `python -m pytest tests/unit/test_model_manager.py -q` (passed) and the broader focused set below (all passed):
  - `python -m pytest tests/unit/test_model_manager.py tests/unit/test_context_profiles.py tests/unit/test_compute_node_runtime.py tests/unit/test_desktop_gpu_packaging.py tests/unit/test_desktop_runtime_setup.py tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (all tests in that run passed).
- Ran the full unit suite: `python -m pytest tests/unit -q --maxfail=1` which completed with all tests passing (final run: 1840 passed, 1 skipped, 266 warnings).
- Ran repository checks: `pre-commit run --all-files` which passed (hooks, vulture, bandit, and project checks succeeded).
- Summary of verification commands executed during the rollout are recorded in the branch test log and showed green for the modified code paths and regressions.

If runtime YaRN support is missing at startup the node now fails before registration with a clear error explaining the missing enum/kwargs and runtime probe diagnostics to guide updating/rebuilding the packaged llama-cpp-python runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45e9314314832f87b76e901e523b1e)