### PR TITLE
Make YaRN/RoPE detection robust and repair stale desktop runtimes for Qwen 64K

### DIFF
--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -58,6 +58,12 @@ class RuntimeProbe:
     base_prefix: str = "unknown"
     dependency_target: str = "unknown"
     pip_version: str = "unknown"
+    llama_cpp_python_version: str = "unknown"
+    qwen_64k_yarn_supported: bool = False
+    yarn_resolver: str = "unsupported"
+    rope_scaling_type_supported: bool = False
+    yarn_ext_factor_supported: bool = False
+    yarn_orig_ctx_supported: bool = False
 
 
 GPU_MODES = frozenset({"auto", "gpu", "hybrid"})
@@ -102,7 +108,9 @@ _PROCESS_PYTHON_VERSION = sys.version.split()[0]
 
 _PROBE_SNIPPET = r"""
 import importlib
+import importlib.metadata
 import importlib.util
+import inspect
 import json
 import os
 import sys
@@ -118,6 +126,45 @@ def _strip_windows_extended_path_prefix(path_text):
 
 def _safe_resolve_path_text(path_text):
     return os.path.realpath(os.path.abspath(_strip_windows_extended_path_prefix(str(path_text))))
+
+def _accepts_kwarg(callable_obj, kwarg):
+    try:
+        init = getattr(callable_obj, "__init__", callable_obj)
+        params = inspect.signature(init).parameters
+    except Exception:
+        return False
+    return kwarg in params or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+def _version(module):
+    value = getattr(module, "__version__", None)
+    if value:
+        return str(value)
+    try:
+        return importlib.metadata.version("llama-cpp-python")
+    except Exception:
+        return "unknown"
+
+def _yarn_probe(module):
+    llama_cls = getattr(module, "Llama", None)
+    rope = _accepts_kwarg(llama_cls, "rope_scaling_type")
+    ext = _accepts_kwarg(llama_cls, "yarn_ext_factor")
+    orig = _accepts_kwarg(llama_cls, "yarn_orig_ctx")
+    if getattr(module, "LLAMA_ROPE_SCALING_TYPE_YARN", None) is not None:
+        resolver = "top_level_enum"
+    elif getattr(getattr(module, "llama_cpp", None), "LLAMA_ROPE_SCALING_TYPE_YARN", None) is not None:
+        resolver = "nested_enum"
+    elif rope:
+        resolver = "numeric_fallback"
+    else:
+        resolver = "unsupported"
+    return {
+        "llama_cpp_python_version": _version(module),
+        "qwen_64k_yarn_supported": bool(resolver != "unsupported" and rope and ext and orig),
+        "yarn_resolver": resolver,
+        "rope_scaling_type_supported": bool(rope),
+        "yarn_ext_factor_supported": bool(ext),
+        "yarn_orig_ctx_supported": bool(orig),
+    }
 
 python_root = os.environ.get("TOKEN_PLACE_DESKTOP_PYTHON_ROOT", "").strip()
 if python_root and python_root not in sys.path:
@@ -196,6 +243,7 @@ try:
         "dependency_target": dependency_target or "unknown",
         "pip_version": os.environ.get("TOKEN_PLACE_DESKTOP_PIP_VERSION", "unknown"),
         "llama_module_path": llama_module_path or "unknown",
+        **_yarn_probe(llama_cpp),
         "error": None,
     }
 except Exception as exc:
@@ -210,6 +258,12 @@ except Exception as exc:
         "dependency_target": dependency_target or "unknown",
         "pip_version": os.environ.get("TOKEN_PLACE_DESKTOP_PIP_VERSION", "unknown"),
         "llama_module_path": "missing",
+        "llama_cpp_python_version": "unknown",
+        "qwen_64k_yarn_supported": False,
+        "yarn_resolver": "unsupported",
+        "rope_scaling_type_supported": False,
+        "yarn_ext_factor_supported": False,
+        "yarn_orig_ctx_supported": False,
         "error": str(exc),
     }
 
@@ -362,6 +416,12 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
         base_prefix=str(payload.get("base_prefix", getattr(sys, "base_prefix", sys.prefix))),
         dependency_target=str(payload.get("dependency_target", dependency_target_text)),
         pip_version=str(payload.get("pip_version", pip_version)),
+        llama_cpp_python_version=str(payload.get("llama_cpp_python_version", "unknown")),
+        qwen_64k_yarn_supported=bool(payload.get("qwen_64k_yarn_supported", False)),
+        yarn_resolver=str(payload.get("yarn_resolver", "unsupported")),
+        rope_scaling_type_supported=bool(payload.get("rope_scaling_type_supported", False)),
+        yarn_ext_factor_supported=bool(payload.get("yarn_ext_factor_supported", False)),
+        yarn_orig_ctx_supported=bool(payload.get("yarn_orig_ctx_supported", False)),
     )
 
 
@@ -593,6 +653,12 @@ def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, str]:
         "interpreter_prefix": probe.prefix,
         "dependency_target": probe.dependency_target,
         "pip_version": probe.pip_version,
+        "llama_cpp_python_version": probe.llama_cpp_python_version,
+        "qwen_64k_yarn_supported": str(probe.qwen_64k_yarn_supported).lower(),
+        "yarn_resolver": probe.yarn_resolver,
+        "rope_scaling_type_supported": str(probe.rope_scaling_type_supported).lower(),
+        "yarn_ext_factor_supported": str(probe.yarn_ext_factor_supported).lower(),
+        "yarn_orig_ctx_supported": str(probe.yarn_orig_ctx_supported).lower(),
         "llama_module_path": probe.llama_module_path,
     }
 
@@ -812,7 +878,23 @@ def _resolve_requirements_path(target_root: Path) -> Path:
     return candidates[0]
 
 
-def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] = None) -> Dict[str, str]:
+def _requires_qwen_64k_yarn(context_tier: Optional[str]) -> bool:
+    tier = (
+        context_tier
+        or os.getenv("TOKEN_PLACE_CONTEXT_TIER")
+        or os.getenv("TOKEN_PLACE_DESKTOP_CONTEXT_TIER")
+        or ""
+    ).strip()
+    return tier == "64k-full"
+
+
+def _qwen_64k_probe_satisfied(probe: RuntimeProbe, context_tier: Optional[str]) -> bool:
+    return (not _requires_qwen_64k_yarn(context_tier)) or probe.qwen_64k_yarn_supported
+
+
+def _ensure_desktop_llama_runtime_impl(
+    mode: str, *, repo_root: Optional[Path] = None, context_tier: Optional[str] = None
+) -> Dict[str, str]:
     """Ensure the sidecar interpreter has a GPU-capable runtime when mode prefers GPU."""
 
     selected_mode = (mode or "auto").strip().lower()
@@ -840,7 +922,11 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
             **_probe_result_payload(before),
         }
 
-    if before.gpu_offload_supported and before.backend in {"cuda", "metal"}:
+    if (
+        before.gpu_offload_supported
+        and before.backend in {"cuda", "metal"}
+        and _qwen_64k_probe_satisfied(before, context_tier)
+    ):
         return {
             "selected_backend": before.backend,
             "fallback_reason": "",
@@ -994,7 +1080,8 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
         plan_satisfied = backend_probe_satisfies_install_plan(plan, after)
         verified_backend = after.gpu_offload_supported and after.backend == plan.backend
         accepted_source_probe = plan_satisfied and after.backend != plan.backend
-        if plan.backend in {"cuda", "metal"} and (verified_backend or accepted_source_probe):
+        qwen_capable = _qwen_64k_probe_satisfied(after, context_tier)
+        if plan.backend in {"cuda", "metal"} and (verified_backend or accepted_source_probe) and qwen_capable:
             if verified_backend:
                 reason = f"installed {after.backend.upper()} runtime; re-executing sidecar"
                 selected_backend = plan.backend
@@ -1100,11 +1187,13 @@ def _record_desktop_runtime_probe(result: Dict[str, str]) -> Dict[str, str]:
     return result
 
 
-def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None) -> Dict[str, str]:
+def ensure_desktop_llama_runtime(
+    mode: str, *, repo_root: Optional[Path] = None, context_tier: Optional[str] = None
+) -> Dict[str, str]:
     """Ensure the sidecar interpreter has a GPU-capable runtime when mode prefers GPU."""
 
     return _record_desktop_runtime_probe(
-        _ensure_desktop_llama_runtime_impl(mode, repo_root=repo_root)
+        _ensure_desktop_llama_runtime_impl(mode, repo_root=repo_root, context_tier=context_tier)
     )
 
 

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -1851,3 +1851,48 @@ def test_windows_cuda_bootstrap_uses_cuda_target_without_macos_metal_branch(monk
     assert '--target' in captured['cmd']
     assert captured['cmd'][captured['cmd'].index('--target') + 1] == str(dependency_target)
     assert result['install_command_summary'].startswith('python -m pip install')
+
+
+def test_macos_metal_already_supported_not_enough_for_qwen_64k(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    monkeypatch.setenv(desktop_runtime_setup.ENABLE_BOOTSTRAP_ENV, '1')
+    probes = iter([
+        _probe(backend='metal', gpu=True, device='metal'),
+        desktop_runtime_setup.RuntimeProbe(
+            backend='metal', gpu_offload_supported=True, detected_device='metal',
+            interpreter=sys.executable, prefix=sys.prefix,
+            llama_module_path='/site/llama_cpp/__init__.py',
+            qwen_64k_yarn_supported=True, yarn_resolver='numeric_fallback',
+            rope_scaling_type_supported=True, yarn_ext_factor_supported=True,
+            yarn_orig_ctx_supported=True,
+        ),
+    ])
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: next(probes))
+    monkeypatch.setattr(desktop_runtime_setup, '_resolve_desktop_dependency_target', lambda _root: (REPO_ROOT, None))
+    monkeypatch.setattr(desktop_runtime_setup, '_run_pip_install', lambda *_, **__: (True, 'ok'))
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT, context_tier='64k-full')
+
+    assert result['runtime_action'] == 'installed_metal_reexec'
+    assert result['qwen_64k_yarn_supported'] == 'true'
+    assert result['yarn_resolver'] == 'numeric_fallback'
+    os.environ.pop(desktop_runtime_setup.RUNTIME_PROBE_ENV, None)
+
+
+def test_macos_metal_qwen_64k_yarn_supported_skips_reinstall(monkeypatch):
+    monkeypatch.setattr(desktop_runtime_setup, 'sys', _PlatformStub('darwin'))
+    probe = desktop_runtime_setup.RuntimeProbe(
+        backend='metal', gpu_offload_supported=True, detected_device='metal',
+        interpreter=sys.executable, prefix=sys.prefix,
+        llama_module_path='/site/llama_cpp/__init__.py',
+        qwen_64k_yarn_supported=True, yarn_resolver='top_level_enum',
+        rope_scaling_type_supported=True, yarn_ext_factor_supported=True,
+        yarn_orig_ctx_supported=True,
+    )
+    monkeypatch.setattr(desktop_runtime_setup, '_probe_llama_runtime', lambda **_: probe)
+
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=REPO_ROOT, context_tier='64k-full')
+
+    assert result['runtime_action'] == 'metal_already_supported'
+    assert result['qwen_64k_yarn_supported'] == 'true'
+    os.environ.pop(desktop_runtime_setup.RUNTIME_PROBE_ENV, None)

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4682,11 +4682,11 @@ def test_qwen_64k_runtime_fails_when_yarn_kwargs_unsupported(tmp_path):
     assert 'active_profile_id=qwen3-8b-q4-k-m' in manager.last_runtime_init_error
     assert 'active_context_tier=64k-full' in manager.last_runtime_init_error
     assert 'llama_module_path=unknown' in manager.last_runtime_init_error
-    assert 'llama_cpp_python_version=unknown' in manager.last_runtime_init_error
+    assert 'llama_cpp_python_version=' in manager.last_runtime_init_error
     assert 'missing constructor kwargs' in manager.last_runtime_init_error
 
 
-def test_qwen_64k_runtime_fails_when_yarn_enum_constant_missing(tmp_path):
+def test_qwen_64k_runtime_uses_numeric_fallback_when_yarn_enum_constant_missing(tmp_path):
     from utils.context_profiles import apply_context_profile
     config = MagicMock(is_production=False)
     values = {
@@ -4711,10 +4711,10 @@ def test_qwen_64k_runtime_fails_when_yarn_enum_constant_missing(tmp_path):
 
     with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=FakeLlama)), \
          patch.object(manager, '_runtime_capabilities', return_value={'backend': 'cpu', 'gpu_offload_supported': False, 'error': None}):
-        assert manager.get_llm_instance() is None
+        assert manager.get_llm_instance() is not None
 
-    assert 'Qwen 64K requires YaRN/RoPE support in llama-cpp-python' in manager.last_runtime_init_error
-    assert 'missing LLAMA_ROPE_SCALING_TYPE_YARN enum constant' in manager.last_runtime_init_error
+    assert manager.last_yarn_rope_diagnostics['yarn_resolver'] == 'numeric_fallback'
+    assert manager.last_compute_diagnostics['yarn_rope_enum_location'] == 'numeric_fallback'
 
 
 def test_qwen_validation_failure_does_not_cache_invalid_llm(tmp_path):

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -8,6 +8,7 @@ from utils.networking.http_requests_compat import requests
 import json
 import sys
 import importlib
+import importlib.metadata
 import inspect
 import subprocess
 import queue
@@ -29,8 +30,13 @@ REPO_LLAMA_CPP_SHIM = (REPO_ROOT / 'llama_cpp.py').resolve()
 DEFAULT_LLAMA_CPP_RUNTIME_STAGE_TIMEOUT_SECONDS = 30.0
 QWEN_64K_YARN_UNSUPPORTED_MESSAGE = (
     'Qwen 64K requires YaRN/RoPE support in llama-cpp-python; '
-    'update or rebuild the runtime'
+    'runtime repair failed'
 )
+# llama.cpp's enum value for LLAMA_ROPE_SCALING_TYPE_YARN.  Some
+# llama-cpp-python wheels accept the constructor kwarg but do not export the
+# generated Python enum symbol, so use this only after constructor support is
+# verified.
+LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK = 2
 
 CRITICAL_STDLIB_IMPORT_MODULES = (
     'collections',
@@ -61,28 +67,58 @@ def _constructor_accepts_kwarg(callable_obj: Any, kwarg: str) -> bool:
     )
 
 
-def _resolve_llama_cpp_rope_scaling_type_yarn(llama_cpp_module: Any, llama_cls: Any = None) -> tuple[Any, Optional[str]]:
-    """Resolve llama-cpp-python's YaRN enum from known safe exports.
+def _llama_constructor_supports_kwargs(llama_cls: Any, required_kwargs: Iterable[str]) -> Dict[str, bool]:
+    return {name: _constructor_accepts_kwarg(llama_cls, name) for name in required_kwargs}
 
