### PR TITLE
Re-enable desktop context-tier selector after Stop Operator

### DIFF
--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -535,6 +535,7 @@ describe('desktop app start failure handling', () => {
         type: 'status',
         running: true,
         registered: true,
+        relay_runtime_state: 'ready',
         warm_load_state: 'ready',
         last_error: null,
       },
@@ -1874,28 +1875,71 @@ describe('desktop app start failure handling', () => {
 
     render(<App />);
     const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    const addRelayButton = (await screen.findByText('Add new relay URL')) as HTMLButtonElement;
     await waitFor(() => expect(contextSelect.disabled).toBe(true));
+    expect(relayInput.disabled).toBe(true);
+    expect(addRelayButton.disabled).toBe(true);
 
     const computeHandler = eventHandlers.get('compute_node_event');
     expect(computeHandler).toBeTruthy();
     computeHandler?.({
       payload: {
         type: 'stopped',
-        running: false,
-        registered: false,
+        running: true,
+        registered: true,
+        active_relay_url: 'https://token.place',
         relay_runtime_state: 'ready',
         warm_load_state: 'ready',
         worker_state: 'ready',
         worker_alive: true,
+        registered_relay_count: 1,
+        registered_relay_urls: ['https://token.place'],
+        active_relay_urls: ['https://token.place'],
+        relay_statuses: [{ relay_url: 'https://token.place', registered: true }],
         operator_session_id: 'session-1',
         sequence: 3,
       },
     });
 
     await waitFor(() => expect(contextSelect.disabled).toBe(false));
+    expect(relayInput.disabled).toBe(false);
+    expect(addRelayButton.disabled).toBe(false);
+    expect(screen.getByText(/Running:/).textContent).toContain('no');
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
     expect(screen.getByText(/Relay runtime state:/).textContent).toContain('stopped');
     expect(screen.getByText(/Worker state:/).textContent).toContain('stopped');
     expect(screen.getByText(/Worker alive:/).textContent).toContain('no');
+    expect(screen.queryByText(/Per-relay status/)).toBeNull();
+  });
+
+  it('preserves relay runtime state when status events only include warm-load state', async () => {
+    mockInitialComputeStatus({
+      running: false,
+      registered: false,
+      relay_runtime_state: 'failed',
+      warm_load_state: 'failed',
+      worker_state: 'failed',
+      worker_alive: false,
+      operator_session_id: 'session-1',
+      sequence: 2,
+    });
+
+    render(<App />);
+    await screen.findByText(/Relay runtime state:/);
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        warm_load_state: 'ready',
+        operator_session_id: 'session-1',
+        sequence: 3,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/Relay runtime state:/).textContent).toContain('failed'));
   });
 
   it('re-enables context tier after pre-registration failure event', async () => {

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -141,7 +141,10 @@ describe('desktop app start failure handling', () => {
     return Promise.resolve(undefined);
   };
 
-  const mockInitialComputeStatus = (statusOverrides: Record<string, unknown>) => {
+  const mockInitialComputeStatus = (
+    statusOverrides: Record<string, unknown>,
+    configOverrides: Record<string, unknown> = {}
+  ) => {
     invokeMock.mockImplementation((command: string) => {
       if (command === 'detect_backend') {
         return Promise.resolve({
@@ -156,6 +159,7 @@ describe('desktop app start failure handling', () => {
           model_path: '/tmp/model.gguf',
           relay_base_url: 'https://token.place',
           preferred_mode: 'auto',
+          ...configOverrides,
         });
       }
       if (command === 'get_compute_node_status') {
@@ -1762,36 +1766,46 @@ describe('desktop app start failure handling', () => {
 
 
   it('re-enables context tier and relay controls immediately after successful Stop Operator', async () => {
-    mockInitialComputeStatus({
-      running: true,
-      registered: true,
-      active_relay_url: 'https://token.place',
-      relay_runtime_state: 'ready',
-      warm_load_state: 'ready',
-      worker_state: 'ready',
-      worker_alive: true,
-      registered_relay_count: 1,
-      registered_relay_urls: ['https://token.place'],
-      active_relay_urls: ['https://token.place'],
-      operator_session_id: 'session-1',
-      sequence: 2,
-    });
+    mockInitialComputeStatus(
+      {
+        running: true,
+        registered: true,
+        active_relay_url: 'https://token.place',
+        relay_runtime_state: 'ready',
+        warm_load_state: 'ready',
+        worker_state: 'ready',
+        worker_alive: true,
+        registered_relay_count: 2,
+        registered_relay_urls: ['https://token.place', 'https://staging.token.place'],
+        active_relay_urls: ['https://token.place', 'https://staging.token.place'],
+        operator_session_id: 'session-1',
+        sequence: 2,
+      },
+      {
+        relay_base_urls: ['https://token.place', 'https://staging.token.place'],
+      }
+    );
 
     render(<App />);
     const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
     const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
     const addRelayButton = (await screen.findByText('Add new relay URL')) as HTMLButtonElement;
+    const deleteSecondRelayButton = (await screen.findByLabelText(
+      'Delete relay URL 2'
+    )) as HTMLButtonElement;
     const stopOperatorButton = (await screen.findByText('Stop operator')) as HTMLButtonElement;
 
     await waitFor(() => expect(contextSelect.disabled).toBe(true));
     expect(relayInput.disabled).toBe(true);
     expect(addRelayButton.disabled).toBe(true);
+    expect(deleteSecondRelayButton.disabled).toBe(true);
 
     fireEvent.click(stopOperatorButton);
 
     await waitFor(() => expect(contextSelect.disabled).toBe(false));
     expect(relayInput.disabled).toBe(false);
     expect(addRelayButton.disabled).toBe(false);
+    expect(deleteSecondRelayButton.disabled).toBe(false);
     expect(screen.getByText(/Running:/).textContent).toContain('no');
     expect(screen.getByText(/Registered:/).textContent).toContain('no');
     expect(screen.getByText(/Relay runtime state:/).textContent).toContain('stopped');

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1760,4 +1760,200 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Last worker error code:/).textContent).toContain('fatal_worker_exit');
   });
 
+
+  it('re-enables context tier and relay controls immediately after successful Stop Operator', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      active_relay_url: 'https://token.place',
+      relay_runtime_state: 'ready',
+      warm_load_state: 'ready',
+      worker_state: 'ready',
+      worker_alive: true,
+      registered_relay_count: 1,
+      registered_relay_urls: ['https://token.place'],
+      active_relay_urls: ['https://token.place'],
+      operator_session_id: 'session-1',
+      sequence: 2,
+    });
+
+    render(<App />);
+    const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    const addRelayButton = (await screen.findByText('Add new relay URL')) as HTMLButtonElement;
+    const stopOperatorButton = (await screen.findByText('Stop operator')) as HTMLButtonElement;
+
+    await waitFor(() => expect(contextSelect.disabled).toBe(true));
+    expect(relayInput.disabled).toBe(true);
+    expect(addRelayButton.disabled).toBe(true);
+
+    fireEvent.click(stopOperatorButton);
+
+    await waitFor(() => expect(contextSelect.disabled).toBe(false));
+    expect(relayInput.disabled).toBe(false);
+    expect(addRelayButton.disabled).toBe(false);
+    expect(screen.getByText(/Running:/).textContent).toContain('no');
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('stopped');
+
+    fireEvent.change(contextSelect, { target: { value: '64k-full' } });
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+    fireEvent.click(startOperatorButton);
+
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.some(
+          ([command, args]) =>
+            command === 'start_compute_node' && args?.request?.context_tier === '64k-full'
+        )
+      ).toBe(true)
+    );
+  });
+
+  it('treats stopped events with omitted fields as terminal stopped state', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      active_relay_url: 'https://token.place',
+      relay_runtime_state: 'ready',
+      warm_load_state: 'ready',
+      worker_state: 'ready',
+      worker_alive: true,
+      operator_session_id: 'session-1',
+      sequence: 2,
+    });
+
+    render(<App />);
+    const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    await waitFor(() => expect(contextSelect.disabled).toBe(true));
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'stopped',
+        operator_session_id: 'session-1',
+        sequence: 3,
+      },
+    });
+
+    await waitFor(() => expect(contextSelect.disabled).toBe(false));
+    expect(screen.getByText(/Running:/).textContent).toContain('no');
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Worker state:/).textContent).toContain('stopped');
+    expect(screen.getByText(/Worker alive:/).textContent).toContain('no');
+  });
+
+  it('re-enables context tier after pre-registration failure event', async () => {
+    render(<App />);
+    const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    const startButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startButton.disabled).toBe(false));
+
+    fireEvent.click(startButton);
+    await waitFor(() => expect(contextSelect.disabled).toBe(true));
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'error',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'failed',
+        warm_load_state: 'failed',
+        worker_state: 'failed',
+        worker_alive: false,
+        last_error: 'registration failed before ready',
+        operator_session_id: 'session-failed',
+        sequence: 1,
+      },
+    });
+
+    await waitFor(() => expect(contextSelect.disabled).toBe(false));
+    expect(screen.getByText(/Last error:/).textContent).toContain('registration failed before ready');
+  });
+
+  it('keeps stopped controls enabled when stale previous-session running events arrive after stop', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      relay_runtime_state: 'ready',
+      worker_state: 'ready',
+      operator_session_id: 'session-2',
+      sequence: 5,
+    });
+
+    render(<App />);
+    const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+
+    computeHandler?.({
+      payload: {
+        type: 'stopped',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'stopped',
+        worker_state: 'stopped',
+        operator_session_id: 'session-2',
+        sequence: 6,
+      },
+    });
+    await waitFor(() => expect(contextSelect.disabled).toBe(false));
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: true,
+        relay_runtime_state: 'ready',
+        worker_state: 'ready',
+        operator_session_id: 'session-1',
+        sequence: 100,
+      },
+    });
+
+    await waitFor(() => expect(contextSelect.disabled).toBe(false));
+    expect(screen.getByText(/Running:/).textContent).toContain('no');
+  });
+
+  it('leaves the running state intact and surfaces safe error when Stop Operator fails', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'stop_compute_node') {
+        return Promise.reject(new Error('stop failed safely'));
+      }
+      if (command === 'get_compute_node_status') {
+        return Promise.resolve({
+          running: true,
+          registered: true,
+          active_relay_url: 'https://token.place',
+          requested_mode: 'auto',
+          effective_mode: 'cpu',
+          backend_available: 'unknown',
+          backend_selected: 'cpu',
+          backend_used: 'cpu',
+          fallback_reason: null,
+          model_path: '/tmp/model.gguf',
+          last_error: null,
+          relay_runtime_state: 'ready',
+          worker_state: 'ready',
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    const stopButton = (await screen.findByText('Stop operator')) as HTMLButtonElement;
+    await waitFor(() => expect(contextSelect.disabled).toBe(true));
+
+    fireEvent.click(stopButton);
+
+    await waitFor(() => expect(screen.getByText(/Error:/).textContent).toContain('stop failed safely'));
+    expect(screen.getByText(/Running:/).textContent).toContain('yes');
+    expect(contextSelect.disabled).toBe(true);
+  });
+
 });

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1845,6 +1845,45 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Worker alive:/).textContent).toContain('no');
   });
 
