### PR TITLE
Improve Qwen 64K completion-smoke diagnostics and apply conservative KV-cache profile

### DIFF
--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -835,6 +835,91 @@ def test_compute_node_runtime_readiness_smoke_completion_records_safe_exception(
     assert diagnostics["api_v1_readiness_completion_smoke_exception_type"] == "RuntimeError"
     assert "prompt text" not in str(diagnostics)
 
+def test_compute_node_runtime_qwen_64k_classifies_metal_smoke_failure(monkeypatch):
+    class MetalFailRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 42}
+
+        def create_chat_completion(self, **_kwargs):
+            raise RuntimeError("llama.cpp Metal malloc failed while allocating KV cache")
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "rope_scaling_policy": {"type": "yarn", "required_for_tier": "64k-full", "factor": 2.0, "original_context_tokens": 32768},
+    }
+    model_manager.context_tier = "64k-full"
+    model_manager.context_window_tokens = 65536
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {"kv_cache_profile": {"type_k": "q8_0", "type_v": "q8_0"}}
+    model_manager.last_yarn_rope_diagnostics = {"supported": True, "yarn_resolver_source": "top_level_enum", "missing_reason": None}
+    model_manager.get_llm_instance.return_value = MetalFailRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=SimpleNamespace(_api_v1_authoritative_context_admission=lambda **_kwargs: (True, None, 42)),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_metal_memory_allocation"
+    assert diagnostics["api_v1_readiness_completion_smoke_exception_category"] == "metal_memory_allocation"
+    assert diagnostics["api_v1_readiness_completion_smoke_repair_attempted"] is False
+    assert "prompt text" not in json.dumps(diagnostics).lower()
+
+
+def test_compute_node_runtime_qwen_64k_classifies_rope_eval_failure():
+    class RopeFailRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 42}
+
+        def create_chat_completion(self, **_kwargs):
+            raise RuntimeError("YaRN RoPE scaling accepted by constructor but failed during eval")
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {
+        "provider": "qwen",
+        "thinking_mode": "disabled",
+        "rope_scaling_policy": {"type": "yarn", "required_for_tier": "64k-full", "factor": 2.0, "original_context_tokens": 32768},
+    }
+    model_manager.context_tier = "64k-full"
+    model_manager.context_window_tokens = 65536
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.last_yarn_rope_diagnostics = {"supported": True, "yarn_resolver_source": "numeric_fallback", "missing_reason": None}
+    model_manager.get_llm_instance.return_value = RopeFailRuntime()
+    runtime = ComputeNodeRuntime(ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None), model_manager=model_manager, relay_client=_ready_relay_client(), crypto_manager=MagicMock())
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    assert model_manager.last_compute_diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_rope_yarn_eval_failure"
+
+
+def test_compute_node_runtime_qwen_64k_classifies_unsupported_internal_generation_kwarg():
+    class KwargFailRuntime:
+        def render_and_tokenize_chat(self, *_args, **_kwargs):
+            return {"prompt_tokens": 42}
+
+        def create_chat_completion(self, **_kwargs):
+            raise TypeError("create_chat_completion() got an unexpected keyword argument 'stream'")
+
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "qwen3-8b-instruct"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.last_yarn_rope_diagnostics = {}
+    model_manager.get_llm_instance.return_value = KwargFailRuntime()
+    runtime = ComputeNodeRuntime(ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None), model_manager=model_manager, relay_client=_ready_relay_client(), crypto_manager=MagicMock())
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    assert model_manager.last_compute_diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_unsupported_generation_kwarg"
+
 @pytest.mark.parametrize(
     "llm_instance,getter,expected",
     [

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4610,6 +4610,65 @@ def test_qwen_64k_runtime_enables_yarn_kwargs(tmp_path):
     assert manager.last_compute_diagnostics['yarn_rope_enum_location'] == 'top_level_enum'
 
 
+def test_qwen_64k_runtime_applies_conservative_kv_cache_profile_when_supported(tmp_path):
+    from utils.context_profiles import apply_context_profile
+    captured = {}
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': 0,
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    class FakeLlama:
+        def __init__(self, model_path, n_gpu_layers, n_ctx, verbose, rope_scaling_type, yarn_ext_factor, yarn_orig_ctx, type_k, type_v, flash_attn, offload_kqv, n_batch, n_ubatch):
+            captured.update({
+                'model_path': model_path,
+                'n_gpu_layers': n_gpu_layers,
+                'n_ctx': n_ctx,
+                'verbose': verbose,
+                'rope_scaling_type': rope_scaling_type,
+                'yarn_ext_factor': yarn_ext_factor,
+                'yarn_orig_ctx': yarn_orig_ctx,
+                'type_k': type_k,
+                'type_v': type_v,
+                'flash_attn': flash_attn,
+                'offload_kqv': offload_kqv,
+                'n_batch': n_batch,
+                'n_ubatch': n_ubatch,
+            })
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+            return '<qwen>'
+
+    fake_llama_cpp = SimpleNamespace(
+        Llama=FakeLlama,
+        LLAMA_ROPE_SCALING_TYPE_YARN=2,
+        __file__='/opt/token.place/llama_cpp/__init__.py',
+        __version__='0.3.32',
+    )
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama_cpp), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'metal', 'gpu_offload_supported': True, 'error': None}):
+        assert manager.get_llm_instance() is not None
+
+    assert captured['n_ctx'] == 65536
+    assert captured['type_k'] == 'q8_0'
+    assert captured['type_v'] == 'q8_0'
+    assert captured['flash_attn'] is True
+    assert captured['offload_kqv'] is True
+    assert captured['n_batch'] == 512
+    assert captured['n_ubatch'] == 128
+    assert manager.last_compute_diagnostics['kv_cache_profile']['type_k'] == 'q8_0'
+    assert manager.last_yarn_rope_diagnostics['kv_cache_profile']['type_v'] == 'q8_0'
+
 def test_qwen_64k_runtime_resolves_nested_yarn_enum(tmp_path):
     from utils.context_profiles import apply_context_profile
     captured = {}

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -54,6 +54,85 @@ class ComputeNodeRuntimeConfig:
     relay_urls: Tuple[str, ...] = ()
 
 
