### PR TITLE
Re-enable context-tier & relay controls after Stop Operator

### DIFF
--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -1760,4 +1760,162 @@ describe('desktop app start failure handling', () => {
     expect(screen.getByText(/Last worker error code:/).textContent).toContain('fatal_worker_exit');
   });
 
+
+  it('re-enables context tier and relay controls immediately after successful Stop Operator without a stopped event', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      active_relay_url: 'https://token.place',
+      relay_runtime_state: 'ready',
+      warm_load_state: 'ready',
+      warm_load_enabled: true,
+      worker_state: 'ready',
+      worker_alive: true,
+      registered_relay_count: 1,
+      registered_relay_urls: ['https://token.place'],
+      active_relay_urls: ['https://token.place'],
+      operator_session_id: 'session-1',
+      sequence: 2,
+    });
+
+    render(<App />);
+    const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    const addRelayButton = (await screen.findByText('Add new relay URL')) as HTMLButtonElement;
+    await waitFor(() => expect(contextSelect.disabled).toBe(true));
+    expect(relayInput.disabled).toBe(true);
+    expect(addRelayButton.disabled).toBe(true);
+
+    fireEvent.click((await screen.findByText('Stop operator')) as HTMLButtonElement);
+
+    await waitFor(() => expect(contextSelect.disabled).toBe(false));
+    expect(relayInput.disabled).toBe(false);
+    expect(addRelayButton.disabled).toBe(false);
+    expect(screen.getByText(/Running:/).textContent).toContain('no');
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('stopped');
+    expect(screen.getByText(/Worker state:/).textContent).toContain('stopped');
+
+    fireEvent.change(contextSelect, { target: { value: '64k-full' } });
+    fireEvent.click((await screen.findByText('Start operator')) as HTMLButtonElement);
+
+    await waitFor(() =>
+      expect(
+        invokeMock.mock.calls.some(
+          ([command, args]) => command === 'start_compute_node' && args?.request?.context_tier === '64k-full'
+        )
+      ).toBe(true)
+    );
+  });
+
+  it('treats sparse stopped events as terminal stopped state and re-enables context tier', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      relay_runtime_state: 'ready',
+      warm_load_state: 'ready',
+      worker_state: 'ready',
+      worker_alive: true,
+      registered_relay_count: 1,
+      active_relay_url: 'https://token.place',
+      relay_statuses: [{ relay_url: 'https://token.place', registered: true, relay_runtime_state: 'ready', last_error: null, last_request_id: null }],
+      operator_session_id: 'session-1',
+      sequence: 2,
+    });
+
+    render(<App />);
+    const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    await waitFor(() => expect(contextSelect.disabled).toBe(true));
+
+    eventHandlers.get('compute_node_event')?.({
+      payload: { type: 'stopped', operator_session_id: 'session-1', sequence: 3 },
+    });
+
+    await waitFor(() => expect(contextSelect.disabled).toBe(false));
+    expect(screen.getByText(/Running:/).textContent).toContain('no');
+    expect(screen.getByText(/Registered:/).textContent).toContain('no');
+    expect(screen.getByText(/Relay runtime state:/).textContent).toContain('stopped');
+    expect(screen.getByText(/Worker alive:/).textContent).toContain('no');
+  });
+
+  it('re-enables context tier after a pre-registration failure event while leaving transient registration failures disabled', async () => {
+    render(<App />);
+    const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    const computeHandler = eventHandlers.get('compute_node_event');
+    expect(computeHandler).toBeTruthy();
+
+    computeHandler?.({
+      payload: {
+        type: 'status',
+        running: true,
+        registered: false,
+        relay_runtime_state: 'ready',
+        worker_state: 'ready',
+        worker_alive: true,
+        last_error: 'relay registration retrying',
+        operator_session_id: 'session-1',
+        sequence: 1,
+      },
+    });
+    await waitFor(() => expect(contextSelect.disabled).toBe(true));
+    expect(screen.getByText(/Running:/).textContent).toContain('yes');
+
+    computeHandler?.({
+      payload: {
+        type: 'error',
+        running: false,
+        registered: false,
+        relay_runtime_state: 'failed',
+        worker_state: 'failed',
+        worker_alive: false,
+        last_error: 'warm-load failed before registration',
+        operator_session_id: 'session-1',
+        sequence: 2,
+      },
+    });
+
+    await waitFor(() => expect(contextSelect.disabled).toBe(false));
+    expect(screen.getByText(/Running:/).textContent).toContain('no');
+    expect(screen.getByText(/Last error:/).textContent).toContain('warm-load failed before registration');
+  });
+
+  it('keeps running state and safe error visible when Stop Operator fails', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'stop_compute_node') {
+        return Promise.reject(new Error('stop failed: process still running'));
+      }
+      if (command === 'get_compute_node_status') {
+        return Promise.resolve({
+          running: true,
+          registered: true,
+          active_relay_url: 'https://token.place',
+          requested_mode: 'auto',
+          effective_mode: 'cpu',
+          backend_available: 'unknown',
+          backend_selected: 'cpu',
+          backend_used: 'cpu',
+          fallback_reason: null,
+          model_path: '/tmp/model.gguf',
+          last_error: null,
+          relay_runtime_state: 'ready',
+          warm_load_state: 'ready',
+          worker_state: 'ready',
+          worker_alive: true,
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    const contextSelect = (await screen.findByLabelText('Context tier')) as HTMLSelectElement;
+    await waitFor(() => expect(contextSelect.disabled).toBe(true));
+
+    fireEvent.click((await screen.findByText('Stop operator')) as HTMLButtonElement);
+
+    await waitFor(() => expect(screen.getByText(/Error:/).textContent).toContain('stop failed: process still running'));
+    expect(screen.getByText(/Running:/).textContent).toContain('yes');
+    expect(contextSelect.disabled).toBe(true);
+    expect(screen.getByText(/Last error:/).textContent).toContain('stop failed: process still running');
+  });
+
 });

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -155,8 +155,8 @@ function displayStatusValue(value: string | null | undefined, fallback: string):
   return value && value.trim() ? value : fallback;
 }
 
