### PR TITLE
Make YaRN/RoPE detection robust and auto-repair stale desktop runtimes for Qwen 64K

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import concurrent.futures
+import inspect
 import json
 import math
 import os
@@ -521,11 +522,16 @@ def _bridge_session_id_from_env() -> str:
 
 def _ensure_desktop_llama_runtime_for_context(mode: str, context_tier: str) -> Dict[str, str]:
     try:
+        parameters = inspect.signature(ensure_desktop_llama_runtime).parameters
+    except (TypeError, ValueError):
+        parameters = {}
+    accepts_context_tier = (
+        "context_tier" in parameters
+        or any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters.values())
+    )
+    if accepts_context_tier:
         return ensure_desktop_llama_runtime(mode, context_tier=context_tier)
-    except TypeError as exc:
-        if "context_tier" not in str(exc) and "unexpected keyword" not in str(exc):
-            raise
-        return ensure_desktop_llama_runtime(mode)
+    return ensure_desktop_llama_runtime(mode)
 
 def _startup_context_tier(args: argparse.Namespace) -> str:
     raw_context_tier = getattr(args, "context_tier", "8k-fast")

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -40,7 +40,7 @@ except ModuleNotFoundError:
     def desktop_gpu_runtime_failure_message(_mode: str, _runtime_setup: Dict[str, str]) -> None:
         return None
 
-    def ensure_desktop_llama_runtime(_mode: str) -> Dict[str, str]:
+    def ensure_desktop_llama_runtime(_mode: str, **_kwargs: Any) -> Dict[str, str]:
         return {
             "selected_backend": "cpu",
             "detected_device": "cpu",
@@ -219,7 +219,6 @@ def _registration_fresh(relay_client: Any, relay_url: str) -> bool:
         except TypeError:
             return bool(is_fresh())
     return False
-
 
 
 def _cached_poll_wait_seconds(relay_client: Any, relay_url: str, default: float) -> float:
@@ -520,6 +519,14 @@ def _bridge_session_id_from_env() -> str:
     return value or uuid.uuid4().hex
 
 
+def _ensure_desktop_llama_runtime_for_context(mode: str, context_tier: str) -> Dict[str, str]:
+    try:
+        return ensure_desktop_llama_runtime(mode, context_tier=context_tier)
+    except TypeError as exc:
+        if "context_tier" not in str(exc) and "unexpected keyword" not in str(exc):
+            raise
+        return ensure_desktop_llama_runtime(mode)
+
 def _startup_context_tier(args: argparse.Namespace) -> str:
     raw_context_tier = getattr(args, "context_tier", "8k-fast")
     if raw_context_tier in {"8k-fast", "64k-full"}:
@@ -533,7 +540,6 @@ def _load_context_profile_helpers() -> Tuple[Any, Any]:
     from utils.context_profiles import apply_context_profile, normalize_context_tier
 
     return apply_context_profile, normalize_context_tier
-
 
 
 def _sanitize_context_profile_import_error(exc: BaseException) -> str:
@@ -603,7 +609,6 @@ def _sleep_with_cancel(seconds: float) -> bool:
     return stop_requested()
 
 
-
 def _expand_relay_url_candidate(candidate: Any) -> List[str]:
     """Expand one CLI relay-url value without logging secrets or payloads."""
 
@@ -666,7 +671,7 @@ def run(args: argparse.Namespace) -> int:
     def emit_startup_error(message: str) -> None:
         emit_operator_event(_structured_startup_error_payload(args, message))
 
-    runtime_setup = ensure_desktop_llama_runtime(args.mode)
+    runtime_setup = _ensure_desktop_llama_runtime_for_context(args.mode, _startup_context_tier(args))
     maybe_reexec_for_runtime_refresh(runtime_setup)
     print(
         "desktop.runtime_setup "

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import importlib.metadata
 import importlib.util
-import inspect
 import json
 import os
 import platform as platform_module
@@ -907,6 +905,8 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
             **_probe_result_payload(before),
         }
 
+    last_error = ""
+
     if before.gpu_offload_supported and before.backend in {"cuda", "metal"}:
         if not qwen_64k_required or before.yarn_rope_supported:
             return {
@@ -942,8 +942,8 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
         return {
             "selected_backend": "cpu",
             "fallback_reason": (
-                f"GPU runtime probe only ({before.error or before.backend}); {policy.bootstrap_reason}"
-            ),
+                f"{last_error}; " if last_error else ""
+            ) + f"GPU runtime probe only ({before.error or before.backend}); {policy.bootstrap_reason}",
             "runtime_action": "probe_only",
             **_probe_result_payload(before),
         }
@@ -966,7 +966,8 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
         return {
             "selected_backend": "cpu",
             "fallback_reason": (
-                f"{disabled_reason}; platform={policy.platform}; arch={policy.arch}; "
+                (f"{last_error}; " if last_error else "")
+                + f"{disabled_reason}; platform={policy.platform}; arch={policy.arch}; "
                 f"expected_backend={expected_backend}; interpreter={before.interpreter}; "
                 f"prefix={before.prefix}; llama_module_path={before.llama_module_path}"
             ),
@@ -975,7 +976,6 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
         }
 
     requirements_path = _resolve_requirements_path(target_root)
-    last_error = locals().get("last_error", "")
     install_diagnostics: Dict[str, str] = {}
 
     if expected_backend == "cuda":
@@ -995,18 +995,26 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
                     )
                     after = _probe_runtime(target_root)
                     if after.gpu_offload_supported and after.backend == "cuda":
-                        return {
-                            "selected_backend": "cuda",
-                            "fallback_reason": "installed CUDA runtime; re-executing sidecar",
-                            "runtime_action": "installed_cuda_reexec",
-                            **_probe_result_payload(after),
-                            **install_diagnostics,
-                        }
+                        if not qwen_64k_required or after.yarn_rope_supported:
+                            return {
+                                "selected_backend": "cuda",
+                                "fallback_reason": "installed CUDA runtime; re-executing sidecar",
+                                "runtime_action": "installed_cuda_reexec",
+                                **_probe_result_payload(after),
+                                **install_diagnostics,
+                            }
+                        last_error = (
+                            "CUDA source reinstall completed but Qwen 64K YaRN/RoPE support is still missing; "
+                            f"resolver={after.yarn_resolver_source}; version={after.llama_cpp_python_version}; "
+                            f"module={after.llama_module_path}"
+                        )
+                        _record_source_repair_failure(last_error)
                     source_detail = _summarize_install_error(source_log)
-                    last_error = (
-                        "CUDA source reinstall completed but runtime still CPU-only; "
-                        "check CUDA toolkit/build tools"
-                    )
+                    if not last_error:
+                        last_error = (
+                            "CUDA source reinstall completed but runtime still CPU-only; "
+                            "check CUDA toolkit/build tools"
+                        )
                     if source_detail and source_detail != "install failed":
                         last_error = f"{last_error}; source repair detail: {source_detail}"
                     _record_source_repair_failure(last_error)

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -661,6 +661,17 @@ def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, str]:
     }
 
 