+
+_RUNTIME_SMOKE_CATEGORY_REASON = {
+    "metal_memory_allocation": "runtime_completion_smoke_metal_memory_allocation",
+    "kv_cache_allocation": "runtime_completion_smoke_kv_cache_allocation",
+    "rope_yarn_eval_failure": "runtime_completion_smoke_rope_yarn_eval_failure",
+    "unsupported_generation_kwarg": "runtime_completion_smoke_unsupported_generation_kwarg",
+    "worker_timeout": "runtime_completion_smoke_worker_timeout",
+    "worker_dead": "runtime_completion_smoke_worker_dead",
+    "worker_eof": "runtime_completion_smoke_worker_dead",
+    "worker_broken_pipe": "runtime_completion_smoke_worker_dead",
+    "unknown_generation_exception": "runtime_completion_smoke_exception",
+}
+
+
+def _bounded_safe_exception_summary(exc: BaseException) -> str:
+    text = " ".join(str(exc).split())
+    if not text:
+        text = type(exc).__name__
+    # Keep only operationally useful native-runtime terms; never preserve prompts.
+    lowered = text.lower()
+    safe_terms = [
+        "metal", "malloc", "allocation", "alloc", "kv", "cache", "rope",
+        "yarn", "unexpected keyword argument", "timeout", "dead", "eof",
+        "broken pipe", "out of memory", "oom", "kqv", "flash_attn",
+    ]
+    if not any(term in lowered for term in safe_terms):
+        return type(exc).__name__
+    for marker in ("/users/", "/home/", "/workspace/", "\\users\\"):
+        lowered = lowered.replace(marker, "<path>/")
+        text = text.replace(marker, "<path>/")
+    return text[:240]
+
+
+def _completion_smoke_failure_category(exc: BaseException) -> str:
+    diagnostics = getattr(exc, "diagnostics", None)
+    if isinstance(diagnostics, dict):
+        for key in ("category", "safe_category", "failure_class"):
+            value = diagnostics.get(key)
+            if isinstance(value, str) and value in _RUNTIME_SMOKE_CATEGORY_REASON:
+                return value
+        reason = str(diagnostics.get("reason") or diagnostics.get("code") or "").lower()
+        if "unsupported_generation" in reason or "unsupported_generation_option" in reason:
+            return "unsupported_generation_kwarg"
+    name = type(exc).__name__
+    text = f"{name} {str(exc)}".lower()
+    if "timeout" in text:
+        return "worker_timeout"
+    if "workerdead" in name.lower() or "worker dead" in text or "liveness" in text:
+        return "worker_dead"
+    if "eof" in text or "broken pipe" in text:
+        return "worker_dead"
+    if "unexpected keyword argument" in text or "got an unexpected keyword" in text:
+        return "unsupported_generation_kwarg"
+    if "yarn" in text or ("rope" in text and ("eval" in text or "scaling" in text)):
+        return "rope_yarn_eval_failure"
+    if "metal" in text and ("alloc" in text or "memory" in text or "oom" in text):
+        return "metal_memory_allocation"
+    if "kv" in text and ("alloc" in text or "cache" in text or "memory" in text or "oom" in text):
+        return "kv_cache_allocation"
+    if "out of memory" in text or "malloc" in text:
+        return "metal_memory_allocation"
+    return "unknown_generation_exception"
+
+
+def _completion_smoke_failure_diagnostics(exc: BaseException) -> Dict[str, Any]:
+    diagnostics = getattr(exc, "diagnostics", None)
+    safe_worker_diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
+    category = _completion_smoke_failure_category(exc)
+    payload: Dict[str, Any] = {
+        "exception_type": type(exc).__name__,
+        "exception_category": category,
+        "safe_summary": _bounded_safe_exception_summary(exc),
+    }
+    for key in ("reason", "code", "rejected_option", "method", "stream", "stderr_tail", "llama_cpp_python_version"):
+        value = safe_worker_diagnostics.get(key)
+        if isinstance(value, (str, bool, int, float, type(None))):
+            payload[f"worker_{key}"] = value if not isinstance(value, str) else value[:240]
+    return payload
+
 LEGACY_RELAY_REQUIRED_FIELDS = frozenset({"client_public_key", "chat_history", "cipherkey", "iv"})
 
 
