### PR TITLE
Fix Qwen 64K completion smoke diagnostics and add conservative KV-cache memory profile

### DIFF
--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -366,6 +366,53 @@ def test_compute_node_runtime_qwen_64k_readiness_reports_yarn_rope():
     assert diagnostics["api_v1_readiness_tokenizer_render_bridge_available"] is True
 
 
+def test_compute_node_runtime_qwen_64k_readiness_reports_kv_cache_metadata():
+    class ReadyRuntime:
+        def create_chat_completion(self, **_kwargs):
+            return {"choices": [{"message": {"role": "assistant", "content": "ready"}}]}
+
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "rope_scaling_policy": {"type": "yarn", "required_for_tier": "64k-full", "factor": 2.0, "original_context_tokens": 32768},
+    }
+    model_manager.context_tier = "64k-full"
+    model_manager.context_window_tokens = 65536
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {
+        "qwen_64k_kv_cache_profile": {"active": True, "applied": {"type_k": "q8_0", "type_v": "q8_0"}},
+        "type_k": "q8_0",
+        "type_v": "q8_0",
+        "flash_attn": True,
+        "offload_kqv": True,
+        "backend_used": "metal",
+        "llama_cpp_python_version": "0.3.32",
+    }
+    model_manager.last_yarn_rope_diagnostics = {"supported": True, "missing_reason": None, "yarn_resolver_source": "top_level_enum"}
+    model_manager.get_llm_instance.return_value = ReadyRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(_api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_qwen_64k_kv_cache_profile"]["active"] is True
+    assert diagnostics["api_v1_readiness_kv_type_k"] == "q8_0"
+    assert diagnostics["api_v1_readiness_kv_type_v"] == "q8_0"
+    assert diagnostics["api_v1_readiness_flash_attn"] is True
+    assert diagnostics["api_v1_readiness_offload_kqv"] is True
+    assert diagnostics["api_v1_readiness_yarn_rope_resolver_source"] == "top_level_enum"
+    assert diagnostics["api_v1_readiness_llama_cpp_python_version"] == "0.3.32"
+
+
 def test_compute_node_runtime_qwen_64k_readiness_rejects_missing_yarn_rope():
     class ReadyRuntime:
         def create_chat_completion(self, **_kwargs):
@@ -833,7 +880,113 @@ def test_compute_node_runtime_readiness_smoke_completion_records_safe_exception(
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "failed"
     assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_exception"
     assert diagnostics["api_v1_readiness_completion_smoke_exception_type"] == "RuntimeError"
+    assert diagnostics["api_v1_readiness_completion_smoke_exception_category"] == "unknown_generation_exception"
     assert "prompt text" not in str(diagnostics)
+
+
+def test_compute_node_runtime_qwen_64k_smoke_classifies_worker_generation_exceptions():
+    class FailingRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 42}
+
+        def create_chat_completion(self, **_kwargs):
+            raise RuntimeError("llama_kv_cache_init failed: KV cache allocation failed")
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "rope_scaling_policy": {"type": "yarn", "required_for_tier": "64k-full", "factor": 2.0, "original_context_tokens": 32768},
+    }
+    model_manager.context_tier = "64k-full"
+    model_manager.context_window_tokens = 65536
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {
+        "qwen_64k_kv_cache_profile": {"active": True, "applied": {"type_k": "q8_0", "type_v": "q8_0"}},
+        "type_k": "q8_0",
+        "type_v": "q8_0",
+    }
+    model_manager.last_yarn_rope_diagnostics = {"supported": True, "missing_reason": None, "yarn_resolver_source": "numeric_fallback"}
+    model_manager.get_llm_instance.return_value = FailingRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(_api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 42)),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_kv_cache_allocation"
+    assert diagnostics["api_v1_readiness_completion_smoke_exception_category"] == "kv_cache_allocation"
+    assert diagnostics["api_v1_runtime_ready"] is False
+
+
+def test_compute_node_runtime_qwen_64k_smoke_classifies_yarn_eval_failure():
+    class FailingRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 42}
+
+        def create_chat_completion(self, **_kwargs):
+            raise RuntimeError("YaRN RoPE scaling failed during eval")
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "rope_scaling_policy": {"type": "yarn", "required_for_tier": "64k-full", "factor": 2.0, "original_context_tokens": 32768},
+    }
+    model_manager.context_tier = "64k-full"
+    model_manager.context_window_tokens = 65536
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.last_yarn_rope_diagnostics = {"supported": True, "missing_reason": None}
+    model_manager.get_llm_instance.return_value = FailingRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(_api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 42)),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    assert model_manager.last_compute_diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_rope_yarn_eval_failure"
+
+
+def test_compute_node_runtime_smoke_classifies_unsupported_internal_generation_kwarg():
+    from utils.llm.model_manager import LlamaCppInferenceRequestError
+
+    class FailingRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 2}
+
+        def create_chat_completion(self, **_kwargs):
+            raise LlamaCppInferenceRequestError(
+                "llama_cpp request failed",
+                diagnostics={"reason": "unsupported_generation_option", "rejected_option": "stream"},
+            )
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = FailingRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(_api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 2)),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_unsupported_generation_kwarg"
+    assert diagnostics["api_v1_readiness_completion_smoke_worker_diagnostics"]["rejected_option"] == "stream"
 
 @pytest.mark.parametrize(
     "llm_instance,getter,expected",

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4929,3 +4929,76 @@ def test_qwen_64k_diagnostics_mark_supported_when_required_yarn_kwargs_are_avail
     assert diagnostics['missing_reason'] is None
     assert diagnostics['missing_required_kwargs'] == []
     assert diagnostics['yarn_resolver_source'] == 'top_level_enum'
+
+
+def test_qwen_64k_runtime_kwargs_apply_memory_profile_only_to_64k():
+    class Qwen64KLlama:
+        def __init__(
+            self,
+            model_path,
+            n_gpu_layers,
+            n_ctx,
+            verbose,
+            rope_scaling_type=None,
+            yarn_ext_factor=None,
+            yarn_orig_ctx=None,
+            type_k=None,
+            type_v=None,
+            flash_attn=None,
+            offload_kqv=None,
+            n_batch=None,
+            n_ubatch=None,
+        ):
+            self.kwargs = {
+                "model_path": model_path,
+                "n_gpu_layers": n_gpu_layers,
+                "n_ctx": n_ctx,
+                "verbose": verbose,
+                "rope_scaling_type": rope_scaling_type,
+                "yarn_ext_factor": yarn_ext_factor,
+                "yarn_orig_ctx": yarn_orig_ctx,
+                "type_k": type_k,
+                "type_v": type_v,
+                "flash_attn": flash_attn,
+                "offload_kqv": offload_kqv,
+                "n_batch": n_batch,
+                "n_ubatch": n_ubatch,
+            }
+
+    llama_cpp_module = SimpleNamespace(
+        LLAMA_ROPE_SCALING_TYPE_YARN=2,
+        __version__="0.3.32",
+        __file__="/safe/site-packages/llama_cpp/__init__.py",
+    )
+    manager = ModelManager(MagicMock())
+    manager.model_profile = {
+        "provider": "qwen",
+        "chat_template_policy": "gguf-jinja",
+        "native_context_tokens": 32768,
+        "rope_scaling_policy": {"type": "yarn", "required_for_tier": "64k-full", "factor": 2.0, "original_context_tokens": 32768},
+    }
+    manager.profile_id = "qwen3-8b-q4-k-m"
+    manager.model_path = "/models/Qwen3-8B-Q4_K_M.gguf"
+    manager.config = {"model.context_size": 65536}
+    manager.context_tier = "64k-full"
+
+    kwargs = manager._runtime_init_kwargs(Qwen64KLlama, -1, llama_cpp_module)
+
+    assert kwargs["n_ctx"] == 65536
+    assert kwargs["rope_scaling_type"] == 2
+    assert kwargs["yarn_ext_factor"] == 2.0
+    assert kwargs["yarn_orig_ctx"] == 32768
+    assert kwargs["type_k"] == "q8_0"
+    assert kwargs["type_v"] == "q8_0"
+    assert kwargs["flash_attn"] is True
+    assert kwargs["offload_kqv"] is True
+    assert kwargs["n_batch"] == 512
+    assert kwargs["n_ubatch"] == 128
+    assert manager.last_qwen_64k_memory_profile_diagnostics["active"] is True
+
+    manager.config = {"model.context_size": 8192}
+    manager.context_tier = "8k-fast"
+    kwargs = manager._runtime_init_kwargs(Qwen64KLlama, -1, llama_cpp_module)
+    assert "rope_scaling_type" not in kwargs
+    assert "type_k" not in kwargs
+    assert manager.last_qwen_64k_memory_profile_diagnostics["active"] is False

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -44,6 +44,59 @@ def _log_warning(message: str, *, exc_info: bool = False) -> None:
         logger.warning(message, exc_info=exc_info)
 
 
+_RUNTIME_SMOKE_REASON_BY_CATEGORY = {
+    "metal_memory_allocation": "runtime_completion_smoke_metal_memory_allocation",
+    "kv_cache_allocation": "runtime_completion_smoke_kv_cache_allocation",
+    "rope_yarn_eval_failure": "runtime_completion_smoke_rope_yarn_eval_failure",
+    "unsupported_generation_kwarg": "runtime_completion_smoke_unsupported_generation_kwarg",
+    "worker_timeout": "runtime_completion_smoke_worker_timeout",
+    "worker_dead": "runtime_completion_smoke_worker_dead",
+    "unknown_generation_exception": "runtime_completion_smoke_exception",
+}
+
+
+def _bounded_safe_error_summary(exc: BaseException, *, limit: int = 240) -> str:
+    text = str(exc)
+    for marker in ("/Users/", "/home/", "/workspace/", "\\Users\\"):
+        text = text.replace(marker, "<path>/")
+    lowered = text.lower()
+    if any(secretish in lowered for secretish in ("prompt", "message", "response", "content", "cipher", "key")):
+        return "<redacted_request_content>"
+    text = " ".join(text.split())
+    return text[:limit]
+
+
+def classify_completion_smoke_exception(exc: BaseException) -> Dict[str, Any]:
+    diagnostics = getattr(exc, "diagnostics", None)
+    safe_diag = diagnostics if isinstance(diagnostics, dict) else {}
+    text = f"{type(exc).__name__} {_bounded_safe_error_summary(exc)} {safe_diag}".lower()
+    category = "unknown_generation_exception"
+    rejected_option = safe_diag.get("rejected_option")
+    if isinstance(exc, TimeoutError) or "timeout" in text or "timed out" in text:
+        category = "worker_timeout"
+    elif "worker_dead" in text or "worker exited" in text or "broken pipe" in text or "eof" in text:
+        category = "worker_dead"
+    elif safe_diag.get("reason") in {"unsupported_generation_option", "unsupported_generation_kwarg"} or rejected_option:
+        category = "unsupported_generation_kwarg"
+    elif "kv cache" in text or "kv_cache" in text or "llama_kv_cache" in text:
+        category = "kv_cache_allocation"
+    elif "metal" in text and ("alloc" in text or "out of memory" in text or "oom" in text):
+        category = "metal_memory_allocation"
+    elif "yarn" in text or "rope" in text:
+        category = "rope_yarn_eval_failure"
+    return {
+        "category": category,
+        "safe_reason": _RUNTIME_SMOKE_REASON_BY_CATEGORY[category],
+        "exception_type": type(exc).__name__,
+        "safe_error_summary": _bounded_safe_error_summary(exc),
+        "worker_diagnostics": {
+            key: value for key, value in safe_diag.items()
+            if isinstance(key, str) and isinstance(value, (str, bool, int, float, type(None)))
+            and key not in {"prompt", "messages", "content", "response", "ciphertext", "key"}
+        },
+    }
+
+
 @dataclass(frozen=True)
 class ComputeNodeRuntimeConfig:
     """Runtime configuration shared by all compute-node hosts."""
@@ -440,6 +493,14 @@ class ComputeNodeRuntime:
             "api_v1_readiness_yarn_original_context_tokens": rope_policy.get(
                 "original_context_tokens"
             ),
+            "api_v1_readiness_yarn_rope_resolver_source": yarn_diagnostics.get("yarn_resolver_source") or yarn_diagnostics.get("yarn_enum_location"),
+            "api_v1_readiness_qwen_64k_kv_cache_profile": diagnostics.get("qwen_64k_kv_cache_profile"),
+            "api_v1_readiness_kv_type_k": diagnostics.get("type_k"),
+            "api_v1_readiness_kv_type_v": diagnostics.get("type_v"),
+            "api_v1_readiness_flash_attn": diagnostics.get("flash_attn"),
+            "api_v1_readiness_offload_kqv": diagnostics.get("offload_kqv"),
+            "api_v1_readiness_backend_used": diagnostics.get("backend_used"),
+            "api_v1_readiness_llama_cpp_python_version": diagnostics.get("llama_cpp_python_version") or yarn_diagnostics.get("llama_cpp_python_version"),
         })
 
         yarn_required_for_active_tier = (
@@ -561,14 +622,21 @@ class ComputeNodeRuntime:
                     }
             except Exception as exc:
                 admitted = False