+def _qwen_64k_runtime_repair_failed_reason(probe: RuntimeProbe) -> str:
+    return (
+        "Qwen 64K requires YaRN/RoPE support in llama-cpp-python; runtime repair failed; "
+        f"resolver={probe.yarn_resolver_source}; version={probe.llama_cpp_python_version}; "
+        f"module={probe.llama_module_path}; "
+        f"rope_scaling_type_supported={probe.rope_scaling_type_supported}; "
+        f"yarn_ext_factor_supported={probe.yarn_ext_factor_supported}; "
+        f"yarn_orig_ctx_supported={probe.yarn_orig_ctx_supported}"
+    )
+
+
 def _repo_llama_shim_path(repo_root: Path) -> str:
     return str((repo_root / "llama_cpp.py").resolve())
 
@@ -1003,11 +1014,7 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
                                 **_probe_result_payload(after),
                                 **install_diagnostics,
                             }
-                        last_error = (
-                            "CUDA source reinstall completed but Qwen 64K YaRN/RoPE support is still missing; "
-                            f"resolver={after.yarn_resolver_source}; version={after.llama_cpp_python_version}; "
-                            f"module={after.llama_module_path}"
-                        )
+                        last_error = _qwen_64k_runtime_repair_failed_reason(after)
                         _record_source_repair_failure(last_error)
                     source_detail = _summarize_install_error(source_log)
                     if not last_error:
@@ -1079,11 +1086,7 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
         accepted_source_probe = plan_satisfied and after.backend != plan.backend
         if plan.backend in {"cuda", "metal"} and (verified_backend or accepted_source_probe):
             if qwen_64k_required and not after.yarn_rope_supported:
-                last_error = (
-                    "Qwen 64K requires YaRN/RoPE support in llama-cpp-python; runtime repair failed; "
-                    f"resolver={after.yarn_resolver_source}; version={after.llama_cpp_python_version}; "
-                    f"module={after.llama_module_path}"
-                )
+                last_error = _qwen_64k_runtime_repair_failed_reason(after)
                 continue
             if verified_backend:
                 reason = f"installed {after.backend.upper()} runtime; re-executing sidecar"

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import importlib.metadata
 import importlib.util
+import inspect
 import json
 import os
 import platform as platform_module
@@ -58,6 +60,12 @@ class RuntimeProbe:
     base_prefix: str = "unknown"
     dependency_target: str = "unknown"
     pip_version: str = "unknown"
+    llama_cpp_python_version: str = "unknown"
+    yarn_rope_supported: bool = False
+    yarn_resolver_source: str = "unsupported"
+    rope_scaling_type_supported: bool = False
+    yarn_ext_factor_supported: bool = False
+    yarn_orig_ctx_supported: bool = False
 
 
 GPU_MODES = frozenset({"auto", "gpu", "hybrid"})
