### PR TITLE
Re-enable context-tier & relay controls after Stop Operator

### DIFF
--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -834,6 +834,151 @@ describe('desktop app start failure handling', () => {
   });
 
 
+
+  it('re-enables context tier and relay URL controls immediately after successful Stop Operator', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      active_relay_url: 'https://token.place',
+      relay_runtime_state: 'ready',
+      warm_load_state: 'ready',
+      worker_state: 'ready',
+      worker_alive: true,
+      registered_relay_count: 1,
+      registered_relay_urls: ['https://token.place'],
+      active_relay_urls: ['https://token.place'],
+      relay_statuses: [{
+        relay_url: 'https://token.place',
+        registered: true,
+        relay_runtime_state: 'ready',
+        last_error: null,
+        last_request_id: null,
+      }],
+      operator_session_id: 'session-1',
+      sequence: 2,
+    });
+
+    render(<App />);
+    const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    const addRelayButton = (await screen.findByText('Add new relay URL')) as HTMLButtonElement;
+    const stopOperatorButton = (await screen.findByText('Stop operator')) as HTMLButtonElement;
+
+    await waitFor(() => expect(contextSelect.disabled).toBe(true));
+    expect(relayInput.disabled).toBe(true);
+    expect(addRelayButton.disabled).toBe(true);
+
+    fireEvent.click(stopOperatorButton);
+
+    await waitFor(() => expect(contextSelect.disabled).toBe(false));
+    expect(relayInput.disabled).toBe(false);
+    expect(addRelayButton.disabled).toBe(false);
+    expect(screen.getByText(/Running:/).textContent).toContain('no');
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('stopped');
+    expect(screen.getByText(/Worker state:/).textContent).toContain('stopped');
+  });
+
+  it('allows switching from 8k to 64k and starting again after Stop Operator without an app restart', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      active_relay_url: 'https://token.place',
+      relay_runtime_state: 'ready',
+      warm_load_state: 'ready',
+      worker_state: 'ready',
+      worker_alive: true,
+      operator_session_id: 'session-1',
+      sequence: 2,
+    });
+
+    render(<App />);
+    const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    await waitFor(() => expect(contextSelect.disabled).toBe(true));
+
+    fireEvent.click((await screen.findByText('Stop operator')) as HTMLButtonElement);
+    await waitFor(() => expect(contextSelect.disabled).toBe(false));
+    fireEvent.change(contextSelect, { target: { value: '64k-full' } });
+
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.some(
+          ([command, args]) => command === 'start_compute_node' && args?.request?.context_tier === '64k-full'
+        )
+      ).toBe(true)
+    );
+  });
+
+  it('re-enables the context tier selector after a pre-registration failure event', async () => {
+    render(<App />);
+    const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+
+    await waitFor(() => expect(contextSelect.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+    await waitFor(() => expect(contextSelect.disabled).toBe(true));
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'error',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'failed',
+        warm_load_state: 'failed',
+        worker_state: 'failed',
+        worker_alive: false,
+        last_error: 'pre-registration warm load failed',
+        operator_session_id: 'session-1',
+        sequence: 1,
+      },
+    });
+
+    await waitFor(() => expect(contextSelect.disabled).toBe(false));
+    expect(screen.getByText(/Last error:/).textContent).toContain('pre-registration warm load failed');
+  });
+
+  it('keeps running controls disabled and surfaces a safe error when Stop Operator fails', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'stop_compute_node') {
+        return Promise.reject(new Error('stop rpc failed'));
+      }
+      if (command === 'get_compute_node_status') {
+        return Promise.resolve({
+          running: true,
+          registered: true,
+          active_relay_url: 'https://token.place',
+          requested_mode: 'auto',
+          effective_mode: 'cpu',
+          backend_available: 'unknown',
+          backend_selected: 'cpu',
+          backend_used: 'cpu',
+          fallback_reason: null,
+          model_path: '/tmp/model.gguf',
+          last_error: null,
+          relay_runtime_state: 'ready',
+          warm_load_state: 'ready',
+          worker_state: 'ready',
+          worker_alive: true,
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    fireEvent.click((await screen.findByText('Stop operator')) as HTMLButtonElement);
+
+    await waitFor(() => expect(screen.getByText(/Error:/).textContent).toContain('stop rpc failed'));
+    expect(screen.getByText(/Running:/).textContent).toContain('yes');
+    expect(contextSelect.disabled).toBe(true);
+  });
+
   it('handles Start Stop Start with fresh registration and cleared errors', async () => {
     mockInitialComputeStatus({
       running: false,

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -155,8 +155,8 @@ function displayStatusValue(value: string | null | undefined, fallback: string):
   return value && value.trim() ? value : fallback;
 }
 
-function isStoppedOrIdleOperatorStatus(status: ComputeNodeStatus, isStarting: boolean): boolean {
-  if (isStarting || status.running) {
+function isStoppedOrIdleOperatorStatus(status: ComputeNodeStatus, isStarting: boolean, isStopping: boolean): boolean {
+  if (isStarting || isStopping || status.running) {
     return false;
   }
   const workerState = status.worker_state?.trim().toLowerCase() || 'stopped';
@@ -330,6 +330,7 @@ function mergeComputeStatusEvent(
   ) {
     return prev;
   }
+  const isTerminalStoppedEvent = payload.type === 'stopped';
   const payloadWorkerGeneration =
     typeof payload.worker_generation === 'number' ? payload.worker_generation : null;
   if (
@@ -345,13 +346,13 @@ function mergeComputeStatusEvent(
     running:
       typeof payload.running === 'boolean'
         ? payload.running
-        : payload.type === 'error'
+        : payload.type === 'error' || isTerminalStoppedEvent
           ? false
           : prev.running,
     registered:
       typeof payload.registered === 'boolean'
         ? payload.registered
-        : payload.type === 'error'
+        : payload.type === 'error' || isTerminalStoppedEvent
           ? false
           : prev.registered,
     active_relay_url:
@@ -369,7 +370,7 @@ function mergeComputeStatusEvent(
     registered_relay_count:
       typeof payload.registered_relay_count === 'number'
         ? payload.registered_relay_count
-        : payload.type === 'error'
+        : payload.type === 'error' || isTerminalStoppedEvent
           ? 0
           : prev.registered_relay_count,
     configured_relay_count:
@@ -379,13 +380,13 @@ function mergeComputeStatusEvent(
     registered_relay_urls:
       Array.isArray(payload.registered_relay_urls)
         ? stringArrayPayload(payload.registered_relay_urls)
-        : payload.type === 'error'
+        : payload.type === 'error' || isTerminalStoppedEvent
           ? []
           : prev.registered_relay_urls,
     active_relay_urls:
       Array.isArray(payload.active_relay_urls)
         ? stringArrayPayload(payload.active_relay_urls)
-        : payload.type === 'error'
+        : payload.type === 'error' || isTerminalStoppedEvent
           ? []
           : prev.active_relay_urls,
     requested_mode:
@@ -416,12 +417,16 @@ function mergeComputeStatusEvent(
           ? payload.warm_load_state
           : payload.type === 'error'
             ? 'failed'
+            : isTerminalStoppedEvent
+              ? 'stopped'
             : prev.relay_runtime_state,
     warm_load_state:
       typeof payload.warm_load_state === 'string'
         ? payload.warm_load_state
         : payload.type === 'error'
           ? 'failed'
+          : isTerminalStoppedEvent
+            ? 'stopped'
           : prev.warm_load_state,
     warm_load_enabled:
       typeof payload.warm_load_enabled === 'boolean'
@@ -441,7 +446,9 @@ function mergeComputeStatusEvent(
         ? payload.worker_state
         : payload.type === 'error'
           ? 'failed'
-          : prev.worker_state,
+          : isTerminalStoppedEvent
+            ? 'stopped'
+            : prev.worker_state,
     worker_generation:
       typeof payload.worker_generation === 'number' ? payload.worker_generation : prev.worker_generation,
     worker_restart_count:
@@ -449,7 +456,7 @@ function mergeComputeStatusEvent(
     worker_alive:
       typeof payload.worker_alive === 'boolean'
         ? payload.worker_alive
-        : payload.type === 'error'
+        : payload.type === 'error' || isTerminalStoppedEvent
           ? false
           : prev.worker_alive,
     last_worker_error_code:
@@ -524,6 +531,7 @@ export function App() {
   const [error, setError] = useState('');
   const [isForwarding, setIsForwarding] = useState(false);
   const [isStartingComputeNode, setIsStartingComputeNode] = useState(false);
+  const [isStoppingComputeNode, setIsStoppingComputeNode] = useState(false);
   const [operatorLogText, setOperatorLogText] = useState('');
   const [isDebugConsoleOpen, setIsDebugConsoleOpen] = useState(false);
   const relayRuntimeState =
@@ -608,6 +616,10 @@ export function App() {
       if (payload.type === 'started' || payload.type === 'error') {
         setIsStartingComputeNode(false);
       }
+      if (payload.type === 'stopped') {
+        setIsStartingComputeNode(false);
+        setIsStoppingComputeNode(false);
+      }
       if (payload.type === 'error') {
         const computeMessage =
           typeof payload.last_error === 'string'
@@ -642,12 +654,12 @@ export function App() {
   );
 
   const canStartComputeNode = useMemo(
-    () => Boolean(config.model_path.trim()) && !computeStatus.running && !isStartingComputeNode,
-    [config.model_path, computeStatus.running, isStartingComputeNode]
+    () => Boolean(config.model_path.trim()) && !computeStatus.running && !isStartingComputeNode && !isStoppingComputeNode,
+    [config.model_path, computeStatus.running, isStartingComputeNode, isStoppingComputeNode]
   );
   const canChangeContextTier = useMemo(
-    () => isStoppedOrIdleOperatorStatus(computeStatus, isStartingComputeNode),
-    [computeStatus, isStartingComputeNode]
+    () => isStoppedOrIdleOperatorStatus(computeStatus, isStartingComputeNode, isStoppingComputeNode),
+    [computeStatus, isStartingComputeNode, isStoppingComputeNode]
   );
   const availableBackend = backend?.available_backend ?? 'cpu';
   const gpuCapable = availableBackend === 'metal' || availableBackend === 'cuda';
@@ -792,11 +804,43 @@ export function App() {
     }
   };
 
+  const stoppedComputeStatus = (previous: ComputeNodeStatus, lastError: string | null = null): ComputeNodeStatus => ({
+    ...previous,
+    running: false,
+    registered: false,
+    relay_runtime_state: 'stopped',
+    warm_load_state: 'stopped',
+    worker_state: 'stopped',
+    worker_alive: false,
+    registered_relay_count: 0,
+    registered_relay_urls: [],
+    active_relay_urls: [],
+    relay_statuses: previous.relay_statuses.map((relayStatus) => ({
+      ...relayStatus,
+      registered: false,
+      relay_runtime_state: 'stopped',
+      last_error: null,
+    })),
+    last_error: lastError,
+  });
+
   const stopComputeNode = async () => {
     try {
+      setIsStoppingComputeNode(true);
+      setError('');
       await invoke('stop_compute_node');
+      setIsStartingComputeNode(false);
+      const stoppedStatus = stoppedComputeStatus(computeStatusRef.current);
+      computeStatusRef.current = stoppedStatus;
+      setComputeStatus(stoppedStatus);
     } catch (e) {
-      setError(formatErrorMessage(e));
+      const message = formatErrorMessage(e);
+      setError(message);
+      const failedStopStatus = { ...computeStatusRef.current, last_error: message };
+      computeStatusRef.current = failedStopStatus;
+      setComputeStatus(failedStopStatus);
+    } finally {
+      setIsStoppingComputeNode(false);
     }
   };
 
@@ -915,14 +959,14 @@ export function App() {
 
       <section aria-labelledby="relay-urls-heading" style={{ marginTop: 12 }}>
         <h2 id="relay-urls-heading" style={{ fontSize: 16, marginBottom: 8 }}>Relay URLs</h2>
-        {(computeStatus.running || isStartingComputeNode) && (
+        {(computeStatus.running || isStartingComputeNode || isStoppingComputeNode) && (
           <p style={{ marginTop: 0, fontSize: 12, color: '#555' }}>
             Stop the operator to edit relay URLs. Changes apply on next start.
           </p>
         )}
         {config.relay_base_urls.map((relayUrl, index) => {
           const inputId = `relay-url-${index}`;
-          const relayControlsDisabled = computeStatus.running || isStartingComputeNode;
+          const relayControlsDisabled = computeStatus.running || isStartingComputeNode || isStoppingComputeNode;
           return (
             <div key={index} style={{ display: 'flex', gap: 8, marginTop: 6, alignItems: 'center' }}>
               <label htmlFor={inputId} style={{ minWidth: 92 }}>Relay URL {index + 1}</label>
@@ -949,7 +993,7 @@ export function App() {
         <button
           type="button"
           onClick={() => updateConfig(addRelayUrl(config))}
-          disabled={computeStatus.running || isStartingComputeNode || config.relay_base_urls.length >= MAX_RELAY_BASE_URLS}
+          disabled={computeStatus.running || isStartingComputeNode || isStoppingComputeNode || config.relay_base_urls.length >= MAX_RELAY_BASE_URLS}
           style={{ marginTop: 8 }}
         >
           Add new relay URL
@@ -979,7 +1023,7 @@ export function App() {
         <div style={{ display: 'flex', gap: 8 }}>
           <button disabled={!canStartComputeNode} onClick={startComputeNode}>Start operator</button>
           <button
-            disabled={!computeStatus.running}
+            disabled={!computeStatus.running || isStartingComputeNode || isStoppingComputeNode}
             onClick={stopComputeNode}
           >
             Stop operator


### PR DESCRIPTION
### Motivation
- Fix UI bug where the context-tier dropdown and relay URL controls remained disabled after clicking `Stop Operator` until the app was restarted.
- Ensure the frontend reliably reflects a stopped/idle operator even if the backend emits a delayed `stopped` event.
- Prevent stale prior-session events from re-disabling controls and preserve a safe error when a stop RPC fails.

### Description
- Treat `payload.type === 'stopped'` as a terminal stopped/idle state in `mergeComputeStatusEvent()` so omitted fields are interpreted as stopped/cleared where appropriate.
- Add `isStoppingComputeNode` state and a `stoppedComputeStatus()` helper in `desktop-tauri/src/App.tsx` and apply an optimistic stopped status after a successful `stop_compute_node` response so UI controls re-enable immediately.
- Clear `isStartingComputeNode` and `isStoppingComputeNode` on explicit `stopped` events and update `isStoppedOrIdleOperatorStatus()` to consider stopping state when deciding if context-tier may be changed.
- Expand disable rules to include the stopping-in-flight state for context tier and relay URL inputs, Add/Delete relay buttons, and Start/Stop controls.
- Add focused React tests in `desktop-tauri/src/App.test.tsx` that reproduce the bug and verify recovery paths: immediate post-stop re-enable, switching 8k→64k and re-start without restart, pre-registration failure recovery, and stop-command failure handling.

### Testing
- Ran desktop unit tests with `cd desktop-tauri && npm test -- App` and the App test suite passed (`49 tests, 49 passed`).
- Ran repository checks `pre-commit run --all-files` and `git diff --check`; both completed without errors.
- New/updated tests added: `re-enables context tier and relay URL controls immediately after successful Stop Operator`, `allows switching from 8k to 64k and starting again after Stop Operator without an app restart`, `re-enables the context tier selector after a pre-registration failure event`, and `keeps running controls disabled and surfaces a safe error when Stop Operator fails`, and they all passed under the App test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45ebec8850832f873cdd40c9f85462)