@@ -440,6 +519,15 @@ class ComputeNodeRuntime:
             "api_v1_readiness_yarn_original_context_tokens": rope_policy.get(
                 "original_context_tokens"
             ),
+            "api_v1_readiness_yarn_rope_resolver_source": yarn_diagnostics.get("yarn_resolver_source"),
+            "api_v1_readiness_llama_cpp_python_version": (
+                diagnostics.get("llama_cpp_python_version")
+                or yarn_diagnostics.get("llama_cpp_python_version")
+            ),
+            "api_v1_readiness_kv_cache_profile": diagnostics.get("kv_cache_profile"),
+            "api_v1_readiness_backend_used": (
+                diagnostics.get("backend_used") or diagnostics.get("device_backend")
+            ),
         })
 
         yarn_required_for_active_tier = (
@@ -561,14 +649,26 @@ class ComputeNodeRuntime:
                     }
             except Exception as exc:
                 admitted = False
+                smoke_failure = _completion_smoke_failure_diagnostics(exc)
+                smoke_category = str(smoke_failure["exception_category"])
+                smoke_reason = _RUNTIME_SMOKE_CATEGORY_REASON.get(
+                    smoke_category, "runtime_completion_smoke_exception"
+                )
                 admission_error = {
                     "code": "compute_node_context_admission_unavailable",
-                    "internal_reason": "runtime_completion_smoke_exception",
+                    "internal_reason": smoke_reason,
                 }
                 diagnostics["api_v1_readiness_completion_smoke_result"] = "failed"
-                diagnostics["api_v1_readiness_completion_smoke_failure_reason"] = "runtime_completion_smoke_exception"
+                diagnostics["api_v1_readiness_completion_smoke_failure_reason"] = smoke_reason
                 diagnostics["api_v1_readiness_completion_smoke_shape"] = "exception"
-                diagnostics["api_v1_readiness_completion_smoke_exception_type"] = type(exc).__name__
+                diagnostics["api_v1_readiness_completion_smoke_exception_type"] = smoke_failure["exception_type"]
+                diagnostics["api_v1_readiness_completion_smoke_exception_category"] = smoke_category
+                diagnostics["api_v1_readiness_completion_smoke_safe_summary"] = smoke_failure["safe_summary"]
+                diagnostics["api_v1_readiness_completion_smoke_repair_attempted"] = False
+                diagnostics["api_v1_readiness_completion_smoke_recovery_succeeded"] = False
+                for key, value in smoke_failure.items():
+                    if key.startswith("worker_"):
+                        diagnostics[f"api_v1_readiness_completion_smoke_{key}"] = value
             diagnostics["api_v1_runtime_ready"] = bool(admitted)
             diagnostics["api_v1_readiness_result"] = "passed" if admitted else "failed"
             diagnostics["api_v1_readiness_error_code"] = (admission_error or {}).get("code") if not admitted else None

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -28,6 +28,15 @@ logger = logging.getLogger('model_manager')
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REPO_LLAMA_CPP_SHIM = (REPO_ROOT / 'llama_cpp.py').resolve()
 DEFAULT_LLAMA_CPP_RUNTIME_STAGE_TIMEOUT_SECONDS = 30.0
+QWEN_64K_KV_CACHE_PROFILE = {
+    'type_k': 'q8_0',
+    'type_v': 'q8_0',
+    'flash_attn': True,
+    'offload_kqv': True,
+    'n_batch': 512,
+    'n_ubatch': 128,
+}
+
 QWEN_64K_YARN_UNSUPPORTED_MESSAGE = (
     'Qwen 64K requires YaRN/RoPE support in llama-cpp-python; '
     'update or rebuild the runtime'
@@ -2304,7 +2313,12 @@ class ModelManager:
             and context_tier == rope_policy.get('required_for_tier')
             and n_ctx > native_context
         )