-function isStoppedOrIdleOperatorStatus(status: ComputeNodeStatus, isStarting: boolean): boolean {
-  if (isStarting || status.running) {
+function isStoppedOrIdleOperatorStatus(status: ComputeNodeStatus, isStarting: boolean, isStopping = false): boolean {
+  if (isStarting || isStopping || status.running) {
     return false;
   }
   const workerState = status.worker_state?.trim().toLowerCase() || 'stopped';
@@ -302,6 +302,24 @@ export function removeRelayUrl(config: DesktopConfig, index: number): DesktopCon
   };
 }
 
+function stoppedComputeStatus(prev: ComputeNodeStatus, lastError: string | null = null): ComputeNodeStatus {
+  return {
+    ...prev,
+    running: false,
+    registered: false,
+    relay_runtime_state: 'stopped',
+    warm_load_state: 'stopped',
+    worker_state: 'stopped',
+    worker_alive: false,
+    active_relay_url: '',
+    relay_statuses: [],
+    registered_relay_count: 0,
+    registered_relay_urls: [],
+    active_relay_urls: [],
+    last_error: lastError,
+  };
+}
+
 function mergeComputeStatusEvent(
   prev: ComputeNodeStatus,
   payload: Record<string, unknown>
@@ -341,23 +359,29 @@ function mergeComputeStatusEvent(
     return prev;
   }
 
+  const isTerminalStoppedEvent = payload.type === 'stopped' || payload.type === 'error';
+  const baseStatus = payload.type === 'stopped' ? stoppedComputeStatus(prev) : prev;
+
   return {
+    ...baseStatus,
     running:
       typeof payload.running === 'boolean'
         ? payload.running
-        : payload.type === 'error'
+        : isTerminalStoppedEvent
           ? false
           : prev.running,
     registered:
       typeof payload.registered === 'boolean'
         ? payload.registered
-        : payload.type === 'error'
+        : isTerminalStoppedEvent
           ? false
           : prev.registered,
     active_relay_url:
       typeof payload.active_relay_url === 'string'
         ? payload.active_relay_url
-        : prev.active_relay_url,
+        : payload.type === 'stopped'
+          ? ''
+          : prev.active_relay_url,
     configured_relay_urls:
       Array.isArray(payload.configured_relay_urls)
         ? stringArrayPayload(payload.configured_relay_urls)
@@ -365,11 +389,13 @@ function mergeComputeStatusEvent(
     relay_statuses:
       Array.isArray(payload.relay_statuses)
         ? relayStatusesPayload(payload.relay_statuses)
-        : prev.relay_statuses,
+        : payload.type === 'stopped'
+          ? []
+          : prev.relay_statuses,
     registered_relay_count:
       typeof payload.registered_relay_count === 'number'
         ? payload.registered_relay_count
-        : payload.type === 'error'
+        : isTerminalStoppedEvent
           ? 0
           : prev.registered_relay_count,
     configured_relay_count:
@@ -379,13 +405,13 @@ function mergeComputeStatusEvent(
     registered_relay_urls:
       Array.isArray(payload.registered_relay_urls)
         ? stringArrayPayload(payload.registered_relay_urls)
-        : payload.type === 'error'
+        : isTerminalStoppedEvent
           ? []
           : prev.registered_relay_urls,
     active_relay_urls:
       Array.isArray(payload.active_relay_urls)
         ? stringArrayPayload(payload.active_relay_urls)
-        : payload.type === 'error'
+        : isTerminalStoppedEvent
           ? []
           : prev.active_relay_urls,
     requested_mode:
@@ -416,13 +442,17 @@ function mergeComputeStatusEvent(
           ? payload.warm_load_state
           : payload.type === 'error'
             ? 'failed'
-            : prev.relay_runtime_state,
+            : payload.type === 'stopped'
+              ? 'stopped'
+              : prev.relay_runtime_state,
     warm_load_state:
       typeof payload.warm_load_state === 'string'
         ? payload.warm_load_state
         : payload.type === 'error'
           ? 'failed'
-          : prev.warm_load_state,
+          : payload.type === 'stopped'
+            ? 'stopped'
+            : prev.warm_load_state,
     warm_load_enabled:
       typeof payload.warm_load_enabled === 'boolean'
         ? payload.warm_load_enabled
@@ -441,7 +471,9 @@ function mergeComputeStatusEvent(
         ? payload.worker_state
         : payload.type === 'error'
           ? 'failed'
-          : prev.worker_state,
+          : payload.type === 'stopped'
+            ? 'stopped'
+            : prev.worker_state,
     worker_generation:
       typeof payload.worker_generation === 'number' ? payload.worker_generation : prev.worker_generation,
     worker_restart_count:
@@ -449,7 +481,7 @@ function mergeComputeStatusEvent(
     worker_alive:
       typeof payload.worker_alive === 'boolean'
         ? payload.worker_alive
-        : payload.type === 'error'
+        : isTerminalStoppedEvent
           ? false
           : prev.worker_alive,
     last_worker_error_code:
@@ -524,6 +556,7 @@ export function App() {
   const [error, setError] = useState('');
   const [isForwarding, setIsForwarding] = useState(false);
   const [isStartingComputeNode, setIsStartingComputeNode] = useState(false);
+  const [isStoppingComputeNode, setIsStoppingComputeNode] = useState(false);
   const [operatorLogText, setOperatorLogText] = useState('');
   const [isDebugConsoleOpen, setIsDebugConsoleOpen] = useState(false);
   const relayRuntimeState =
@@ -605,8 +638,11 @@ export function App() {
       }
       computeStatusRef.current = next;
       setComputeStatus(next);
-      if (payload.type === 'started' || payload.type === 'error') {
+      if (payload.type === 'started' || payload.type === 'error' || payload.type === 'stopped') {
         setIsStartingComputeNode(false);
+      }
+      if (payload.type === 'stopped') {
+        setIsStoppingComputeNode(false);
       }
       if (payload.type === 'error') {
         const computeMessage =
@@ -642,12 +678,12 @@ export function App() {
   );
 
   const canStartComputeNode = useMemo(
-    () => Boolean(config.model_path.trim()) && !computeStatus.running && !isStartingComputeNode,
-    [config.model_path, computeStatus.running, isStartingComputeNode]
+    () => Boolean(config.model_path.trim()) && !computeStatus.running && !isStartingComputeNode && !isStoppingComputeNode,
+    [config.model_path, computeStatus.running, isStartingComputeNode, isStoppingComputeNode]
   );
   const canChangeContextTier = useMemo(
-    () => isStoppedOrIdleOperatorStatus(computeStatus, isStartingComputeNode),
-    [computeStatus, isStartingComputeNode]
+    () => isStoppedOrIdleOperatorStatus(computeStatus, isStartingComputeNode, isStoppingComputeNode),
+    [computeStatus, isStartingComputeNode, isStoppingComputeNode]
   );
   const availableBackend = backend?.available_backend ?? 'cpu';
   const gpuCapable = availableBackend === 'metal' || availableBackend === 'cuda';
@@ -794,9 +830,21 @@ export function App() {
 
   const stopComputeNode = async () => {
     try {
+      setIsStoppingComputeNode(true);
+      setError('');
       await invoke('stop_compute_node');
+      setIsStartingComputeNode(false);
+      setIsStoppingComputeNode(false);
+      const nextStatus = stoppedComputeStatus(computeStatusRef.current, null);
+      computeStatusRef.current = nextStatus;
+      setComputeStatus(nextStatus);
     } catch (e) {
-      setError(formatErrorMessage(e));
+      setIsStoppingComputeNode(false);
+      const message = formatErrorMessage(e);
+      setError(message);
+      const nextStatus = { ...computeStatusRef.current, last_error: message };
+      computeStatusRef.current = nextStatus;
+      setComputeStatus(nextStatus);
     }
   };
 
@@ -915,14 +963,14 @@ export function App() {
 
       <section aria-labelledby="relay-urls-heading" style={{ marginTop: 12 }}>
         <h2 id="relay-urls-heading" style={{ fontSize: 16, marginBottom: 8 }}>Relay URLs</h2>
-        {(computeStatus.running || isStartingComputeNode) && (
+        {(computeStatus.running || isStartingComputeNode || isStoppingComputeNode) && (
           <p style={{ marginTop: 0, fontSize: 12, color: '#555' }}>
             Stop the operator to edit relay URLs. Changes apply on next start.
           </p>
         )}
         {config.relay_base_urls.map((relayUrl, index) => {
           const inputId = `relay-url-${index}`;
-          const relayControlsDisabled = computeStatus.running || isStartingComputeNode;
+          const relayControlsDisabled = computeStatus.running || isStartingComputeNode || isStoppingComputeNode;
           return (
             <div key={index} style={{ display: 'flex', gap: 8, marginTop: 6, alignItems: 'center' }}>
               <label htmlFor={inputId} style={{ minWidth: 92 }}>Relay URL {index + 1}</label>
@@ -949,7 +997,7 @@ export function App() {
         <button
           type="button"
           onClick={() => updateConfig(addRelayUrl(config))}
-          disabled={computeStatus.running || isStartingComputeNode || config.relay_base_urls.length >= MAX_RELAY_BASE_URLS}
+          disabled={computeStatus.running || isStartingComputeNode || isStoppingComputeNode || config.relay_base_urls.length >= MAX_RELAY_BASE_URLS}
           style={{ marginTop: 8 }}
         >
           Add new relay URL
@@ -979,7 +1027,7 @@ export function App() {
         <div style={{ display: 'flex', gap: 8 }}>
           <button disabled={!canStartComputeNode} onClick={startComputeNode}>Start operator</button>
           <button
-            disabled={!computeStatus.running}
+            disabled={!computeStatus.running || isStartingComputeNode || isStoppingComputeNode}
             onClick={stopComputeNode}
           >
             Stop operator


### PR DESCRIPTION
### Motivation
- Fix a UI bug where the context-tier dropdown and relay URL controls stayed disabled after clicking `Stop Operator` until the app was restarted or a delayed stopped event arrived. This blocked switching tiers (e.g. `8k-fast` → `64k-full`).

### Description
- Add an explicit `isStoppingComputeNode` UI state to protect start/stop/relay controls while a stop is in-flight and to avoid races with `isStartingComputeNode` by updating `App` state hooks and derived `canStartComputeNode` / `canChangeContextTier` logic. 
- Implement `stoppedComputeStatus()` and apply an optimistic stopped status after `stopComputeNode` succeeds so the UI clears `running`/`registered`/`worker`/`relay` fields immediately and re-enables controls even if a backend `stopped` event is delayed. 
- Update `mergeComputeStatusEvent()` so `payload.type === 'stopped'` (and `error`) is treated as a terminal stopped state while preserving existing session/sequence stale-event guards. Sparse stopped events now normalize to stopped/idle fields instead of leaving stale values. 
- Keep relay URL inputs and Add/Delete buttons consistent with operator state by including the stopping state in their disabled checks. 
- Add focused React tests in `desktop-tauri/src/App.test.tsx` that reproduce and lock the fix, including immediate re-enable after stop, sparse `stopped` event handling, pre-registration failures, stop failure behavior, and the Start→Stop→Start tier-change flow.

### Testing
- Ran focused desktop tests: `cd desktop-tauri && npm test -- App`, which completed with `Test Files 1 passed (1)` and `Tests 49 passed (49)`. 
- Ran repository checks: `git diff --check` which reported no problems. 
- Ran pre-commit hooks: `pre-commit run --all-files` which completed successfully. 

All automated tests and checks listed above passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45ec40b948832f90fa0a79019b5a0c)