### PR TITLE
Fix Qwen 64K completion-smoke diagnostics and add conservative 64K KV profile

### DIFF
--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -4,6 +4,7 @@ from unittest.mock import call, MagicMock
 
 import pytest
 
+from utils.llm.model_manager import LlamaCppInferenceRequestError
 from utils.compute_node_runtime import (
     ApiV1RelayRequestAdapter,
     apply_compute_mode,
@@ -833,7 +834,106 @@ def test_compute_node_runtime_readiness_smoke_completion_records_safe_exception(
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
     assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_exception"
     assert diagnostics["api_v1_readiness_completion_smoke_exception_type"] == "RuntimeError"
+    assert diagnostics["api_v1_readiness_completion_smoke_exception_category"] == "unknown_generation_exception"
     assert "prompt text" not in str(diagnostics)
+
+
+def test_compute_node_runtime_qwen_64k_smoke_classifies_worker_kv_failure(monkeypatch):
+    class RaisingRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 42}
+
+        def create_chat_completion(self, **_kwargs):
+            raise LlamaCppInferenceRequestError(
+                "llama_cpp request failed",
+                diagnostics={
+                    "reason": "inference_exception",
+                    "category": "kv_cache_allocation",
+                    "exception_type": "RuntimeError",
+                    "error_summary": "llama_kv_cache_init failed to allocate cache",
+                },
+            )
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", "1")
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "profile_id": "qwen3-8b-q4-k-m",
+        "native_context_tokens": 32768,
+        "rope_scaling_policy": {
+            "type": "yarn",
+            "required_for_tier": "64k-full",
+            "factor": 2.0,
+            "original_context_tokens": 32768,
+        },
+    }
+    model_manager.context_tier = "64k-full"
+    model_manager.context_window_tokens = 65536
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {
+        "qwen_64k_kv_cache_profile": {"type_k": "q8_0", "type_v": "q8_0", "flash_attn": True},
+        "backend_used": "metal",
+    }
+    model_manager.last_yarn_rope_diagnostics = {
+        "supported": True,
+        "yarn_resolver_source": "top_level_enum",
+        "llama_cpp_python_version": "0.3.32",
+        "missing_reason": None,
+    }
+    model_manager.get_llm_instance.return_value = RaisingRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(
+            _api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 42)
+        ),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_prompt_tokens"] == 42
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_kv_cache_allocation"
+    assert diagnostics["api_v1_readiness_completion_smoke_exception_category"] == "kv_cache_allocation"
+    assert diagnostics["api_v1_readiness_kv_cache_profile"]["type_k"] == "q8_0"
+
+
+def test_compute_node_runtime_qwen_64k_smoke_classifies_yarn_eval_failure(monkeypatch):
+    class RaisingRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 42}
+
+        def create_chat_completion(self, **_kwargs):
+            raise RuntimeError("RoPE YaRN eval failed before token generation")
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", "1")
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "rope_scaling_policy": {"type": "yarn", "required_for_tier": "64k-full", "factor": 2.0, "original_context_tokens": 32768},
+    }
+    model_manager.context_tier = "64k-full"
+    model_manager.context_window_tokens = 65536
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.last_yarn_rope_diagnostics = {"supported": True, "yarn_resolver_source": "numeric_fallback"}
+    model_manager.get_llm_instance.return_value = RaisingRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(_api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 42)),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_rope_yarn_eval_failure"
+    assert diagnostics["api_v1_readiness_completion_smoke_exception_category"] == "rope_yarn_eval_failure"
+
 
 @pytest.mark.parametrize(
     "llm_instance,getter,expected",

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 # Import the module to test
+from utils.llm import model_manager as model_manager_module
 from utils.llm.model_manager import ModelManager
 
 
@@ -4929,3 +4930,103 @@ def test_qwen_64k_diagnostics_mark_supported_when_required_yarn_kwargs_are_avail
     assert diagnostics['missing_reason'] is None
     assert diagnostics['missing_required_kwargs'] == []
     assert diagnostics['yarn_resolver_source'] == 'top_level_enum'
+
+
+def test_qwen_64k_runtime_applies_conservative_kv_cache_profile(tmp_path):
+    from utils.context_profiles import apply_context_profile
+
+    captured = {}
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': 0,
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    class FakeLlama:
+        def __init__(self, model_path, n_gpu_layers, n_ctx, verbose, rope_scaling_type, yarn_ext_factor, yarn_orig_ctx, type_k, type_v, flash_attn, offload_kqv, n_batch, n_ubatch):
+            captured.update({
+                'type_k': type_k,
+                'type_v': type_v,
+                'flash_attn': flash_attn,
+                'offload_kqv': offload_kqv,
+                'n_batch': n_batch,
+                'n_ubatch': n_ubatch,
+                'n_ctx': n_ctx,
+            })
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+            return '<qwen>'
+
+    fake_llama_cpp = SimpleNamespace(
+        Llama=FakeLlama,
+        LLAMA_ROPE_SCALING_TYPE_YARN=2,
+        __file__='/opt/token.place/llama_cpp/__init__.py',
+        __version__='0.3.32',
+    )
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama_cpp), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'metal', 'gpu_offload_supported': True, 'error': None}):
+        assert manager.get_llm_instance() is not None
+
+    assert captured['n_ctx'] == 65536
+    assert captured['type_k'] == 'q8_0'
+    assert captured['type_v'] == 'q8_0'
+    assert captured['flash_attn'] is True
+    assert manager.last_compute_diagnostics['qwen_64k_kv_cache_profile']['type_k'] == 'q8_0'
+    assert manager.last_compute_diagnostics['qwen_64k_kv_cache_profile_active'] is True
+
+
+def test_qwen_8k_runtime_does_not_apply_64k_kv_cache_profile(tmp_path):
+    config = MagicMock(is_production=False)
+    config.get.side_effect = lambda key, default=None: {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': 0,
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }.get(key, default)
+    manager = ModelManager(config)
+    Path(manager.model_path).write_text('fake')
+
+    class FakeLlama:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+            return '<qwen>'
+
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=SimpleNamespace(Llama=FakeLlama)), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'metal', 'gpu_offload_supported': True, 'error': None}):
+        llm = manager.get_llm_instance()
+
+    assert 'type_k' not in llm.kwargs
+    assert manager.last_compute_diagnostics['qwen_64k_kv_cache_profile'] == {}
+    assert manager.last_compute_diagnostics['qwen_64k_kv_cache_profile_active'] is False
+
+
+def test_generation_exception_classifier_detects_unsupported_internal_kwarg():
+    exc = model_manager_module.LlamaCppInferenceRequestError(
+        'llama_cpp request failed',
+        diagnostics={
+            'reason': 'unsupported_generation_option',
+            'category': 'unsupported_generation_kwarg',
+            'exception_type': 'TypeError',
+            'rejected_option': 'stream',
+            'error_summary': "got an unexpected keyword argument 'stream'",
+        },
+    )
+
+    diagnostics = model_manager_module.classify_generation_exception(exc)
+
+    assert diagnostics['category'] == 'unsupported_generation_kwarg'
+    assert diagnostics['rejected_option'] == 'stream'
+    assert model_manager_module.runtime_completion_smoke_reason_for_category(diagnostics['category']) == 'runtime_completion_smoke_unsupported_generation_kwarg'

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Protocol,
 from urllib.parse import urlparse
 
 from utils.processing_result import RelayProcessingResult