+                smoke_exception = classify_completion_smoke_exception(exc)
+                safe_reason = smoke_exception["safe_reason"]
                 admission_error = {
                     "code": "compute_node_context_admission_unavailable",
-                    "internal_reason": "runtime_completion_smoke_exception",
+                    "internal_reason": safe_reason,
                 }
                 diagnostics["api_v1_readiness_completion_smoke_result"] = "failed"
-                diagnostics["api_v1_readiness_completion_smoke_failure_reason"] = "runtime_completion_smoke_exception"
+                diagnostics["api_v1_readiness_completion_smoke_failure_reason"] = safe_reason
                 diagnostics["api_v1_readiness_completion_smoke_shape"] = "exception"
-                diagnostics["api_v1_readiness_completion_smoke_exception_type"] = type(exc).__name__
+                diagnostics["api_v1_readiness_completion_smoke_exception_type"] = smoke_exception["exception_type"]
+                diagnostics["api_v1_readiness_completion_smoke_exception_category"] = smoke_exception["category"]
+                diagnostics["api_v1_readiness_completion_smoke_safe_error_summary"] = smoke_exception["safe_error_summary"]
+                diagnostics["api_v1_readiness_completion_smoke_worker_diagnostics"] = smoke_exception["worker_diagnostics"]
+                diagnostics["api_v1_readiness_completion_smoke_repair_attempted"] = False
+                diagnostics["api_v1_readiness_completion_smoke_recovery_succeeded"] = False
             diagnostics["api_v1_runtime_ready"] = bool(admitted)
             diagnostics["api_v1_readiness_result"] = "passed" if admitted else "failed"
             diagnostics["api_v1_readiness_error_code"] = (admission_error or {}).get("code") if not admitted else None

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -36,6 +36,19 @@ QWEN_64K_YARN_UNSUPPORTED_MESSAGE = (
 # wheels accept rope_scaling_type as a constructor kwarg but do not export the
 # generated enum symbol, so this is only used after constructor support is verified.
 LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK = 2
+QWEN_64K_KV_CACHE_TYPE = 'q8_0'
+QWEN_64K_FLASH_ATTN = True
+QWEN_64K_OFFLOAD_KQV = True
+QWEN_64K_N_BATCH = 512
+QWEN_64K_N_UBATCH = 128
+QWEN_64K_MEMORY_PROFILE_KWARGS = {
+    'type_k': QWEN_64K_KV_CACHE_TYPE,
+    'type_v': QWEN_64K_KV_CACHE_TYPE,
+    'flash_attn': QWEN_64K_FLASH_ATTN,
+    'offload_kqv': QWEN_64K_OFFLOAD_KQV,
+    'n_batch': QWEN_64K_N_BATCH,
+    'n_ubatch': QWEN_64K_N_UBATCH,
+}
 
 CRITICAL_STDLIB_IMPORT_MODULES = (
     'collections',
@@ -171,6 +184,23 @@ def _qwen_64k_rope_support_diagnostics(llama_cpp_module: Any, llama_cls: Any) ->
 
 def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> Dict[str, Any]:
     return _qwen_64k_rope_support_diagnostics(llama_cpp_module, llama_cls)
+
+
+def _qwen_64k_memory_profile(llama_cls: Any) -> Dict[str, Any]:
+    """Return conservative 64K-only llama.cpp cache kwargs supported by the runtime."""
+
+    support = _llama_constructor_supports_kwargs(llama_cls, QWEN_64K_MEMORY_PROFILE_KWARGS)
+    applied = {
+        name: value
+        for name, value in QWEN_64K_MEMORY_PROFILE_KWARGS.items()
+        if support.get(name)
+    }
+    return {
+        'id': 'qwen3_64k_q8_kv_cache',
+        'attempted': dict(QWEN_64K_MEMORY_PROFILE_KWARGS),
+        'applied': applied,
+        'constructor_kwarg_support': support,
+    }
 
 def _is_site_packages_path(path_text: Any) -> bool:
     normalized = str(path_text).replace('\\', '/').lower()
@@ -2334,7 +2364,20 @@ class ModelManager:
                     'yarn_orig_ctx': int(rope_policy.get('original_context_tokens', native_context)),
                 }
             )