@@ -102,7 +110,9 @@ _PROCESS_PYTHON_VERSION = sys.version.split()[0]
 
 _PROBE_SNIPPET = r"""
 import importlib
+import importlib.metadata
 import importlib.util
+import inspect
 import json
 import os
 import sys
@@ -185,6 +195,38 @@ try:
     if gpu_offload_supported and backend == "cpu":
         backend = "metal" if sys.platform == "darwin" else "cuda"
 
+    def _accepts(cls, name):
+        try:
+            params = inspect.signature(getattr(cls, "__init__", cls)).parameters
+        except (TypeError, ValueError):
+            return False
+        return name in params or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+    Llama = getattr(llama_cpp, "Llama", None)
+    rope_scaling_type_supported = _accepts(Llama, "rope_scaling_type")
+    yarn_ext_factor_supported = _accepts(Llama, "yarn_ext_factor")
+    yarn_orig_ctx_supported = _accepts(Llama, "yarn_orig_ctx")
+    if getattr(llama_cpp, "LLAMA_ROPE_SCALING_TYPE_YARN", None) is not None:
+        yarn_resolver_source = "top_level_enum"
+    elif getattr(getattr(llama_cpp, "llama_cpp", None), "LLAMA_ROPE_SCALING_TYPE_YARN", None) is not None:
+        yarn_resolver_source = "nested_enum"
+    elif rope_scaling_type_supported:
+        yarn_resolver_source = "numeric_fallback"
+    else:
+        yarn_resolver_source = "unsupported"
+    yarn_rope_supported = bool(
+        yarn_resolver_source != "unsupported"
+        and rope_scaling_type_supported
+        and yarn_ext_factor_supported
+        and yarn_orig_ctx_supported
+    )
+    llama_cpp_python_version = getattr(llama_cpp, "__version__", None)
+    if not llama_cpp_python_version:
+        try:
+            llama_cpp_python_version = importlib.metadata.version("llama-cpp-python")
+        except importlib.metadata.PackageNotFoundError:
+            llama_cpp_python_version = "unknown"
+
     payload = {
         "backend": backend,
         "gpu_offload_supported": gpu_offload_supported,
@@ -196,6 +238,12 @@ try:
         "dependency_target": dependency_target or "unknown",
         "pip_version": os.environ.get("TOKEN_PLACE_DESKTOP_PIP_VERSION", "unknown"),
         "llama_module_path": llama_module_path or "unknown",
+        "llama_cpp_python_version": llama_cpp_python_version,
+        "yarn_rope_supported": yarn_rope_supported,
+        "yarn_resolver_source": yarn_resolver_source,
+        "rope_scaling_type_supported": rope_scaling_type_supported,
+        "yarn_ext_factor_supported": yarn_ext_factor_supported,
+        "yarn_orig_ctx_supported": yarn_orig_ctx_supported,
         "error": None,
     }
 except Exception as exc:
@@ -210,6 +258,12 @@ except Exception as exc:
         "dependency_target": dependency_target or "unknown",
         "pip_version": os.environ.get("TOKEN_PLACE_DESKTOP_PIP_VERSION", "unknown"),
         "llama_module_path": "missing",
+        "llama_cpp_python_version": "unknown",
+        "yarn_rope_supported": False,
+        "yarn_resolver_source": "unsupported",
+        "rope_scaling_type_supported": False,
+        "yarn_ext_factor_supported": False,
+        "yarn_orig_ctx_supported": False,
         "error": str(exc),
     }
 
@@ -362,6 +416,12 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
         base_prefix=str(payload.get("base_prefix", getattr(sys, "base_prefix", sys.prefix))),
         dependency_target=str(payload.get("dependency_target", dependency_target_text)),
         pip_version=str(payload.get("pip_version", pip_version)),
+        llama_cpp_python_version=str(payload.get("llama_cpp_python_version", "unknown")),
+        yarn_rope_supported=bool(payload.get("yarn_rope_supported", False)),
+        yarn_resolver_source=str(payload.get("yarn_resolver_source", "unsupported")),
+        rope_scaling_type_supported=bool(payload.get("rope_scaling_type_supported", False)),
+        yarn_ext_factor_supported=bool(payload.get("yarn_ext_factor_supported", False)),
+        yarn_orig_ctx_supported=bool(payload.get("yarn_orig_ctx_supported", False)),
     )
 
 
@@ -594,6 +654,12 @@ def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, str]:
         "dependency_target": probe.dependency_target,
         "pip_version": probe.pip_version,
         "llama_module_path": probe.llama_module_path,
+        "llama_cpp_python_version": probe.llama_cpp_python_version,
+        "yarn_rope_supported": str(probe.yarn_rope_supported).lower(),
+        "yarn_resolver_source": probe.yarn_resolver_source,
+        "rope_scaling_type_supported": str(probe.rope_scaling_type_supported).lower(),
+        "yarn_ext_factor_supported": str(probe.yarn_ext_factor_supported).lower(),
+        "yarn_orig_ctx_supported": str(probe.yarn_orig_ctx_supported).lower(),
     }
 
 
@@ -812,11 +878,12 @@ def _resolve_requirements_path(target_root: Path) -> Path:
     return candidates[0]
 
 
-def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] = None) -> Dict[str, str]:
+def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] = None, context_tier: Optional[str] = None) -> Dict[str, str]:
     """Ensure the sidecar interpreter has a GPU-capable runtime when mode prefers GPU."""
 
     selected_mode = (mode or "auto").strip().lower()
     target_root = _resolve_runtime_root(repo_root=repo_root)
+    qwen_64k_required = (context_tier or os.getenv("TOKEN_PLACE_CONTEXT_TIER", "")).strip() == "64k-full"
     before = _probe_runtime(target_root)
     dependency_target, dependency_target_error = _prepend_dependency_target_to_sys_path(target_root)
     dependency_target_text = str(dependency_target) if dependency_target is not None else "unknown"
@@ -841,12 +908,20 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
         }
 
     if before.gpu_offload_supported and before.backend in {"cuda", "metal"}:
-        return {
-            "selected_backend": before.backend,
-            "fallback_reason": "",
-            "runtime_action": _already_supported_action(before.backend),
-            **_probe_result_payload(before),
-        }
+        if not qwen_64k_required or before.yarn_rope_supported:
+            return {
+                "selected_backend": before.backend,
+                "fallback_reason": "",
+                "runtime_action": _already_supported_action(before.backend),
+                **_probe_result_payload(before),
+            }
+        # Metal/CUDA import and offload are not enough for Qwen 64K. Continue
+        # into deterministic reinstall/upgrade so stale packaged sites are repaired.
+        last_error = (
+            "Qwen 64K requires YaRN/RoPE support in llama-cpp-python; "
+            f"installed runtime lacks support; resolver={before.yarn_resolver_source}; "
+            f"version={before.llama_cpp_python_version}; module={before.llama_module_path}"
+        )
 
     policy = _runtime_bootstrap_policy()
     expected_backend = policy.expected_backend
@@ -900,7 +975,7 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
         }
 
     requirements_path = _resolve_requirements_path(target_root)
-    last_error = ""
+    last_error = locals().get("last_error", "")
     install_diagnostics: Dict[str, str] = {}
 
     if expected_backend == "cuda":
@@ -995,6 +1070,13 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
         verified_backend = after.gpu_offload_supported and after.backend == plan.backend
         accepted_source_probe = plan_satisfied and after.backend != plan.backend
         if plan.backend in {"cuda", "metal"} and (verified_backend or accepted_source_probe):
+            if qwen_64k_required and not after.yarn_rope_supported:
+                last_error = (
+                    "Qwen 64K requires YaRN/RoPE support in llama-cpp-python; runtime repair failed; "
+                    f"resolver={after.yarn_resolver_source}; version={after.llama_cpp_python_version}; "
+                    f"module={after.llama_module_path}"
+                )
+                continue
             if verified_backend:
                 reason = f"installed {after.backend.upper()} runtime; re-executing sidecar"
                 selected_backend = plan.backend
@@ -1100,11 +1182,11 @@ def _record_desktop_runtime_probe(result: Dict[str, str]) -> Dict[str, str]:
     return result
 
 
-def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None) -> Dict[str, str]:
+def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None, context_tier: Optional[str] = None) -> Dict[str, str]:
     """Ensure the sidecar interpreter has a GPU-capable runtime when mode prefers GPU."""
 
     return _record_desktop_runtime_probe(
-        _ensure_desktop_llama_runtime_impl(mode, repo_root=repo_root)
+        _ensure_desktop_llama_runtime_impl(mode, repo_root=repo_root, context_tier=context_tier)
     )
 
 

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -107,10 +107,6 @@ _PROCESS_SYS_PATH = sys.path
 _PROCESS_PYTHON_VERSION = sys.version.split()[0]
 
 _PROBE_SNIPPET = r"""
-import importlib
-import importlib.metadata
-import importlib.util
-import inspect
 import json
 import os
 import sys
@@ -141,6 +137,10 @@ if bootstrap_script:
 
     ensure_runtime_import_paths(bootstrap_script, avoid_llama_cpp_shadowing=True)
 
+import importlib
+import importlib.metadata
+import importlib.util
+import inspect
 from pathlib import Path
 
 repo_root = Path(_safe_resolve_path_text(os.environ.get("TOKEN_PLACE_PROBE_REPO_ROOT", os.getcwd())))

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -4764,3 +4764,23 @@ def test_desktop_runtime_context_shim_uses_legacy_signature(monkeypatch):
         'runtime_action': 'legacy'
     }
     assert calls == ['auto']
+
+
+def test_desktop_runtime_context_shim_uses_legacy_call_when_signature_uninspectable(monkeypatch):
+    calls = []
+
+    def _legacy_runtime(mode):
+        calls.append(mode)
+        return {'runtime_action': 'legacy_uninspectable'}
+
+    monkeypatch.setattr(compute_node_bridge, 'ensure_desktop_llama_runtime', _legacy_runtime)
+    monkeypatch.setattr(
+        compute_node_bridge.inspect,
+        'signature',
+        lambda _target: (_ for _ in ()).throw(ValueError('signature unavailable')),
+    )
+
+    assert compute_node_bridge._ensure_desktop_llama_runtime_for_context('auto', '64k-full') == {
+        'runtime_action': 'legacy_uninspectable'
+    }
+    assert calls == ['auto']

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -4735,3 +4735,32 @@ def test_api_v1_unhealthy_result_without_recovery_attempt_sets_terminal_state(
     events = [json.loads(line) for line in output.out.splitlines() if line.strip()]
     status_events = [event for event in events if event.get('type') == 'status']
     assert status_events[-1]['relay_runtime_state'] == expected_state
+
+
+def test_desktop_runtime_context_shim_does_not_swallow_internal_type_error(monkeypatch):
+    def _runtime_with_internal_type_error(_mode, *, context_tier):
+        raise TypeError('nested helper got unexpected keyword argument')
+
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'ensure_desktop_llama_runtime',
+        _runtime_with_internal_type_error,
+    )
+
+    with pytest.raises(TypeError, match='nested helper'):
+        compute_node_bridge._ensure_desktop_llama_runtime_for_context('auto', '64k-full')
+
+
+def test_desktop_runtime_context_shim_uses_legacy_signature(monkeypatch):
+    calls = []
+
+    def _legacy_runtime(mode):
+        calls.append(mode)
+        return {'runtime_action': 'legacy'}
+
+    monkeypatch.setattr(compute_node_bridge, 'ensure_desktop_llama_runtime', _legacy_runtime)
+
+    assert compute_node_bridge._ensure_desktop_llama_runtime_for_context('auto', '64k-full') == {
+        'runtime_action': 'legacy'
+    }
+    assert calls == ['auto']

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -27,7 +27,7 @@ class _SysStub:
     argv = [str(MODULE_PATH)]
 
 