+  it('forces stopped worker fields even when stopped events include ready lifecycle values', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      active_relay_url: 'https://token.place',
+      relay_runtime_state: 'ready',
+      warm_load_state: 'ready',
+      worker_state: 'ready',
+      worker_alive: true,
+      operator_session_id: 'session-1',
+      sequence: 2,
+    });
+
+    render(<App />);
+    const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    await waitFor(() => expect(contextSelect.disabled).toBe(true));
+
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+    computeHandler?.({
+      payload: {
+        type: 'stopped',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'ready',
+        warm_load_state: 'ready',
+        worker_state: 'ready',
+        worker_alive: true,
+        operator_session_id: 'session-1',
+        sequence: 3,
+      },
+    });
+
+    await waitFor(() => expect(contextSelect.disabled).toBe(false));
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('stopped');
+    expect(screen.getByText(/Worker state:/).textContent).toContain('stopped');
+    expect(screen.getByText(/Worker alive:/).textContent).toContain('no');
+  });
+
   it('re-enables context tier after pre-registration failure event', async () => {
     render(<App />);
     const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -439,23 +439,23 @@ function mergeComputeStatusEvent(
           : prev.fallback_reason,
     model_path: typeof payload.model_path === 'string' ? payload.model_path : prev.model_path,
     relay_runtime_state:
-      typeof payload.relay_runtime_state === 'string'
-        ? payload.relay_runtime_state
+      isStoppedEvent
+        ? stoppedBase.relay_runtime_state
+        : typeof payload.relay_runtime_state === 'string'
+          ? payload.relay_runtime_state
+          : payload.type === 'error'
+            ? 'failed'
+            : typeof payload.warm_load_state === 'string'
+              ? 'idle'
+              : prev.relay_runtime_state,
+    warm_load_state:
+      isStoppedEvent
+        ? stoppedBase.warm_load_state
         : typeof payload.warm_load_state === 'string'
           ? payload.warm_load_state
           : payload.type === 'error'
             ? 'failed'
-            : isStoppedEvent
-              ? 'stopped'
-              : stoppedBase.relay_runtime_state,
-    warm_load_state:
-      typeof payload.warm_load_state === 'string'
-        ? payload.warm_load_state
-        : payload.type === 'error'
-          ? 'failed'
-          : isStoppedEvent
-            ? 'stopped'
-            : stoppedBase.warm_load_state,
+            : prev.warm_load_state,
     warm_load_enabled:
       typeof payload.warm_load_enabled === 'boolean'
         ? payload.warm_load_enabled
@@ -470,23 +470,25 @@ function mergeComputeStatusEvent(
         ? payload.relay_runtime_path
         : prev.relay_runtime_path,
     worker_state:
-      typeof payload.worker_state === 'string'
-        ? payload.worker_state
-        : payload.type === 'error'
-          ? 'failed'
-          : isStoppedEvent
-            ? 'stopped'
-            : stoppedBase.worker_state,
+      isStoppedEvent
+        ? stoppedBase.worker_state
+        : typeof payload.worker_state === 'string'
+          ? payload.worker_state
+          : payload.type === 'error'
+            ? 'failed'
+            : prev.worker_state,
     worker_generation:
       typeof payload.worker_generation === 'number' ? payload.worker_generation : prev.worker_generation,
     worker_restart_count:
       typeof payload.worker_restart_count === 'number' ? payload.worker_restart_count : prev.worker_restart_count,
     worker_alive:
-      typeof payload.worker_alive === 'boolean'
-        ? payload.worker_alive
-        : payload.type === 'error' || isStoppedEvent
-          ? false
-          : stoppedBase.worker_alive,
+      isStoppedEvent
+        ? stoppedBase.worker_alive
+        : typeof payload.worker_alive === 'boolean'
+          ? payload.worker_alive
+          : payload.type === 'error'
+            ? false
+            : prev.worker_alive,
     last_worker_error_code:
       payload.last_worker_error_code === null
         ? null
@@ -684,8 +686,14 @@ export function App() {
     () => Boolean(config.model_path.trim()) && !computeStatus.running && !isStartingComputeNode && !isStoppingComputeNode,
     [config.model_path, computeStatus.running, isStartingComputeNode, isStoppingComputeNode]
   );
-  const operatorControlsDisabled = isStartingComputeNode || isStoppingComputeNode;
-  const operatorEditControlsDisabled = computeStatus.running || operatorControlsDisabled;
+  const operatorControlsDisabled = useMemo(
+    () => isStartingComputeNode || isStoppingComputeNode,
+    [isStartingComputeNode, isStoppingComputeNode]
+  );
+  const operatorEditControlsDisabled = useMemo(
+    () => computeStatus.running || operatorControlsDisabled,
+    [computeStatus.running, operatorControlsDisabled]
+  );
   const canChangeContextTier = useMemo(
     () => isStoppedOrIdleOperatorStatus(computeStatus, isStartingComputeNode, isStoppingComputeNode),
     [computeStatus, isStartingComputeNode, isStoppingComputeNode]

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -372,19 +372,25 @@ function mergeComputeStatusEvent(
   return {
     ...stoppedBase,
     running:
-      typeof payload.running === 'boolean'
-        ? payload.running
-        : payload.type === 'error' || isStoppedEvent
+      isStoppedEvent
+        ? stoppedBase.running
+        : typeof payload.running === 'boolean'
+          ? payload.running
+          : payload.type === 'error'
           ? false
           : stoppedBase.running,
     registered:
-      typeof payload.registered === 'boolean'
-        ? payload.registered
-        : payload.type === 'error' || isStoppedEvent
+      isStoppedEvent
+        ? stoppedBase.registered
+        : typeof payload.registered === 'boolean'
+          ? payload.registered
+          : payload.type === 'error'
           ? false
           : stoppedBase.registered,
     active_relay_url:
-      typeof payload.active_relay_url === 'string'
+      isStoppedEvent
+        ? stoppedBase.active_relay_url
+        : typeof payload.active_relay_url === 'string'
         ? payload.active_relay_url
         : stoppedBase.active_relay_url,
     configured_relay_urls:
@@ -392,13 +398,17 @@ function mergeComputeStatusEvent(
         ? stringArrayPayload(payload.configured_relay_urls)
         : prev.configured_relay_urls,
     relay_statuses:
-      Array.isArray(payload.relay_statuses)
+      isStoppedEvent
+        ? stoppedBase.relay_statuses
+        : Array.isArray(payload.relay_statuses)
         ? relayStatusesPayload(payload.relay_statuses)
         : stoppedBase.relay_statuses,
     registered_relay_count:
-      typeof payload.registered_relay_count === 'number'
-        ? payload.registered_relay_count
-        : payload.type === 'error' || isStoppedEvent
+      isStoppedEvent
+        ? stoppedBase.registered_relay_count
+        : typeof payload.registered_relay_count === 'number'
+          ? payload.registered_relay_count
+          : payload.type === 'error'
           ? 0
           : stoppedBase.registered_relay_count,
     configured_relay_count:
@@ -406,15 +416,19 @@ function mergeComputeStatusEvent(
         ? payload.configured_relay_count
         : prev.configured_relay_count,
     registered_relay_urls:
-      Array.isArray(payload.registered_relay_urls)
-        ? stringArrayPayload(payload.registered_relay_urls)
-        : payload.type === 'error' || isStoppedEvent
+      isStoppedEvent
+        ? stoppedBase.registered_relay_urls
+        : Array.isArray(payload.registered_relay_urls)
+          ? stringArrayPayload(payload.registered_relay_urls)
+          : payload.type === 'error'
           ? []
           : stoppedBase.registered_relay_urls,
     active_relay_urls:
-      Array.isArray(payload.active_relay_urls)
-        ? stringArrayPayload(payload.active_relay_urls)
-        : payload.type === 'error' || isStoppedEvent
+      isStoppedEvent
+        ? stoppedBase.active_relay_urls
+        : Array.isArray(payload.active_relay_urls)
+          ? stringArrayPayload(payload.active_relay_urls)
+          : payload.type === 'error'
           ? []
           : stoppedBase.active_relay_urls,
     requested_mode:
@@ -445,9 +459,7 @@ function mergeComputeStatusEvent(
           ? payload.relay_runtime_state
           : payload.type === 'error'
             ? 'failed'
-            : typeof payload.warm_load_state === 'string'
-              ? 'idle'
-              : prev.relay_runtime_state,
+            : prev.relay_runtime_state,
     warm_load_state:
       isStoppedEvent
         ? stoppedBase.warm_load_state

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -155,8 +155,12 @@ function displayStatusValue(value: string | null | undefined, fallback: string):
   return value && value.trim() ? value : fallback;
 }
 
-function isStoppedOrIdleOperatorStatus(status: ComputeNodeStatus, isStarting: boolean): boolean {
-  if (isStarting || status.running) {
+function isStoppedOrIdleOperatorStatus(
+  status: ComputeNodeStatus,
+  isStarting: boolean,
+  isStopping = false
+): boolean {
+  if (isStarting || isStopping || status.running) {
     return false;
   }
   const workerState = status.worker_state?.trim().toLowerCase() || 'stopped';
@@ -302,6 +306,27 @@ export function removeRelayUrl(config: DesktopConfig, index: number): DesktopCon
   };
 }
 
+function stoppedComputeStatus(
+  prev: ComputeNodeStatus,
+  lastError: string | null = null
+): ComputeNodeStatus {
+  return {
+    ...prev,
+    running: false,
+    registered: false,
+    active_relay_url: '',
+    relay_statuses: [],
+    registered_relay_count: 0,
+    registered_relay_urls: [],
+    active_relay_urls: [],
+    relay_runtime_state: 'stopped',
+    warm_load_state: 'stopped',
+    worker_state: 'stopped',
+    worker_alive: false,
+    last_error: lastError,
+  };
+}
+
 function mergeComputeStatusEvent(
   prev: ComputeNodeStatus,
   payload: Record<string, unknown>
@@ -341,23 +366,27 @@ function mergeComputeStatusEvent(
     return prev;
   }
 
+  const isStoppedEvent = payload.type === 'stopped';
+  const stoppedBase = isStoppedEvent ? stoppedComputeStatus(prev, null) : prev;
+
   return {
+    ...stoppedBase,
     running:
       typeof payload.running === 'boolean'
         ? payload.running
-        : payload.type === 'error'
+        : payload.type === 'error' || isStoppedEvent
           ? false
-          : prev.running,
+          : stoppedBase.running,
     registered:
       typeof payload.registered === 'boolean'
         ? payload.registered
-        : payload.type === 'error'
+        : payload.type === 'error' || isStoppedEvent
           ? false
-          : prev.registered,
+          : stoppedBase.registered,
     active_relay_url:
       typeof payload.active_relay_url === 'string'
         ? payload.active_relay_url
-        : prev.active_relay_url,
+        : stoppedBase.active_relay_url,
     configured_relay_urls:
       Array.isArray(payload.configured_relay_urls)
         ? stringArrayPayload(payload.configured_relay_urls)
@@ -365,13 +394,13 @@ function mergeComputeStatusEvent(
     relay_statuses:
       Array.isArray(payload.relay_statuses)
         ? relayStatusesPayload(payload.relay_statuses)
-        : prev.relay_statuses,
+        : stoppedBase.relay_statuses,
     registered_relay_count:
       typeof payload.registered_relay_count === 'number'
         ? payload.registered_relay_count
-        : payload.type === 'error'
+        : payload.type === 'error' || isStoppedEvent
           ? 0
-          : prev.registered_relay_count,
+          : stoppedBase.registered_relay_count,
     configured_relay_count:
       typeof payload.configured_relay_count === 'number'
         ? payload.configured_relay_count
@@ -379,15 +408,15 @@ function mergeComputeStatusEvent(
     registered_relay_urls:
       Array.isArray(payload.registered_relay_urls)
         ? stringArrayPayload(payload.registered_relay_urls)
-        : payload.type === 'error'
+        : payload.type === 'error' || isStoppedEvent
           ? []
-          : prev.registered_relay_urls,
+          : stoppedBase.registered_relay_urls,
     active_relay_urls:
       Array.isArray(payload.active_relay_urls)
         ? stringArrayPayload(payload.active_relay_urls)
-        : payload.type === 'error'
+        : payload.type === 'error' || isStoppedEvent
           ? []
-          : prev.active_relay_urls,
+          : stoppedBase.active_relay_urls,
     requested_mode:
       typeof payload.requested_mode === 'string' ? payload.requested_mode : prev.requested_mode,
     effective_mode:
@@ -416,13 +445,17 @@ function mergeComputeStatusEvent(
           ? payload.warm_load_state
           : payload.type === 'error'
             ? 'failed'
-            : prev.relay_runtime_state,
+            : isStoppedEvent
+              ? 'stopped'
+              : stoppedBase.relay_runtime_state,
     warm_load_state:
       typeof payload.warm_load_state === 'string'
         ? payload.warm_load_state
         : payload.type === 'error'
           ? 'failed'
-          : prev.warm_load_state,
+          : isStoppedEvent
+            ? 'stopped'
+            : stoppedBase.warm_load_state,
     warm_load_enabled:
       typeof payload.warm_load_enabled === 'boolean'
         ? payload.warm_load_enabled
@@ -441,7 +474,9 @@ function mergeComputeStatusEvent(
         ? payload.worker_state
         : payload.type === 'error'
           ? 'failed'
-          : prev.worker_state,
+          : isStoppedEvent
+            ? 'stopped'
+            : stoppedBase.worker_state,
     worker_generation:
       typeof payload.worker_generation === 'number' ? payload.worker_generation : prev.worker_generation,
     worker_restart_count:
@@ -449,9 +484,9 @@ function mergeComputeStatusEvent(
     worker_alive:
       typeof payload.worker_alive === 'boolean'
         ? payload.worker_alive
-        : payload.type === 'error'
+        : payload.type === 'error' || isStoppedEvent
           ? false
-          : prev.worker_alive,
+          : stoppedBase.worker_alive,
     last_worker_error_code:
       payload.last_worker_error_code === null
         ? null
@@ -491,7 +526,7 @@ function mergeComputeStatusEvent(
           ? payload.last_error
           : typeof payload.message === 'string'
             ? payload.message
-            : prev.last_error,
+            : stoppedBase.last_error,
   };
 }
 
@@ -524,6 +559,7 @@ export function App() {
   const [error, setError] = useState('');
   const [isForwarding, setIsForwarding] = useState(false);
   const [isStartingComputeNode, setIsStartingComputeNode] = useState(false);
+  const [isStoppingComputeNode, setIsStoppingComputeNode] = useState(false);
   const [operatorLogText, setOperatorLogText] = useState('');
   const [isDebugConsoleOpen, setIsDebugConsoleOpen] = useState(false);
   const relayRuntimeState =
@@ -605,8 +641,11 @@ export function App() {
       }
       computeStatusRef.current = next;
       setComputeStatus(next);
-      if (payload.type === 'started' || payload.type === 'error') {
+      if (payload.type === 'started' || payload.type === 'error' || payload.type === 'stopped') {
         setIsStartingComputeNode(false);
+      }
+      if (payload.type === 'stopped') {
+        setIsStoppingComputeNode(false);
       }
       if (payload.type === 'error') {
         const computeMessage =
@@ -642,12 +681,14 @@ export function App() {
   );
 
   const canStartComputeNode = useMemo(
-    () => Boolean(config.model_path.trim()) && !computeStatus.running && !isStartingComputeNode,
-    [config.model_path, computeStatus.running, isStartingComputeNode]
+    () => Boolean(config.model_path.trim()) && !computeStatus.running && !isStartingComputeNode && !isStoppingComputeNode,
+    [config.model_path, computeStatus.running, isStartingComputeNode, isStoppingComputeNode]
   );
+  const operatorControlsDisabled = isStartingComputeNode || isStoppingComputeNode;
+  const operatorEditControlsDisabled = computeStatus.running || operatorControlsDisabled;
   const canChangeContextTier = useMemo(
-    () => isStoppedOrIdleOperatorStatus(computeStatus, isStartingComputeNode),
-    [computeStatus, isStartingComputeNode]
+    () => isStoppedOrIdleOperatorStatus(computeStatus, isStartingComputeNode, isStoppingComputeNode),
+    [computeStatus, isStartingComputeNode, isStoppingComputeNode]
   );
   const availableBackend = backend?.available_backend ?? 'cpu';
   const gpuCapable = availableBackend === 'metal' || availableBackend === 'cuda';
@@ -794,9 +835,21 @@ export function App() {
 
   const stopComputeNode = async () => {
     try {
+      setIsStoppingComputeNode(true);
+      setError('');
       await invoke('stop_compute_node');
+      const nextStatus = stoppedComputeStatus(computeStatusRef.current, null);
+      computeStatusRef.current = nextStatus;
+      setComputeStatus(nextStatus);
+      setIsStartingComputeNode(false);
+      setIsStoppingComputeNode(false);
     } catch (e) {
-      setError(formatErrorMessage(e));
+      setIsStoppingComputeNode(false);
+      const message = formatErrorMessage(e);
+      const failedStopStatus = { ...computeStatusRef.current, last_error: message };
+      computeStatusRef.current = failedStopStatus;
+      setComputeStatus(failedStopStatus);
+      setError(message);
     }
   };
 
@@ -915,14 +968,14 @@ export function App() {
 
       <section aria-labelledby="relay-urls-heading" style={{ marginTop: 12 }}>
         <h2 id="relay-urls-heading" style={{ fontSize: 16, marginBottom: 8 }}>Relay URLs</h2>
-        {(computeStatus.running || isStartingComputeNode) && (
+        {operatorEditControlsDisabled && (
           <p style={{ marginTop: 0, fontSize: 12, color: '#555' }}>
             Stop the operator to edit relay URLs. Changes apply on next start.
           </p>
         )}
         {config.relay_base_urls.map((relayUrl, index) => {
           const inputId = `relay-url-${index}`;
-          const relayControlsDisabled = computeStatus.running || isStartingComputeNode;
+          const relayControlsDisabled = operatorEditControlsDisabled;
           return (
             <div key={index} style={{ display: 'flex', gap: 8, marginTop: 6, alignItems: 'center' }}>
               <label htmlFor={inputId} style={{ minWidth: 92 }}>Relay URL {index + 1}</label>
@@ -949,7 +1002,7 @@ export function App() {
         <button
           type="button"
           onClick={() => updateConfig(addRelayUrl(config))}
-          disabled={computeStatus.running || isStartingComputeNode || config.relay_base_urls.length >= MAX_RELAY_BASE_URLS}
+          disabled={operatorEditControlsDisabled || config.relay_base_urls.length >= MAX_RELAY_BASE_URLS}
           style={{ marginTop: 8 }}
         >
           Add new relay URL
@@ -979,7 +1032,7 @@ export function App() {
         <div style={{ display: 'flex', gap: 8 }}>
           <button disabled={!canStartComputeNode} onClick={startComputeNode}>Start operator</button>
           <button
-            disabled={!computeStatus.running}
+            disabled={!computeStatus.running || operatorControlsDisabled}
             onClick={stopComputeNode}
           >
             Stop operator


### PR DESCRIPTION
### Motivation
- The context-tier dropdown and relay URL controls stayed disabled after clicking `Stop Operator` until the app was restarted, blocking switching tiers (e.g. 8k-fast → 64k-full).
- The UI should re-enable those controls as soon as the operator is known to be stopped/idle, and should remain robust if a backend stopped event is delayed.

### Description
- Add an explicit stopped normalization helper `stoppedComputeStatus()` and apply it optimistically after a successful `stop_compute_node` invocation so UI becomes idle without requiring a restart (`desktop-tauri/src/App.tsx`).
- Update `mergeComputeStatusEvent()` so `payload.type === 'stopped'` is treated as a terminal stopped/idle state even when some fields are omitted, while preserving existing session/sequence stale-event protections (`desktop-tauri/src/App.tsx`).
- Introduce `isStoppingComputeNode` state and wire start/stop/edit control disabling so controls are disabled only during real start/stop/running transitions and re-enable after stop success or stopped event (`desktop-tauri/src/App.tsx`).
- Make stop failure preserve running state and surface a safe `last_error` without falsely re-enabling controls (`desktop-tauri/src/App.tsx`).
- Add focused React tests that reproduce the bug and assert correct behavior for: post-stop re-enable, stopped events with omitted fields, pre-registration failure re-enable, stale previous-session events, relay control re-enable, and stop failure handling (`desktop-tauri/src/App.test.tsx`).

### Testing
- Ran desktop unit tests: `cd desktop-tauri && npm test -- App` — all tests passed (`50 passed`).
- Ran repository checks: `pre-commit run --all-files` — passed.
- Ran quick check: `git diff --check` — no issues.
- Tests added/updated in `desktop-tauri/src/App.test.tsx` cover:
  - context tier select disabled while starting/running and re-enabled after Stop Operator success,
  - relay URL controls re-enabled after Stop Operator,
  - Start → error (pre-registration) re-enables selector,
  - `stopped` events with omitted fields treated as terminal stop,
  - stale previous-session events do not re-disable controls,
  - stop command failure surfaces safe error and leaves running state intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45ebfa024c832f93eb00578bcdca27)