-    Runtime inspection checks the supplied ``Llama.__init__`` signature and both
-    top-level and nested ``llama_cpp.llama_cpp`` constants.  Older
-    llama-cpp-python builds may not re-export the enum at the top level, while
-    newer generated bindings can expose it from the nested ctypes module.
+
+def _llama_cpp_python_version(llama_cpp_module: Any) -> Optional[str]:
+    version = getattr(llama_cpp_module, '__version__', None)
+    if version:
+        return str(version)
+    try:
+        return importlib.metadata.version('llama-cpp-python')
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _resolve_yarn_rope_scaling_type(llama_cpp_module: Any, llama_cls: Any = None) -> tuple[Any, str]:
+    """Resolve the YaRN scaling type from safe runtime evidence.
+
+    Prefer exported llama-cpp-python constants.  If a build omits those generated
+    Python symbols but its constructor accepts ``rope_scaling_type``, fall back to
+    llama.cpp's stable YaRN enum value.  This avoids rejecting capable packaged
+    runtimes solely because the binding did not re-export the enum constant.
     """
 
-    locations = (
-        (llama_cpp_module, 'llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN'),
-        (getattr(llama_cpp_module, 'llama_cpp', None), 'llama_cpp.llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN'),
-        (llama_cls, 'Llama.LLAMA_ROPE_SCALING_TYPE_YARN'),
-    )
-    for owner, location in locations:
-        if owner is None:
-            continue
-        value = getattr(owner, 'LLAMA_ROPE_SCALING_TYPE_YARN', None)
-        if value is not None:
-            return value, location
-    return None, None
+    top_level = getattr(llama_cpp_module, 'LLAMA_ROPE_SCALING_TYPE_YARN', None)
+    if top_level is not None:
+        return top_level, 'top_level_enum'
 