+            memory_profile = _qwen_64k_memory_profile(llama_cls)
+            kwargs.update(memory_profile['applied'])
+            self.last_qwen_64k_memory_profile_diagnostics = {
+                'active': True,
+                'profile_id': memory_profile['id'],
+                'attempted': memory_profile['attempted'],
+                'applied': memory_profile['applied'],
+                'constructor_kwarg_support': memory_profile['constructor_kwarg_support'],
+            }
         else:
+            self.last_qwen_64k_memory_profile_diagnostics = {
+                'active': False,
+                'missing_reason': 'not_required_for_active_profile_or_tier',
+            }
             self.last_yarn_rope_diagnostics = {
                 'supported': False,
                 'active': False,
@@ -2671,6 +2714,14 @@ class ModelManager:
                                 'rope_yarn_enabled': 'yarn_ext_factor' in runtime_kwargs,
                                 'rope_yarn_factor': runtime_kwargs.get('yarn_ext_factor'),
                                 'yarn_original_context': runtime_kwargs.get('yarn_orig_ctx') or rope_policy.get('original_context_tokens'),
+                                'llama_cpp_python_version': _llama_cpp_python_version(llama_cpp),
+                                'qwen_64k_kv_cache_profile': getattr(self, 'last_qwen_64k_memory_profile_diagnostics', None),
+                                'type_k': runtime_kwargs.get('type_k'),
+                                'type_v': runtime_kwargs.get('type_v'),
+                                'flash_attn': runtime_kwargs.get('flash_attn'),
+                                'offload_kqv': runtime_kwargs.get('offload_kqv'),
+                                'n_batch': runtime_kwargs.get('n_batch'),
+                                'n_ubatch': runtime_kwargs.get('n_ubatch'),
                             })
                             yarn_diagnostics = getattr(self, 'last_yarn_rope_diagnostics', None)
                             if isinstance(yarn_diagnostics, dict):