-def _probe(*, backend='cpu', gpu=False, device='cpu', error=None):
+def _probe(*, backend='cpu', gpu=False, device='cpu', error=None, yarn=False, resolver='unsupported'):
     return desktop_runtime_setup.RuntimeProbe(
         backend=backend,
         gpu_offload_supported=gpu,
@@ -36,6 +36,12 @@ def _probe(*, backend='cpu', gpu=False, device='cpu', error=None):
         prefix=sys.prefix,
         llama_module_path='C:/Python/Lib/site-packages/llama_cpp/__init__.py',
         error=error,
+        llama_cpp_python_version='0.3.16',
+        yarn_rope_supported=yarn,
+        yarn_resolver_source=resolver,
+        rope_scaling_type_supported=yarn,
+        yarn_ext_factor_supported=yarn,
+        yarn_orig_ctx_supported=yarn,
     )
 
 
@@ -136,6 +142,49 @@ def test_macos_metal_already_supported_reports_metal_action(monkeypatch):
     assert result['runtime_action'] == 'metal_already_supported'
 
 
+def test_macos_metal_already_supported_requires_yarn_for_qwen_64k(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    probes = iter([
+        _probe(backend='metal', gpu=True, device='metal', yarn=False),
+        _probe(backend='metal', gpu=True, device='metal', yarn=True, resolver='numeric_fallback'),
+    ])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    plan = desktop_runtime_setup.LlamaCppInstallPlan(
+        platform='darwin',
+        backend='metal',
+        package_spec='llama-cpp-python==0.3.32',
+        cmake_args='-DGGML_METAL=on',
+        force_cmake=True,
+        index_url='https://pypi.org/simple',
+        only_binary=False,
+        no_binary=True,
+    )
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [plan])
+    installs = []
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', lambda *args, **kwargs: (installs.append(args) or (True, 'ok')))
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT, context_tier='64k-full')
+
+    assert installs
+    assert result['runtime_action'] == 'installed_metal_reexec'
+    assert result['yarn_rope_supported'] == 'true'
+    assert result['yarn_resolver_source'] == 'numeric_fallback'
+
+
+def test_macos_metal_already_supported_skips_yarn_probe_for_qwen_8k(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: _probe(backend='metal', gpu=True, device='metal', yarn=False),
+    )
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', lambda *_args, **_kwargs: pytest.fail('unexpected install'))
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT, context_tier='8k-fast')
+
+    assert result['runtime_action'] == 'metal_already_supported'
+    assert result['yarn_rope_supported'] == 'false'
 
 def test_already_supported_runtime_prepends_dependency_target(monkeypatch, tmp_path):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
@@ -196,7 +245,6 @@ def test_macos_missing_metal_runtime_bootstrap_attempts_metal_plan(monkeypatch):
     assert captured['env']['CMAKE_ARGS'] == '-DGGML_METAL=on -DGGML_NATIVE=off'
     assert captured['env']['FORCE_CMAKE'] == '1'
     assert captured['timeout'] == desktop_runtime_setup.PIP_SOURCE_BUILD_TIMEOUT_SECONDS
-
 
 
 def test_macos_metal_source_install_clean_cpu_probe_reexecs_auto(monkeypatch):