+from utils.llm.model_manager import classify_generation_exception, runtime_completion_smoke_reason_for_category
 
 if TYPE_CHECKING:
     from utils.networking.relay_client import RelayClient
@@ -440,6 +441,11 @@ class ComputeNodeRuntime:
             "api_v1_readiness_yarn_original_context_tokens": rope_policy.get(
                 "original_context_tokens"
             ),
+            "api_v1_readiness_yarn_rope_resolver_source": yarn_diagnostics.get("yarn_resolver_source"),
+            "api_v1_readiness_llama_cpp_python_version": yarn_diagnostics.get("llama_cpp_python_version"),
+            "api_v1_readiness_kv_cache_profile": diagnostics.get("qwen_64k_kv_cache_profile"),
+            "api_v1_readiness_backend_used": diagnostics.get("backend_used"),
+            "api_v1_readiness_backend_offload_mode": diagnostics.get("effective_mode"),
         })
 
         yarn_required_for_active_tier = (
@@ -561,14 +567,21 @@ class ComputeNodeRuntime:
                     }
             except Exception as exc:
                 admitted = False
+                safe_exception = classify_generation_exception(exc)
+                smoke_reason = runtime_completion_smoke_reason_for_category(safe_exception.get("category"))
                 admission_error = {
                     "code": "compute_node_context_admission_unavailable",
-                    "internal_reason": "runtime_completion_smoke_exception",
+                    "internal_reason": smoke_reason,
                 }
                 diagnostics["api_v1_readiness_completion_smoke_result"] = "failed"