+    nested = getattr(getattr(llama_cpp_module, 'llama_cpp', None), 'LLAMA_ROPE_SCALING_TYPE_YARN', None)
+    if nested is not None:
+        return nested, 'nested_enum'
+
+    for wrapper_name in ('llama_rope_scaling_type', 'LLAMA_ROPE_SCALING_TYPE'):
+        wrapper = getattr(llama_cpp_module, wrapper_name, None)
+        value = getattr(wrapper, 'LLAMA_ROPE_SCALING_TYPE_YARN', None) if wrapper is not None else None
+        if value is not None:
+            return value, f'enum_wrapper:{wrapper_name}'
+
+    if llama_cls is not None and _constructor_accepts_kwarg(llama_cls, 'rope_scaling_type'):
+        return LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK, 'numeric_fallback'
+
+    return None, 'unsupported'
+
+
+def _resolve_llama_cpp_rope_scaling_type_yarn(llama_cpp_module: Any, llama_cls: Any = None) -> tuple[Any, Optional[str]]:
+    value, source = _resolve_yarn_rope_scaling_type(llama_cpp_module, llama_cls)
+    legacy_locations = {
+        'top_level_enum': 'llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN',
+        'nested_enum': 'llama_cpp.llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN',
+        'numeric_fallback': 'numeric_fallback',
+        'unsupported': None,
+    }
+    return value, legacy_locations.get(source, source)
 
 def _format_qwen_yarn_unsupported_diagnostics(diagnostics: Dict[str, Any]) -> str:
     safe_fields = (
@@ -91,6 +127,8 @@ def _format_qwen_yarn_unsupported_diagnostics(diagnostics: Dict[str, Any]) -> st
         'llama_module_path',
         'llama_cpp_python_version',
         'missing_reason',
+        'yarn_resolver',
+        'constructor_kwarg_support',
     )
     return ', '.join(
         f'{field}={diagnostics.get(field) or "unknown"}'
@@ -98,39 +136,46 @@ def _format_qwen_yarn_unsupported_diagnostics(diagnostics: Dict[str, Any]) -> st
     )
 
 