@@ -315,7 +363,6 @@ def test_macos_metal_install_unsatisfied_cpu_probe_falls_back_to_cpu_in_auto(mon
     assert 'follow-up probe reported backend=cpu' in result['fallback_reason']
     assert 'using CPU runtime' in result['fallback_reason']
     assert desktop_runtime_setup.desktop_gpu_runtime_failure_message('auto', result) is None
-
 
 
 def test_macos_cpu_fallback_fails_when_follow_up_probe_is_not_importable(monkeypatch):
@@ -464,7 +511,6 @@ def test_macos_bootstrap_disabled_reports_metal_probe_only(monkeypatch):
     assert desktop_runtime_setup.DISABLE_BOOTSTRAP_ENV in result['fallback_reason']
     assert 'expected_backend=metal' in result['fallback_reason']
     assert invoked['pip'] is False
-
 
 
 def test_macos_bootstrap_disabled_missing_llama_cpp_fails_before_probe_only(monkeypatch):
@@ -965,7 +1011,6 @@ def test_fallback_unpinned_plans_cover_win_darwin_and_other_platforms():
     assert darwin_plans[2].only_binary is True
 
 
-
 def test_windows_source_repair_uses_dependency_target(monkeypatch, tmp_path):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
     requirements_path = tmp_path / 'requirements.txt'
@@ -1089,7 +1134,6 @@ def test_windows_source_repair_returns_actionable_message_when_requirement_is_in
     assert 'falling back to unpinned source reinstall' in reason
     assert str(invalid_requirements) in reason
     assert 'missing pinned llama-cpp-python requirement' in reason
-
 
 
 def test_install_error_summary_prefers_stderr_tail_when_command_is_long():

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -1895,3 +1895,51 @@ def test_windows_cuda_bootstrap_uses_cuda_target_without_macos_metal_branch(monk
     assert '--target' in captured['cmd']
     assert captured['cmd'][captured['cmd'].index('--target') + 1] == str(dependency_target)
     assert result['install_command_summary'].startswith('python -m pip install')
+
+
+def test_windows_cuda_source_repair_continues_when_qwen_64k_yarn_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
+    recorded_failures = []
+    monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', recorded_failures.append)
+    monkeypatch.setattr(desktop_runtime_setup, '_clear_source_repair_failure', lambda: None)
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_resolve_desktop_dependency_target',
+        lambda _root: (tmp_path / 'desktop-site', None),
+    )
+    probes = iter([
+        _probe(backend='cuda', gpu=True, device='cuda', yarn=False),
+        _probe(backend='cuda', gpu=True, device='cuda', yarn=False),
+    ])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    monkeypatch.setattr(desktop_runtime_setup, '_run_windows_cuda_source_repair', lambda *_args: (True, 'ok'))
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: [])
+    monkeypatch.setattr(desktop_runtime_setup, '_fallback_unpinned_plans', lambda _platform: [])
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime(
+        'auto', repo_root=tmp_path, context_tier='64k-full'
+    )
+
+    assert result['runtime_action'] == 'failed'
+    assert result['yarn_rope_supported'] == 'false'
+    assert 'Qwen 64K YaRN/RoPE support is still missing' in result['fallback_reason']
+    assert recorded_failures
+
+
+def test_qwen_64k_probe_only_fallback_reason_keeps_yarn_context(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.delenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, raising=False)
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_probe_llama_runtime',
+        lambda **_: _probe(backend='cuda', gpu=True, device='cuda', yarn=False),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime(
+        'auto', repo_root=tmp_path, context_tier='64k-full'
+    )
+
+    assert result['runtime_action'] == 'probe_only'
+    assert 'Qwen 64K requires YaRN/RoPE support' in result['fallback_reason']

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -2000,6 +2000,60 @@ def test_windows_cuda_source_repair_returns_reexec_when_qwen_64k_yarn_verified(m
     assert result['yarn_rope_supported'] == 'true'
 
 
+def test_qwen_64k_install_plan_continues_when_gpu_runtime_still_lacks_yarn(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    dependency_target = tmp_path / 'desktop-site'
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_resolve_desktop_dependency_target',
+        lambda _root: (dependency_target, None),
+    )
+    probes = iter([
+        _probe(backend='metal', gpu=True, device='metal', yarn=False),
+        _probe(backend='metal', gpu=True, device='metal', yarn=False),
+        _probe(backend='metal', gpu=True, device='metal', yarn=True, resolver='numeric_fallback'),
+    ])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    plans = [
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='darwin',
+            backend='metal',
+            package_spec='llama-cpp-python==0.3.31',
+            cmake_args='-DGGML_METAL=on',
+            force_cmake=True,
+            index_url='https://pypi.org/simple',
+            only_binary=False,
+            no_binary=True,
+        ),
+        desktop_runtime_setup.LlamaCppInstallPlan(
+            platform='darwin',
+            backend='metal',
+            package_spec='llama-cpp-python==0.3.32',
+            cmake_args='-DGGML_METAL=on',
+            force_cmake=True,
+            index_url='https://pypi.org/simple',
+            only_binary=False,
+            no_binary=True,
+        ),
+    ]
+    monkeypatch.setattr(desktop_runtime_setup, 'llama_cpp_install_plan_fallbacks', lambda **_kwargs: plans)
+    installs = []
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_run_pip_install',
+        lambda *args, **kwargs: (installs.append(args), 'ok') and (True, 'ok'),
+    )
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime(
+        'auto', repo_root=tmp_path, context_tier='64k-full'
+    )
+
+    assert len(installs) == 2
+    assert result['runtime_action'] == 'installed_metal_reexec'
+    assert result['yarn_rope_supported'] == 'true'
+
+
 def test_qwen_64k_probe_only_fallback_reason_keeps_yarn_context(monkeypatch, tmp_path):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
     monkeypatch.delenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, raising=False)

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -1321,6 +1321,42 @@ def test_probe_subprocess_sanitizes_repo_root_before_llama_import(monkeypatch):
     )
 
 
+def test_probe_subprocess_keeps_stdlib_ahead_of_polluted_dependency_target(monkeypatch, tmp_path):
+    runtime_root = tmp_path / 'resources'
+    (runtime_root / 'utils').mkdir(parents=True)
+    dependency_target = runtime_root / '.token_place_desktop_site'
+    llama_package = dependency_target / 'llama_cpp'
+    llama_package.mkdir(parents=True)
+    llama_package.joinpath('__init__.py').write_text(
+        '\n'.join(
+            [
+                '__version__ = "0.3.0"',
+                'GGML_METAL = True',
+                'LLAMA_ROPE_SCALING_TYPE_YARN = 2',
+                'def llama_supports_gpu_offload():',
+                '    return True',
+                'class Llama:',
+                '    def __init__(self, rope_scaling_type=None, yarn_ext_factor=None, yarn_orig_ctx=None):',
+                '        pass',
+            ]
+        ),
+        encoding='utf-8',
+    )
+    dependency_target.joinpath('pathlib.py').write_text(
+        'from collections import Sequence\n',
+        encoding='utf-8',
+    )
+    monkeypatch.setenv('TOKEN_PLACE_PYTHON_IMPORT_ROOT', str(runtime_root))
+
+    probe = desktop_runtime_setup._probe_llama_runtime(runtime_root=runtime_root)
+
+    assert probe.error is None
+    assert probe.backend == 'metal'
+    assert probe.gpu_offload_supported is True
+    assert probe.yarn_rope_supported is True
+    assert probe.llama_cpp_python_version == '0.3.0'
+
+
 def test_probe_falls_back_when_payload_is_not_json(monkeypatch):
     monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
 

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -1960,8 +1960,44 @@ def test_windows_cuda_source_repair_continues_when_qwen_64k_yarn_missing(monkeyp
 
     assert result['runtime_action'] == 'failed'
     assert result['yarn_rope_supported'] == 'false'
-    assert 'Qwen 64K YaRN/RoPE support is still missing' in result['fallback_reason']
+    assert (
+        'Qwen 64K requires YaRN/RoPE support in llama-cpp-python; runtime repair failed'
+        in result['fallback_reason']
+    )
+    assert 'resolver=unsupported' in result['fallback_reason']
+    assert 'version=0.3.16' in result['fallback_reason']
+    assert 'module=C:/Python/Lib/site-packages/llama_cpp/__init__.py' in result['fallback_reason']
+    assert 'rope_scaling_type_supported=False' in result['fallback_reason']
+    assert 'yarn_ext_factor_supported=False' in result['fallback_reason']
+    assert 'yarn_orig_ctx_supported=False' in result['fallback_reason']
     assert recorded_failures
+
+
+def test_windows_cuda_source_repair_returns_reexec_when_qwen_64k_yarn_verified(monkeypatch, tmp_path):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _SysStub)
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    monkeypatch.setattr(desktop_runtime_setup, '_should_attempt_source_repair', lambda: (True, ''))
+    monkeypatch.setattr(desktop_runtime_setup, '_record_source_repair_failure', lambda _reason: None)
+    monkeypatch.setattr(desktop_runtime_setup, '_clear_source_repair_failure', lambda: None)
+    monkeypatch.setattr(
+        desktop_runtime_setup,
+        '_resolve_desktop_dependency_target',
+        lambda _root: (tmp_path / 'desktop-site', None),
+    )
+    probes = iter([
+        _probe(backend='cuda', gpu=True, device='cuda', yarn=False),
+        _probe(backend='cuda', gpu=True, device='cuda', yarn=True, resolver='numeric_fallback'),
+    ])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    monkeypatch.setattr(desktop_runtime_setup, '_run_windows_cuda_source_repair', lambda *_args: (True, 'ok'))
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime(
+        'auto', repo_root=tmp_path, context_tier='64k-full'
+    )
+
+    assert result['runtime_action'] == 'installed_cuda_reexec'
+    assert result['selected_backend'] == 'cuda'
+    assert result['yarn_rope_supported'] == 'true'
 
 
 def test_qwen_64k_probe_only_fallback_reason_keeps_yarn_context(monkeypatch, tmp_path):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4607,9 +4607,7 @@ def test_qwen_64k_runtime_enables_yarn_kwargs(tmp_path):
     assert captured['yarn_orig_ctx'] == 32768
     assert manager.last_compute_diagnostics['rope_yarn_enabled'] is True
     assert manager.last_compute_diagnostics['rope_yarn_factor'] == 2.0