-                diagnostics["api_v1_readiness_completion_smoke_failure_reason"] = "runtime_completion_smoke_exception"
+                diagnostics["api_v1_readiness_completion_smoke_failure_reason"] = smoke_reason
                 diagnostics["api_v1_readiness_completion_smoke_shape"] = "exception"
-                diagnostics["api_v1_readiness_completion_smoke_exception_type"] = type(exc).__name__
+                diagnostics["api_v1_readiness_completion_smoke_exception_type"] = safe_exception.get("exception_type")
+                diagnostics["api_v1_readiness_completion_smoke_exception_category"] = safe_exception.get("category")
+                diagnostics["api_v1_readiness_completion_smoke_safe_error_summary"] = safe_exception.get("safe_error_summary")
+                diagnostics["api_v1_readiness_completion_smoke_worker_diagnostics"] = safe_exception
+                diagnostics["api_v1_readiness_repair_attempted"] = False
+                diagnostics["api_v1_readiness_recovery_succeeded"] = False
             diagnostics["api_v1_runtime_ready"] = bool(admitted)
             diagnostics["api_v1_readiness_result"] = "passed" if admitted else "failed"
             diagnostics["api_v1_readiness_error_code"] = (admission_error or {}).get("code") if not admitted else None

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -6,6 +6,7 @@ import time
 import logging
 from utils.networking.http_requests_compat import requests
 import json
+import re
 import sys
 import importlib
 import importlib.metadata