-def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> Dict[str, Any]:
-    accepted_kwargs = sorted(
-        name for name in (
-            'rope_scaling_type',
-            'yarn_ext_factor',
-            'yarn_attn_factor',
-            'yarn_beta_fast',
-            'yarn_beta_slow',
-            'yarn_orig_ctx',
-            'rope_freq_base',
-            'rope_freq_scale',
-        )
-        if _constructor_accepts_kwarg(llama_cls, name)
+def _qwen_64k_rope_support_diagnostics(llama_cpp_module: Any, llama_cls: Any) -> Dict[str, Any]:
+    qwen_kwargs = (
+        'rope_scaling_type',
+        'yarn_ext_factor',
+        'yarn_attn_factor',
+        'yarn_beta_fast',
+        'yarn_beta_slow',
+        'yarn_orig_ctx',
+        'rope_freq_base',
+        'rope_freq_scale',
     )
-    yarn_value, yarn_location = _resolve_llama_cpp_rope_scaling_type_yarn(llama_cpp_module, llama_cls)
+    kwarg_support = _llama_constructor_supports_kwargs(llama_cls, qwen_kwargs)
+    accepted_kwargs = sorted(name for name, accepted in kwarg_support.items() if accepted)
+    yarn_value, resolver = _resolve_yarn_rope_scaling_type(llama_cpp_module, llama_cls)
     required_kwargs = ('rope_scaling_type', 'yarn_ext_factor', 'yarn_orig_ctx')
-    missing_kwargs = [name for name in required_kwargs if name not in accepted_kwargs]
+    missing_kwargs = [name for name in required_kwargs if not kwarg_support.get(name)]
     missing_reasons = []
-    if yarn_location is None:
-        missing_reasons.append('missing LLAMA_ROPE_SCALING_TYPE_YARN enum constant')
+    if resolver == 'unsupported':
+        missing_reasons.append('missing LLAMA_ROPE_SCALING_TYPE_YARN enum constant and rope_scaling_type constructor support')
     if missing_kwargs:
         missing_reasons.append(f'missing constructor kwargs: {", ".join(missing_kwargs)}')
     return {
         'supported': not missing_reasons,
         'yarn_enum_value': yarn_value,
-        'yarn_enum_location': yarn_location,
+        'yarn_enum_location': {
+            'top_level_enum': 'llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN',
+            'nested_enum': 'llama_cpp.llama_cpp.LLAMA_ROPE_SCALING_TYPE_YARN',
+        }.get(resolver, resolver),
+        'yarn_resolver': resolver,
         'accepted_constructor_kwargs': accepted_kwargs,
+        'constructor_kwarg_support': kwarg_support,
         'missing_required_kwargs': missing_kwargs,
         'missing_reason': '; '.join(missing_reasons) if missing_reasons else None,
         'llama_module_path': getattr(llama_cpp_module, '__file__', None),
-        'llama_cpp_python_version': getattr(llama_cpp_module, '__version__', None),
+        'llama_cpp_python_version': _llama_cpp_python_version(llama_cpp_module),
     }
 
+
+def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> Dict[str, Any]:
+    return _qwen_64k_rope_support_diagnostics(llama_cpp_module, llama_cls)
 
 def _is_site_packages_path(path_text: Any) -> bool:
     normalized = str(path_text).replace('\\', '/').lower()
@@ -2273,7 +2318,9 @@ class ModelManager:
             self.last_yarn_rope_diagnostics = {
                 'supported': yarn_probe['supported'],
                 'yarn_enum_location': yarn_probe['yarn_enum_location'],
+                'yarn_resolver': yarn_probe.get('yarn_resolver'),
                 'accepted_constructor_kwargs': yarn_probe['accepted_constructor_kwargs'],
+                'constructor_kwarg_support': yarn_probe.get('constructor_kwarg_support'),
                 'active_profile_id': self.profile_id,
                 'active_context_tier': context_tier,
                 'requested_n_ctx': n_ctx,


### PR DESCRIPTION
### Motivation
- Qwen3 `64k-full` startup on macOS was blocked by brittle detection that hard-failed when `LLAMA_ROPE_SCALING_TYPE_YARN` was not exported, even though some builds accept the `rope_scaling_type` constructor kwarg. 
- The desktop bootstrap erroneously treated Metal availability as sufficient even when YaRN/RoPE support required by Qwen 64K was missing, so packaged runtimes needed deterministic repair logic. 

### Description
- Add robust YaRN/RoPE resolver and helpers in `utils/llm/model_manager.py` including `_resolve_yarn_rope_scaling_type`, `_llama_constructor_supports_kwargs`, `_llama_cpp_python_version`, and `_qwen_64k_rope_support_diagnostics`, plus a documented numeric fallback constant `LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK = 2`. 
- Use the resolver when building Qwen runtime kwargs so numeric/string fallback is applied only when constructor kwarg support is verified and fail-closed otherwise, and surface richer diagnostics (`yarn_resolver`, `constructor_kwarg_support`, `llama_cpp_python_version`, module path). 
- Teach desktop bootstrap (`desktop-tauri/src-tauri/python/desktop_runtime_setup.py`) to probe and report YaRN capability, to treat Metal-only probes as insufficient for active Qwen `64k-full`, and to trigger deterministic reinstall/upgrade plans when the runtime lacks YaRN support. 
- Add/adjust unit tests to regress the missing-enum failure and exercise: top-level enum, nested enum, missing-enum with constructor-support numeric fallback, fail-closed when constructor kwargs are absent, and desktop stale-runtime reinstall/skip behavior. 

### Testing
- Ran unit and focused suites locally: `python -m pytest tests/unit/ -q` and `python -m pytest tests/unit/test_model_manager.py -q` and `python -m pytest tests/unit/test_desktop_runtime_setup.py -q`, all passed. 
- Ran integration guard: `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, which passed. 
- Ran repository checks: `pre-commit run --all-files` and `pre-commit run run-checks --all-files`, both completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45ffed4e84832f8f9758c671757a23)