+        kv_cache_profile: Dict[str, Any] = {}
         if needs_yarn:
+            for cache_kwarg, cache_value in QWEN_64K_KV_CACHE_PROFILE.items():
+                if self._llama_constructor_accepts(llama_cls, cache_kwarg):
+                    kwargs[cache_kwarg] = cache_value
+                    kv_cache_profile[cache_kwarg] = cache_value
             llama_module = llama_cpp_module or inspect.getmodule(llama_cls)
             yarn_probe = _runtime_supports_qwen_yarn_rope(llama_module, llama_cls)
             self.last_yarn_rope_diagnostics = {
@@ -2318,6 +2332,7 @@ class ModelManager:
                 'requested_n_ctx': n_ctx,
                 'llama_module_path': yarn_probe['llama_module_path'],
                 'llama_cpp_python_version': yarn_probe['llama_cpp_python_version'],
+                'kv_cache_profile': dict(kv_cache_profile),
                 'missing_reason': yarn_probe['missing_reason'],
             }
             if not yarn_probe['supported']:
@@ -2671,6 +2686,8 @@ class ModelManager:
                                 'rope_yarn_enabled': 'yarn_ext_factor' in runtime_kwargs,
                                 'rope_yarn_factor': runtime_kwargs.get('yarn_ext_factor'),
                                 'yarn_original_context': runtime_kwargs.get('yarn_orig_ctx') or rope_policy.get('original_context_tokens'),
+                                'kv_cache_profile': {key: runtime_kwargs.get(key) for key in QWEN_64K_KV_CACHE_PROFILE if key in runtime_kwargs},
+                                'llama_cpp_python_version': getattr(llama_cpp, '__version__', None),
                             })
                             yarn_diagnostics = getattr(self, 'last_yarn_rope_diagnostics', None)
                             if isinstance(yarn_diagnostics, dict):


### PR DESCRIPTION
### Motivation
- Qwen 64K nodes could pass model init and exact context admission but fail the tiny non-thinking generation smoke and collapse that into a generic `runtime_completion_smoke_exception`, leaving operators without actionable, safe diagnostics.
- When the root cause is Metal/KV pressure the runtime should prefer a conservative 64K-only KV/cache constructor profile (without changing GGUF weights) and surface that instrumentation in readiness diagnostics.

### Description
- Add safe smoke failure classification and bounded summaries in `utils/compute_node_runtime.py` via `_completion_smoke_failure_category`, `_completion_smoke_failure_diagnostics`, and `_bounded_safe_exception_summary`, and map these to specific internal readiness reasons using `_RUNTIME_SMOKE_CATEGORY_REASON`.
- Replace the previous generic exception handling for completion smoke with the new diagnostics so readiness now sets specific `api_v1_readiness_completion_smoke_*` fields and an `api_v1_readiness_error_reason` such as `runtime_completion_smoke_metal_memory_allocation` / `runtime_completion_smoke_kv_cache_allocation` / `runtime_completion_smoke_rope_yarn_eval_failure` / `runtime_completion_smoke_unsupported_generation_kwarg` / `runtime_completion_smoke_worker_timeout` / `runtime_completion_smoke_worker_dead` with a safe, redacted summary (no plaintext prompts/outputs/logged).
- Add a conservative Qwen 64K KV/cache constructor profile constant `QWEN_64K_KV_CACHE_PROFILE` in `utils/llm/model_manager.py` and apply supported kwargs (`type_k`, `type_v`, `flash_attn`, `offload_kqv`, `n_batch`, `n_ubatch`) only when the 64K YaRN path (`needs_yarn`) is active and the runtime accepts those constructor args; record the applied `kv_cache_profile` and `llama_cpp_python_version` in compute diagnostics and compute plan.
- Ensure this 64K-only change does not affect the `8k-fast` path and preserve existing Qwen 8K behavior.
- Add focused regression tests: new smoke-classification tests in `tests/unit/test_compute_node_runtime.py` (Metal/KV allocation, YaRN eval failure, unsupported internal generation kwarg) and a KV-profile application test in `tests/unit/test_model_manager.py` that asserts the conservative KV kwargs are passed when supported and are recorded in diagnostics.

### Testing
- Ran unit and integration tests: `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/unit/test_compute_node_runtime.py -q`, `python -m pytest tests/unit/test_relay_client.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, `python -m pytest tests/unit/test_desktop_runtime_setup.py -q`, `python -m pytest tests/unit/test_desktop_gpu_packaging.py -q`, and `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`; all suites passed.
- Ran repository checks `pre-commit run --all-files` and project test matrix hooks; they passed.
- No plaintext prompt/response/ciphertext/keys are emitted by the added diagnostics; diagnostics are bounded and redacted as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4746e8a464832f88affa02bd29e298)