@@ -36,6 +37,91 @@ QWEN_64K_YARN_UNSUPPORTED_MESSAGE = (
 # wheels accept rope_scaling_type as a constructor kwarg but do not export the
 # generated enum symbol, so this is only used after constructor support is verified.
 LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK = 2
+
+QWEN_64K_KV_CACHE_PROFILE = {
+    'type_k': 'q8_0',
+    'type_v': 'q8_0',
+    'flash_attn': True,
+    'offload_kqv': True,
+    'n_batch': 512,
+    'n_ubatch': 128,
+}
+QWEN_64K_KV_CACHE_CAPABILITY_KWARGS = tuple(QWEN_64K_KV_CACHE_PROFILE)
+
+
+def _safe_bounded_error_summary(value: Any, *, limit: int = 240) -> str:
+    text = str(value or '').replace('\n', ' ').replace('\r', ' ')
+    text = re.sub(r'(/[^\s:]+)+', '<path>', text)
+    text = re.sub(r'([A-Za-z]:\\[^\s:]+)+', '<path>', text)
+    text = re.sub(r'(?i)(prompt|message|content|response|ciphertext|key|secret)=[^\s,;]+', r'\1=<redacted>', text)
+    text = re.sub(r'\s+', ' ', text).strip()
+    return text[:limit]
+
+
+def classify_generation_exception(exc: BaseException) -> Dict[str, Any]:
+    diagnostics = getattr(exc, 'diagnostics', None)
+    source = diagnostics if isinstance(diagnostics, dict) else {}
+    combined = ' '.join(
+        str(value or '')
+        for value in (
+            type(exc).__name__,
+            str(exc),
+            source.get('reason'),
+            source.get('exception_type'),
+            source.get('stderr_tail'),
+            source.get('error_summary'),
+            source.get('rejected_option'),
+        )
+    ).lower()
+    if isinstance(exc, LlamaCppRuntimeStageTimeout):
+        category = 'worker_timeout'
+    elif isinstance(exc, LlamaCppWorkerDeadError):
+        category = 'worker_dead'
+    elif isinstance(exc, (LlamaCppWorkerEOFError, LlamaCppWorkerBrokenPipeError)):
+        category = 'worker_dead'
+    elif source.get('category') in {
+        'metal_memory_allocation', 'kv_cache_allocation', 'rope_yarn_eval_failure',
+        'unsupported_generation_kwarg', 'worker_dead', 'worker_timeout',
+        'unknown_generation_exception',
+    }:
+        category = str(source.get('category'))
+    elif source.get('reason') in {'unsupported_generation_option', 'unsupported_generation_kwarg'} or source.get('rejected_option'):
+        category = 'unsupported_generation_kwarg'
+    elif 'timeout' in combined:
+        category = 'worker_timeout'
+    elif 'broken pipe' in combined or 'eof' in combined or 'exited before' in combined or 'worker_dead' in combined:
+        category = 'worker_dead'
+    elif 'metal' in combined and ('alloc' in combined or 'out of memory' in combined or 'failed to allocate' in combined):
+        category = 'metal_memory_allocation'
+    elif ('kv' in combined or 'cache' in combined) and ('alloc' in combined or 'out of memory' in combined or 'failed to allocate' in combined):
+        category = 'kv_cache_allocation'
+    elif ('yarn' in combined or 'rope' in combined) and ('eval' in combined or 'invalid' in combined or 'failed' in combined):
+        category = 'rope_yarn_eval_failure'
+    elif 'unexpected keyword argument' in combined or 'unsupported' in combined and 'kwarg' in combined:
+        category = 'unsupported_generation_kwarg'
+    else:
+        category = 'unknown_generation_exception'
+    result = {
+        'category': category,
+        'exception_type': source.get('exception_type') or type(exc).__name__,
+        'safe_error_summary': _safe_bounded_error_summary(source.get('error_summary') or ('request failed' if category == 'unknown_generation_exception' else str(exc))),
+    }
+    for key in ('reason', 'method', 'stream', 'rejected_option', 'stderr_tail'):
+        if key in source and source.get(key) is not None:
+            result[key] = _safe_bounded_error_summary(source[key]) if isinstance(source[key], str) else source[key]
+    return result
+
+
+def runtime_completion_smoke_reason_for_category(category: Any) -> str:
+    mapping = {
+        'metal_memory_allocation': 'runtime_completion_smoke_metal_memory_allocation',
+        'kv_cache_allocation': 'runtime_completion_smoke_kv_cache_allocation',
+        'rope_yarn_eval_failure': 'runtime_completion_smoke_rope_yarn_eval_failure',
+        'unsupported_generation_kwarg': 'runtime_completion_smoke_unsupported_generation_kwarg',
+        'worker_timeout': 'runtime_completion_smoke_worker_timeout',
+        'worker_dead': 'runtime_completion_smoke_worker_dead',
+    }
+    return mapping.get(str(category or ''), 'runtime_completion_smoke_exception')
 
 CRITICAL_STDLIB_IMPORT_MODULES = (
     'collections',
@@ -938,6 +1024,10 @@ def _read_llama_subprocess_message(
         if stage in {'llama_cpp_inference', 'llama_cpp_prompt_render_tokenize'} and message.get('request_error'):
             diagnostics = message.get('diagnostics')
             safe_diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
+            stderr_tail = _safe_bounded_error_summary(_llama_subprocess_tail(process, '_token_place_stderr_tail'), limit=800)
+            if stderr_tail:
+                safe_diagnostics = dict(safe_diagnostics)
+                safe_diagnostics['stderr_tail'] = stderr_tail
             raise LlamaCppInferenceRequestError(error, diagnostics=safe_diagnostics)
         traceback_text = str(message.get('traceback') or '').strip()
         if traceback_text:
@@ -2270,6 +2360,29 @@ class ModelManager:
     def _qwen_non_thinking_required(self) -> bool:
         return self.model_profile.get('provider') == 'qwen' and self.model_profile.get('thinking_mode') == 'disabled'
 
+    def _qwen_64k_kv_cache_profile(self, llama_cls: Any) -> Dict[str, Any]:
+        """Return conservative Qwen 64K-only llama.cpp KV/cache kwargs supported by runtime."""
+
+        context_tier = getattr(self, 'context_tier', '8k-fast')
+        if self.model_profile.get('provider') != 'qwen' or context_tier != '64k-full':
+            return {}
+        supported = {
+            key: _constructor_accepts_kwarg(llama_cls, key)
+            for key in QWEN_64K_KV_CACHE_CAPABILITY_KWARGS
+        }
+        profile = {
+            key: value
+            for key, value in QWEN_64K_KV_CACHE_PROFILE.items()
+            if supported.get(key)
+        }
+        self.last_qwen_64k_memory_profile_diagnostics = {
+            'active': True,
+            'attempted_profile': dict(QWEN_64K_KV_CACHE_PROFILE),
+            'constructor_kwarg_support': supported,
+            'applied_profile': dict(profile),
+        }
+        return profile
+
     def _runtime_init_kwargs(self, llama_cls: Any, n_gpu_layers: int, llama_cpp_module: Any = None) -> Dict[str, Any]:
         """Build verified llama-cpp-python runtime kwargs for the selected profile.
 
@@ -2292,6 +2405,7 @@ class ModelManager:
         if self.model_profile.get('provider') == 'qwen':
             if self._chat_template_mode() != 'gguf-jinja':
                 raise RuntimeError('Qwen runtime requires GGUF/Jinja chat template policy')
+            kwargs.update(self._qwen_64k_kv_cache_profile(llama_cls))
         else:
             kwargs['chat_format'] = self.config.get('model.chat_format', 'llama-3')
 
@@ -2671,6 +2785,8 @@ class ModelManager:
                                 'rope_yarn_enabled': 'yarn_ext_factor' in runtime_kwargs,
                                 'rope_yarn_factor': runtime_kwargs.get('yarn_ext_factor'),
                                 'yarn_original_context': runtime_kwargs.get('yarn_orig_ctx') or rope_policy.get('original_context_tokens'),
+                                'qwen_64k_kv_cache_profile': {key: runtime_kwargs.get(key) for key in QWEN_64K_KV_CACHE_CAPABILITY_KWARGS if key in runtime_kwargs},
+                                'qwen_64k_kv_cache_profile_active': bool({key: runtime_kwargs.get(key) for key in QWEN_64K_KV_CACHE_CAPABILITY_KWARGS if key in runtime_kwargs}),
                             })
                             yarn_diagnostics = getattr(self, 'last_yarn_rope_diagnostics', None)
                             if isinstance(yarn_diagnostics, dict):


### PR DESCRIPTION
### Motivation
- Qwen 64K nodes were passing model init and context admission but collapsing the first non-thinking generation failure into a generic `runtime_completion_smoke_exception`, hiding the real root cause. 
- The change surfaces safe, non-plaintext diagnostics to classify failures like Metal/KV allocation, YaRN/RoPE eval failures, unsupported generation kwargs, worker timeouts/deaths, and unknown runtime exceptions. 
- When the root cause is memory/KV pressure, prefer a minimal Qwen-only 64K KV/cache profile to reduce pressure without changing GGUF quantization. 

### Description
- Add a safe generation-exception classifier (`classify_generation_exception`) and a mapping helper (`runtime_completion_smoke_reason_for_category`) that redact and bound error summaries and classify categories such as `metal_memory_allocation`, `kv_cache_allocation`, `rope_yarn_eval_failure`, `unsupported_generation_kwarg`, `worker_timeout`, and `worker_dead`. (files: `utils/llm/model_manager.py`) 
- Preserve and attach bounded, redacted stderr tail and request-scoped diagnostics from subprocess-backed runtime errors into `LlamaCppInferenceRequestError` so worker diagnostics can be propagated safely. (file: `utils/llm/model_manager.py`) 
- Add a conservative Qwen 64K-only KV/cache profile and runtime capability detection for `type_k`, `type_v`, `flash_attn`, `offload_kqv`, `n_batch`, and `n_ubatch`, applied only for the `64k-full` profile; include profile diagnostics in compute plan. (file: `utils/llm/model_manager.py`) 
- Replace the generic completion-smoke exception handling in readiness with the classifier to set a specific internal reason (`runtime_completion_smoke_*`) and to populate rich, safe readiness diagnostics (`api_v1_readiness_completion_smoke_*`) including category, safe summary, kv profile, backend/offload mode, and repair/recovery flags. (file: `utils/compute_node_runtime.py`) 
- Add focused unit tests that reproduce the constructor-success/admission-success/generation-smoke-failure flows and assert correct classification and Qwen 64K kv-profile behavior, plus non-regression checks for 8k behavior. (files: `tests/unit/test_compute_node_runtime.py`, `tests/unit/test_model_manager.py`) 

### Testing
- Ran focused pytest suites and full project tests: `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/unit/test_compute_node_runtime.py -q`, `python -m pytest tests/unit/test_relay_client.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, `python -m pytest tests/unit/test_desktop_runtime_setup.py -q`, `python -m pytest tests/unit/test_desktop_gpu_packaging.py -q`, and `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`; all reported green in this environment. 
- Ran the project's full test runner `./run_all_tests.sh` and `pre-commit run --all-files`; the run completed with all tests and checks passing in the CI-like run performed locally. 
- CI/automation expectations: the new unit tests exercise classification paths and the Qwen 64K kv-profile application and must be present in CI to prevent regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4746d6c4d4832fa4468657111e62e6)