-    assert manager.last_compute_diagnostics['yarn_rope_enum_location'] == (
-        'llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN'
-    )
+    assert manager.last_compute_diagnostics['yarn_rope_enum_location'] == 'top_level_enum'
 
 
 def test_qwen_64k_runtime_resolves_nested_yarn_enum(tmp_path):
@@ -4648,9 +4646,7 @@ def test_qwen_64k_runtime_resolves_nested_yarn_enum(tmp_path):
         assert manager.get_llm_instance() is not None
 
     assert captured['rope_scaling_type'] == 2
-    assert manager.last_compute_diagnostics['yarn_rope_enum_location'] == (
-        'llama_cpp.llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN'
-    )
+    assert manager.last_compute_diagnostics['yarn_rope_enum_location'] == 'nested_enum'
 
 
 def test_qwen_64k_runtime_fails_when_yarn_kwargs_unsupported(tmp_path):
@@ -4682,12 +4678,13 @@ def test_qwen_64k_runtime_fails_when_yarn_kwargs_unsupported(tmp_path):
     assert 'active_profile_id=qwen3-8b-q4-k-m' in manager.last_runtime_init_error
     assert 'active_context_tier=64k-full' in manager.last_runtime_init_error
     assert 'llama_module_path=unknown' in manager.last_runtime_init_error
-    assert 'llama_cpp_python_version=unknown' in manager.last_runtime_init_error
+    assert 'llama_cpp_python_version=' in manager.last_runtime_init_error
     assert 'missing constructor kwargs' in manager.last_runtime_init_error
 
 
-def test_qwen_64k_runtime_fails_when_yarn_enum_constant_missing(tmp_path):
+def test_qwen_64k_runtime_uses_numeric_yarn_fallback_when_enum_constant_missing(tmp_path):
     from utils.context_profiles import apply_context_profile
+    captured = {}
     config = MagicMock(is_production=False)
     values = {
         'model.profile_id': 'qwen3-8b-q4-k-m',
@@ -4705,17 +4702,63 @@ def test_qwen_64k_runtime_fails_when_yarn_enum_constant_missing(tmp_path):
 
     class FakeLlama:
         def __init__(self, model_path, n_gpu_layers, n_ctx, verbose, rope_scaling_type, yarn_ext_factor, yarn_orig_ctx):
+            captured.update({
+                'n_ctx': n_ctx,
+                'rope_scaling_type': rope_scaling_type,
+                'yarn_ext_factor': yarn_ext_factor,
+                'yarn_orig_ctx': yarn_orig_ctx,
+            })
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+            return '<qwen>'
+
+    fake_llama_cpp = SimpleNamespace(
+        Llama=FakeLlama,
+        llama_cpp=SimpleNamespace(),
+        __file__='/opt/token.place/llama_cpp/__init__.py',
+    )
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama_cpp), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'cpu', 'gpu_offload_supported': False, 'error': None}):
+        assert manager.get_llm_instance() is not None
+
+    assert captured == {
+        'n_ctx': 65536,
+        'rope_scaling_type': 2,
+        'yarn_ext_factor': 2.0,
+        'yarn_orig_ctx': 32768,
+    }
+    assert manager.last_compute_diagnostics['yarn_rope_enum_location'] == 'numeric_fallback'
+    assert manager.last_yarn_rope_diagnostics['constructor_kwarg_support']['rope_scaling_type'] is True
+
+
+def test_qwen_64k_runtime_fails_when_yarn_enum_missing_and_constructor_lacks_rope_scaling(tmp_path):
+    from utils.context_profiles import apply_context_profile
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': 0,
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    class FakeLlama:
+        def __init__(self, model_path, n_gpu_layers, n_ctx, verbose, yarn_ext_factor, yarn_orig_ctx):
             pass
         def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
             return '<qwen>'
 
-    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=FakeLlama)), \
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=FakeLlama, llama_cpp=SimpleNamespace())), \
          patch.object(manager, '_runtime_capabilities', return_value={'backend': 'cpu', 'gpu_offload_supported': False, 'error': None}):
         assert manager.get_llm_instance() is None
 
     assert 'Qwen 64K requires YaRN/RoPE support in llama-cpp-python' in manager.last_runtime_init_error
-    assert 'missing LLAMA_ROPE_SCALING_TYPE_YARN enum constant' in manager.last_runtime_init_error
-
+    assert 'rope_scaling_type constructor support' in manager.last_runtime_init_error
 
 def test_qwen_validation_failure_does_not_cache_invalid_llm(tmp_path):
     config = MagicMock(is_production=False)

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4894,3 +4894,20 @@ def test_qwen_runtime_init_kwargs_rejects_non_gguf_jinja_policy(tmp_path):
 
     with pytest.raises(RuntimeError, match='GGUF/Jinja chat template policy'):
         manager._runtime_init_kwargs(FakeLlama, 0)
+
+
+def test_qwen_64k_missing_reason_does_not_repeat_rope_scaling_type():
+    from utils.llm import model_manager as model_manager_module
+
+    class FakeLlama:
+        def __init__(self, model_path, n_gpu_layers, n_ctx, verbose):
+            pass
+
+    diagnostics = model_manager_module._qwen_64k_rope_support_diagnostics(
+        SimpleNamespace(Llama=FakeLlama),
+        FakeLlama,
+    )
+
+    assert diagnostics['supported'] is False
+    assert diagnostics['missing_reason'].count('rope_scaling_type') == 1
+    assert 'missing constructor kwargs: yarn_ext_factor, yarn_orig_ctx' in diagnostics['missing_reason']

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4911,3 +4911,21 @@ def test_qwen_64k_missing_reason_does_not_repeat_rope_scaling_type():
     assert diagnostics['supported'] is False
     assert diagnostics['missing_reason'].count('rope_scaling_type') == 1
     assert 'missing constructor kwargs: yarn_ext_factor, yarn_orig_ctx' in diagnostics['missing_reason']