### PR DESCRIPTION
### Motivation
- Qwen 64K nodes were passing model init and exact context admission but failing the one-token completion smoke with a generic `runtime_completion_smoke_exception`, hiding the real root cause (KV/Metal allocation, YaRN eval, unsupported generation kwarg, or worker death/timeout).
- We need precise, safe diagnostics and a minimal 64K-only runtime profile to reduce KV/cache pressure without changing GGUF weights and without regressing 8K behavior.

### Description
- Add a conservative Qwen 64K memory profile and named constants in `utils/llm/model_manager.py` (KV/cache candidate `type_k/type_v`, `flash_attn`, `offload_kqv`, `n_batch`, `n_ubatch`) with constructor-capability detection and diagnostic reporting and only apply it when `context_tier == "64k-full"`.
- Apply the detected `qwen_64k` profile to the runtime `kwargs` during `_runtime_init_kwargs` generation and surface the attempted/applied profile in `last_compute_diagnostics` (including `type_k/type_v/flash_attn/offload_kqv/n_batch/n_ubatch` and `llama-cpp-python` version) without logging any prompt/response plaintext.
- Implement safe, bounded, redacted classification of completion-smoke exceptions in `utils/compute_node_runtime.py` via `classify_completion_smoke_exception`, mapping to specific internal reasons such as `runtime_completion_smoke_metal_memory_allocation`, `runtime_completion_smoke_kv_cache_allocation`, `runtime_completion_smoke_rope_yarn_eval_failure`, `runtime_completion_smoke_unsupported_generation_kwarg`, `runtime_completion_smoke_worker_timeout`, `runtime_completion_smoke_worker_dead`, or falling back to `runtime_completion_smoke_exception`.
- Replace the previous generic smoke-exception path so readiness now records the classified safe reason, exception category/type, a bounded/redacted error summary, and safe worker diagnostics (no plaintext), and includes the KV/rope diagnostics fields required by the desktop UI and `last_compute_diagnostics`.
- Add focused regression unit tests and small runtime fakes: new tests in `tests/unit/test_compute_node_runtime.py` and `tests/unit/test_model_manager.py` that assert 64K memory-profile application, smoke exception classification for KV allocation and YaRN eval failures, unsupported internal generation-kwarg detection, and that 8K behavior remains unchanged.

### Testing
- Ran the focused test matrix: `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/unit/test_compute_node_runtime.py -q`, `python -m pytest tests/unit/test_relay_client.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, `python -m pytest tests/unit/test_desktop_runtime_setup.py -q`, `python -m pytest tests/unit/test_desktop_gpu_packaging.py -q`, and `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`; all suites passed locally.
- Ran repository checks: `pre-commit run --all-files` and `git diff --check`; pre-commit hooks and lint/security checks passed.
- The added tests reproduce the constructor-success/admission-success/generation-smoke-failure class and now assert the smoke failure is reported with a specific safe reason and diagnostics rather than the prior generic `runtime_completion_smoke_exception`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4746e1331c832fa61c3a2a861e3d65)