+
+
+def test_qwen_64k_diagnostics_mark_supported_when_required_yarn_kwargs_are_available():
+    from utils.llm import model_manager as model_manager_module
+
+    class FakeLlama:
+        def __init__(self, model_path, n_gpu_layers, n_ctx, verbose, rope_scaling_type, yarn_ext_factor, yarn_orig_ctx):
+            pass
+
+    diagnostics = model_manager_module._qwen_64k_rope_support_diagnostics(
+        SimpleNamespace(LLAMA_ROPE_SCALING_TYPE_YARN='yarn', Llama=FakeLlama),
+        FakeLlama,
+    )
+
+    assert diagnostics['supported'] is True
+    assert diagnostics['missing_reason'] is None
+    assert diagnostics['missing_required_kwargs'] == []
+    assert diagnostics['yarn_resolver_source'] == 'top_level_enum'

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -8,6 +8,7 @@ from utils.networking.http_requests_compat import requests
 import json
 import sys
 import importlib
+import importlib.metadata
 import inspect
 import subprocess
 import queue
@@ -31,6 +32,10 @@ QWEN_64K_YARN_UNSUPPORTED_MESSAGE = (
     'Qwen 64K requires YaRN/RoPE support in llama-cpp-python; '
     'update or rebuild the runtime'
 )
+# llama.cpp defines LLAMA_ROPE_SCALING_TYPE_YARN as 2. Some llama-cpp-python
+# wheels accept rope_scaling_type as a constructor kwarg but do not export the
+# generated enum symbol, so this is only used after constructor support is verified.
+LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK = 2
 
 CRITICAL_STDLIB_IMPORT_MODULES = (
     'collections',
@@ -61,28 +66,54 @@ def _constructor_accepts_kwarg(callable_obj: Any, kwarg: str) -> bool:
     )
 
 
-def _resolve_llama_cpp_rope_scaling_type_yarn(llama_cpp_module: Any, llama_cls: Any = None) -> tuple[Any, Optional[str]]:
-    """Resolve llama-cpp-python's YaRN enum from known safe exports.
+def _llama_constructor_supports_kwargs(llama_cls: Any, required_kwargs: Iterable[str]) -> Dict[str, bool]:
+    return {name: _constructor_accepts_kwarg(llama_cls, name) for name in required_kwargs}
 
-    Runtime inspection checks the supplied ``Llama.__init__`` signature and both
-    top-level and nested ``llama_cpp.llama_cpp`` constants.  Older
-    llama-cpp-python builds may not re-export the enum at the top level, while
-    newer generated bindings can expose it from the nested ctypes module.
+
+def _llama_cpp_python_version(llama_cpp_module: Any) -> Optional[str]:
+    module_version = getattr(llama_cpp_module, '__version__', None)
+    if module_version:
+        return str(module_version)
+    try:
+        return importlib.metadata.version('llama-cpp-python')
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _resolve_yarn_rope_scaling_type(llama_cpp_module: Any, llama_cls: Any = None) -> tuple[Any, str]:
+    """Resolve a YaRN RoPE scaling value from installed llama-cpp-python.
+
+    Prefer exported enum constants. If the runtime accepts the modern
+    ``rope_scaling_type`` constructor kwarg but simply omitted the Python enum
+    export, use llama.cpp's numeric YaRN value as a compatibility fallback.
     """
 
     locations = (
-        (llama_cpp_module, 'llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN'),
-        (getattr(llama_cpp_module, 'llama_cpp', None), 'llama_cpp.llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN'),
-        (llama_cls, 'Llama.LLAMA_ROPE_SCALING_TYPE_YARN'),
+        (llama_cpp_module, 'top_level_enum'),
+        (getattr(llama_cpp_module, 'llama_cpp', None), 'nested_enum'),
+        (llama_cls, 'llama_class_enum'),
     )
-    for owner, location in locations:
+    for owner, source in locations:
         if owner is None:
             continue
         value = getattr(owner, 'LLAMA_ROPE_SCALING_TYPE_YARN', None)
         if value is not None:
-            return value, location
-    return None, None
+            return value, source
 
+    if _constructor_accepts_kwarg(llama_cls, 'rope_scaling_type'):
+        return LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK, 'numeric_fallback'
+    return None, 'unsupported'
+
+
+def _resolve_llama_cpp_rope_scaling_type_yarn(llama_cpp_module: Any, llama_cls: Any = None) -> tuple[Any, Optional[str]]:
+    value, source = _resolve_yarn_rope_scaling_type(llama_cpp_module, llama_cls)
+    legacy_locations = {
+        'top_level_enum': 'llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN',
+        'nested_enum': 'llama_cpp.llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN',
+        'llama_class_enum': 'Llama.LLAMA_ROPE_SCALING_TYPE_YARN',
+        'numeric_fallback': 'numeric_fallback',
+    }
+    return value, legacy_locations.get(source)
 
 def _format_qwen_yarn_unsupported_diagnostics(diagnostics: Dict[str, Any]) -> str:
     safe_fields = (
@@ -91,6 +122,8 @@ def _format_qwen_yarn_unsupported_diagnostics(diagnostics: Dict[str, Any]) -> st
         'llama_module_path',
         'llama_cpp_python_version',
         'missing_reason',
+        'yarn_resolver_source',
+        'constructor_kwarg_support',
     )
     return ', '.join(
         f'{field}={diagnostics.get(field) or "unknown"}'
@@ -98,39 +131,43 @@ def _format_qwen_yarn_unsupported_diagnostics(diagnostics: Dict[str, Any]) -> st
     )
 
 
-def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> Dict[str, Any]:
-    accepted_kwargs = sorted(
-        name for name in (
-            'rope_scaling_type',
-            'yarn_ext_factor',
-            'yarn_attn_factor',
-            'yarn_beta_fast',
-            'yarn_beta_slow',
-            'yarn_orig_ctx',
-            'rope_freq_base',
-            'rope_freq_scale',
-        )
-        if _constructor_accepts_kwarg(llama_cls, name)
+def _qwen_64k_rope_support_diagnostics(llama_cpp_module: Any, llama_cls: Any) -> Dict[str, Any]:
+    probe_kwargs = (
+        'rope_scaling_type',
+        'yarn_ext_factor',
+        'yarn_attn_factor',
+        'yarn_beta_fast',
+        'yarn_beta_slow',
+        'yarn_orig_ctx',
+        'rope_freq_base',
+        'rope_freq_scale',
     )
-    yarn_value, yarn_location = _resolve_llama_cpp_rope_scaling_type_yarn(llama_cpp_module, llama_cls)
+    kwarg_support = _llama_constructor_supports_kwargs(llama_cls, probe_kwargs)
+    accepted_kwargs = sorted(name for name, supported in kwarg_support.items() if supported)
+    yarn_value, resolver_source = _resolve_yarn_rope_scaling_type(llama_cpp_module, llama_cls)
     required_kwargs = ('rope_scaling_type', 'yarn_ext_factor', 'yarn_orig_ctx')
-    missing_kwargs = [name for name in required_kwargs if name not in accepted_kwargs]
+    missing_kwargs = [name for name in required_kwargs if not kwarg_support.get(name)]
     missing_reasons = []
-    if yarn_location is None:
-        missing_reasons.append('missing LLAMA_ROPE_SCALING_TYPE_YARN enum constant')
+    if resolver_source == 'unsupported':
+        missing_reasons.append('missing LLAMA_ROPE_SCALING_TYPE_YARN enum constant and rope_scaling_type constructor support')
     if missing_kwargs:
         missing_reasons.append(f'missing constructor kwargs: {", ".join(missing_kwargs)}')
     return {
         'supported': not missing_reasons,
         'yarn_enum_value': yarn_value,
-        'yarn_enum_location': yarn_location,
+        'yarn_enum_location': resolver_source,
+        'yarn_resolver_source': resolver_source,
         'accepted_constructor_kwargs': accepted_kwargs,
+        'constructor_kwarg_support': kwarg_support,
         'missing_required_kwargs': missing_kwargs,
         'missing_reason': '; '.join(missing_reasons) if missing_reasons else None,
         'llama_module_path': getattr(llama_cpp_module, '__file__', None),
-        'llama_cpp_python_version': getattr(llama_cpp_module, '__version__', None),
+        'llama_cpp_python_version': _llama_cpp_python_version(llama_cpp_module),
     }
 
+
+def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> Dict[str, Any]:
+    return _qwen_64k_rope_support_diagnostics(llama_cpp_module, llama_cls)
 
 def _is_site_packages_path(path_text: Any) -> bool:
     normalized = str(path_text).replace('\\', '/').lower()
@@ -906,8 +943,6 @@ def _read_llama_subprocess_message(
     return message
 
 
-
-
 def _safe_worker_error_code(value: Any) -> str:
     text = str(value or '').strip().lower()
     if isinstance(value, LlamaCppWorkerDeadError):
@@ -1548,7 +1583,6 @@ for line in sys.stdin:
     except Exception as exc:
         _emit(_safe_request_error('inference_exception', request=request, exc=exc))
 """
-
 
 
 def _llama_cpp_package_parent_from_module_path(module_path: Any) -> Optional[str]:
@@ -2273,6 +2307,8 @@ class ModelManager:
             self.last_yarn_rope_diagnostics = {
                 'supported': yarn_probe['supported'],
                 'yarn_enum_location': yarn_probe['yarn_enum_location'],
+                'yarn_resolver_source': yarn_probe.get('yarn_resolver_source'),
+                'constructor_kwarg_support': yarn_probe.get('constructor_kwarg_support'),
                 'accepted_constructor_kwargs': yarn_probe['accepted_constructor_kwargs'],
                 'active_profile_id': self.profile_id,
                 'active_context_tier': context_tier,

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -150,8 +150,11 @@ def _qwen_64k_rope_support_diagnostics(llama_cpp_module: Any, llama_cls: Any) ->
     missing_reasons = []
     if resolver_source == 'unsupported':
         missing_reasons.append('missing LLAMA_ROPE_SCALING_TYPE_YARN enum constant and rope_scaling_type constructor support')
-    if missing_kwargs:
-        missing_reasons.append(f'missing constructor kwargs: {", ".join(missing_kwargs)}')
+        missing_kwargs_for_reason = [name for name in missing_kwargs if name != 'rope_scaling_type']
+    else:
+        missing_kwargs_for_reason = missing_kwargs
+    if missing_kwargs_for_reason:
+        missing_reasons.append(f'missing constructor kwargs: {", ".join(missing_kwargs_for_reason)}')
     return {
         'supported': not missing_reasons,
         'yarn_enum_value': yarn_value,


### PR DESCRIPTION
### Motivation
- Qwen 64K startup was brittle: node registration failed when the Python wrapper lacked an exported `LLAMA_ROPE_SCALING_TYPE_YARN` symbol even though the constructor accepted `rope_scaling_type`, and the packaged desktop bootstrap treated Metal import/offload as sufficient even when YaRN/RoPE support was missing.
- The change aims to allow packaged macOS desktop runtimes to run Qwen3 `64k-full` when the runtime truly supports YaRN via constructor kwargs, and to detect+repair stale packaged runtimes that lack YaRN support.

### Description
- Add robust YaRN/RoPE resolver and helpers in `utils/llm/model_manager.py`: `_llama_constructor_supports_kwargs`, `_llama_cpp_python_version`, `_resolve_yarn_rope_scaling_type`, `_qwen_64k_rope_support_diagnostics`, and keep the existing API via `_resolve_llama_cpp_rope_scaling_type_yarn` wrapper.  Introduce a documented numeric fallback constant `LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK = 2` used only after verifying constructor support.
- Apply Qwen 64K kwargs exactly and only when verified: set `n_ctx=65536`, `yarn_ext_factor=2.0`, `yarn_orig_ctx=32768`, and pass `rope_scaling_type` via resolved enum/numeric/string value while omitting unknown/unsupported kwargs; fail-closed if required constructor support is missing.
- Improve diagnostics: collect `llama-cpp-python` version, module path, resolver source (`top_level_enum`, `nested_enum`, `numeric_fallback`, `unsupported`), and constructor-kwarg support details and include them in safe error messages and runtime probe payloads.
- Teach desktop bootstrap to require YaRN for Qwen 64K: extend `desktop_runtime_setup.py` probe to surface YaRN capabilities, and change install/repair logic to treat Metal/CUDA import alone as insufficient for `64k-full` (deterministic reinstall/upgrade + re-probe when needed).
- Thread the selected context tier into desktop bootstrap: `compute_node_bridge.py` now passes `context_tier` into `ensure_desktop_llama_runtime` with a compatibility shim for older call sites.
- Add regression/unit tests that reproduce and cover the scenarios requested, including: top-level enum, nested enum, missing enum with numeric fallback when constructor supports `rope_scaling_type`, missing enum with constructor lacking `rope_scaling_type` (fail-closed), and desktop bootstrap reinstall behavior for stale Metal runtimes; tests updated in `tests/unit/test_model_manager.py` and `tests/unit/test_desktop_runtime_setup.py`.

### Testing
- Ran focused unit suites and new/modified tests: `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/unit/test_desktop_runtime_setup.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, `python -m pytest tests/unit/test_compute_node_runtime.py -q`, and `python -m pytest tests/unit/test_desktop_gpu_packaging.py -q`, and all passed locally after the changes.
- Exercised desktop bridge and integration smoke: `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` and `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, and these passed after adding the compatibility shim and probe updates.
- Ran repository checks: `pre-commit run --all-files` and `git diff --check` with no remaining issues.

Residual notes: this PR does not change UI state, context tier IDs, API v2, E2EE semantics, or model registrations unless YaRN/RoPE support is genuinely verified; follow-ups may be needed to pin `llama-cpp-python` only if packager constraints require a minimum wheel version for macOS Metal builds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45fffacf14832fb6437bc0510d0d3a)