### PR TITLE
Probe real subprocess for YaRN/RoPE support and add packaged-desktop regression tests

### DIFF
--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -5184,3 +5184,130 @@ def test_subprocess_worker_error_summary_keeps_safe_category_hint():
     summary = namespace['_sanitize_error_summary'](RuntimeError('Metal failed to allocate KV cache for /tmp/model.gguf'))
 
     assert summary == 'RuntimeError:metal_memory_allocation'
+
+
+def test_qwen_64k_subprocess_facade_uses_child_probe_not_parent_signature(tmp_path):
+    from utils.context_profiles import apply_context_profile
+    from utils.llm import model_manager as model_manager_module
+
+    captured = {}
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': 0,
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    class FakeProxy:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+            return '<qwen>'
+
+    support = {
+        'rope_scaling_type': True,
+        'yarn_ext_factor': True,
+        'yarn_orig_ctx': True,
+        'type_k': False,
+        'type_v': False,
+        'flash_attn': False,
+        'offload_kqv': False,
+        'n_batch': False,
+        'n_ubatch': False,
+    }
+    facade = model_manager_module._SubprocessLlamaCppModule(
+        '/packaged/llama_cpp/__init__.py',
+        desktop_runtime_probe={
+            'backend': 'metal',
+            'gpu_offload_supported': True,
+            'constructor_kwarg_support': support,
+            'yarn_resolver_source': 'numeric_fallback',
+            'yarn_enum_value': 2,
+            'llama_cpp_python_version': '0.3.32',
+        },
+    )
+
+    with patch('utils.llm.model_manager._SubprocessLlamaProxy', FakeProxy), \
+         patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=facade), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'metal', 'gpu_offload_supported': True, 'error': None}):
+        assert manager.get_llm_instance() is not None
+
+    assert captured['n_ctx'] == 65536
+    assert captured['rope_scaling_type'] == 2
+    assert captured['yarn_ext_factor'] == 2.0
+    assert captured['yarn_orig_ctx'] == 32768
+    assert 'missing constructor kwargs' not in (manager.last_runtime_init_error or '')
+    assert manager.last_yarn_rope_diagnostics['yarn_resolver_source'] == 'top_level_enum'
+
+
+def test_qwen_64k_child_unknown_kwargs_attempts_constructor_not_false_failure(tmp_path):
+    from utils.context_profiles import apply_context_profile
+    from utils.llm import model_manager as model_manager_module
+
+    captured = {}
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': 0,
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    class FakeProxy:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+            return '<qwen>'
+
+    support = {'rope_scaling_type': 'unknown', 'yarn_ext_factor': 'unknown', 'yarn_orig_ctx': 'unknown'}
+    facade = model_manager_module._SubprocessLlamaCppModule(
+        '/packaged/llama_cpp/__init__.py',
+        desktop_runtime_probe={'backend': 'cpu', 'constructor_kwarg_support': support, 'yarn_resolver_source': 'numeric_fallback', 'yarn_enum_value': 2},
+    )
+
+    with patch('utils.llm.model_manager._SubprocessLlamaProxy', FakeProxy), \
+         patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=facade), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'cpu', 'gpu_offload_supported': False, 'error': None}):
+        assert manager.get_llm_instance() is not None
+
+    assert captured['rope_scaling_type'] == 2
+    assert manager.last_yarn_rope_diagnostics['constructor_kwarg_support']['rope_scaling_type'] == 'unknown'
+
+
+def test_qwen_64k_numeric_fallback_not_used_when_child_probe_rejects_rope_scaling():
+    from utils.llm import model_manager as model_manager_module
+
+    facade = model_manager_module._SubprocessLlamaCppModule(
+        '/packaged/llama_cpp/__init__.py',
+        desktop_runtime_probe={
+            'backend': 'cpu',
+            'constructor_kwarg_support': {
+                'rope_scaling_type': False,
+                'yarn_ext_factor': True,
+                'yarn_orig_ctx': True,
+            },
+        },
+    )
+
+    diagnostics = model_manager_module._qwen_64k_rope_support_diagnostics(facade, facade.Llama)
+
+    assert diagnostics['supported'] is False
+    assert diagnostics['yarn_resolver_source'] == 'unsupported'
+    assert diagnostics['yarn_enum_value'] is None

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -70,7 +70,10 @@ def _constructor_accepts_kwarg(callable_obj: Any, kwarg: str) -> bool:
     )
 
 
-def _llama_constructor_supports_kwargs(llama_cls: Any, required_kwargs: Iterable[str]) -> Dict[str, bool]:
+def _llama_constructor_supports_kwargs(llama_cls: Any, required_kwargs: Iterable[str]) -> Dict[str, Any]:
+    facade_support = getattr(llama_cls, '__token_place_constructor_kwarg_support__', None)
+    if isinstance(facade_support, dict):
+        return {name: facade_support.get(name, False) for name in required_kwargs}
     facade_kwargs = getattr(llama_cls, '__token_place_supported_constructor_kwargs__', None)
     if facade_kwargs is not None:
         supported = {str(name) for name in facade_kwargs if isinstance(name, str)}
@@ -86,8 +89,13 @@ def _safe_constructor_capability_payload(llama_cpp_module: Any) -> Dict[str, Any
     support = capabilities.get('constructor_kwarg_support')
     if isinstance(support, dict):
         payload['constructor_kwarg_support'] = {
-            str(name): bool(value) for name, value in support.items() if isinstance(name, str)
+            str(name): (value if value in (True, False, 'unknown') else bool(value))
+            for name, value in support.items()
+            if isinstance(name, str)
         }
+    for field in ('constructor_has_var_kwargs', 'qwen_64k_yarn_support', 'yarn_resolver_source', 'yarn_enum_value'):
+        if field in capabilities:
+            payload[field] = capabilities.get(field)
     q8_value = capabilities.get('q8_kv_cache_type_value')
     if isinstance(q8_value, int):
         payload['q8_kv_cache_type_value'] = q8_value
@@ -127,6 +135,11 @@ def _resolve_yarn_rope_scaling_type(llama_cpp_module: Any, llama_cls: Any = None
         if value is not None:
             return value, source
 
+    worker_support = _safe_constructor_capability_payload(llama_cpp_module).get('constructor_kwarg_support')
+    if isinstance(worker_support, dict):
+        if worker_support.get('rope_scaling_type') is True or worker_support.get('rope_scaling_type') == 'unknown':
+            return LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK, 'numeric_fallback'
+        return None, 'unsupported'
     if _constructor_accepts_kwarg(llama_cls, 'rope_scaling_type'):
         return LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK, 'numeric_fallback'
     return None, 'unsupported'
@@ -747,21 +760,38 @@ def _probe_llama_cpp_capabilities_in_subprocess(*, timeout_seconds: Optional[flo
     code = (
         "import importlib, inspect, json, sys\n"
         "llama_cpp = importlib.import_module('llama_cpp')\n"
-        "def _ctor_support(cls, names):\n"
+        "def _ctor_details(cls, names):\n"
         "    ctor = getattr(cls, '__init__', cls)\n"
         "    try:\n"
         "        params = inspect.signature(ctor).parameters\n"
         "    except (TypeError, ValueError):\n"
-        "        return {name: False for name in names}\n"
+        "        return {name: 'unknown' for name in names}, False, 'uninspectable'\n"
         "    accepts_var_kw = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())\n"
-        "    return {name: (name in params or accepts_var_kw) for name in names}\n"
+        "    return {name: (name in params or accepts_var_kw) for name in names}, accepts_var_kw, 'inspectable'\n"
         "probe_kwargs = (\n"
         "    'type_k', 'type_v', 'flash_attn', 'offload_kqv', 'n_batch', 'n_ubatch',\n"
         "    'rope_scaling_type', 'yarn_ext_factor', 'yarn_attn_factor', 'yarn_beta_fast',\n"
         "    'yarn_beta_slow', 'yarn_orig_ctx', 'rope_freq_base', 'rope_freq_scale',\n"
         ")\n"
         "llama_cls = getattr(llama_cpp, 'Llama', None)\n"
-        "constructor_support = _ctor_support(llama_cls, probe_kwargs)\n"
+        "constructor_support, constructor_has_var_kwargs, signature_classification = _ctor_details(llama_cls, probe_kwargs)\n"
+        "top_yarn = getattr(llama_cpp, 'LLAMA_ROPE_SCALING_TYPE_YARN', None)\n"
+        "nested_yarn = getattr(getattr(llama_cpp, 'llama_cpp', None), 'LLAMA_ROPE_SCALING_TYPE_YARN', None)\n"
+        "if top_yarn is not None:\n"
+        "    yarn_source, yarn_value = 'top_level_enum', top_yarn\n"
+        "elif nested_yarn is not None:\n"
+        "    yarn_source, yarn_value = 'nested_enum', nested_yarn\n"
+        "elif constructor_support.get('rope_scaling_type') in (True, 'unknown'):\n"
+        "    yarn_source, yarn_value = 'numeric_fallback', 2\n"
+        "else:\n"
+        "    yarn_source, yarn_value = 'unsupported', None\n"
+        "required_yarn = ('rope_scaling_type', 'yarn_ext_factor', 'yarn_orig_ctx')\n"
+        "if yarn_source == 'unsupported' or any(constructor_support.get(k) is False for k in required_yarn):\n"
+        "    qwen_64k_yarn_support = 'unsupported'\n"
+        "elif any(constructor_support.get(k) == 'unknown' for k in required_yarn):\n"
+        "    qwen_64k_yarn_support = 'unknown'\n"
+        "else:\n"
+        "    qwen_64k_yarn_support = 'supported'\n"
         "q8_value = getattr(llama_cpp, 'LLAMA_TYPE_Q8_0', None)\n"
         "if q8_value is None:\n"
         "    q8_value = getattr(getattr(llama_cpp, 'llama_cpp', None), 'LLAMA_TYPE_Q8_0', None)\n"
@@ -788,6 +818,11 @@ def _probe_llama_cpp_capabilities_in_subprocess(*, timeout_seconds: Optional[flo
         "    'prefix': sys.prefix,\n"
         "    'llama_module_path': getattr(llama_cpp, '__file__', 'unknown'),\n"
         "    'constructor_kwarg_support': constructor_support,\n"
+        "    'constructor_has_var_kwargs': constructor_has_var_kwargs,\n"
+        "    'child_signature_classification': signature_classification,\n"
+        "    'yarn_resolver_source': yarn_source,\n"
+        "    'yarn_enum_value': yarn_value,\n"
+        "    'qwen_64k_yarn_support': qwen_64k_yarn_support,\n"
         "    'q8_kv_cache_type_value': q8_value if isinstance(q8_value, int) else None,\n"
         "    'capability_source': 'worker_probe',\n"
         "    'llama_cpp_python_version': getattr(llama_cpp, '__version__', None),\n"
@@ -1298,6 +1333,10 @@ class _SubprocessLlamaCppModule:
         self.__token_place_worker_capabilities__ = dict(probe or {})
         if 'constructor_kwarg_support' in self.__token_place_worker_capabilities__:
             self.__token_place_worker_capabilities__['capability_source'] = 'worker_probe'
+        if self.__token_place_worker_capabilities__.get('yarn_resolver_source') in {'top_level_enum', 'nested_enum', 'numeric_fallback'}:
+            self.LLAMA_ROPE_SCALING_TYPE_YARN = self.__token_place_worker_capabilities__.get(
+                'yarn_enum_value', LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK
+            )
         backend = str((probe or {}).get('backend') or '').lower()
         self.GGML_USE_CUDA = backend == 'cuda'
         self.GGML_USE_METAL = backend == 'metal'
@@ -1314,15 +1353,17 @@ class _SubprocessLlamaCppModule:
         module_path_hint = self.__file__
 
         worker_capabilities = _safe_constructor_capability_payload(self)
+        constructor_support = dict(worker_capabilities.get('constructor_kwarg_support') or {})
         supported_kwargs = tuple(
             sorted(
-                name for name, supported in (worker_capabilities.get('constructor_kwarg_support') or {}).items()
-                if supported
+                name for name, supported in constructor_support.items()
+                if supported is True
             )
         )
 
         class _ConfiguredSubprocessLlama(_SubprocessLlamaProxy):
             __token_place_supported_constructor_kwargs__ = supported_kwargs
+            __token_place_constructor_kwarg_support__ = constructor_support
 
             def __init__(self, *args, **kwargs):
                 super().__init__(
@@ -2111,7 +2152,9 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
     support = probe.get('constructor_kwarg_support')
     if isinstance(support, dict):
         coerced['constructor_kwarg_support'] = {
-            str(name): bool(value) for name, value in support.items() if isinstance(name, str)
+            str(name): (value if value in (True, False, 'unknown') else bool(value))
+            for name, value in support.items()
+            if isinstance(name, str)
         }
     q8_value = probe.get('q8_kv_cache_type_value')
     if isinstance(q8_value, int):
@@ -2120,6 +2163,9 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
         coerced['capability_source'] = str(probe.get('capability_source'))
     if probe.get('llama_cpp_python_version'):
         coerced['llama_cpp_python_version'] = str(probe.get('llama_cpp_python_version'))
+    for field in ('constructor_has_var_kwargs', 'child_signature_classification', 'yarn_resolver_source', 'yarn_enum_value', 'qwen_64k_yarn_support'):
+        if field in probe:
+            coerced[field] = probe.get(field)
     return coerced
 
 


### PR DESCRIPTION
### Motivation
- Packaged macOS desktop runs for Qwen3 64K were falsely failing because parent-process facade signatures were treated as authoritative for constructor kwarg support. 
- The runtime capability check must be performed inside the actual subprocess worker so the parent facade can't cause false-negative YaRN/RoPE decisions. 
- Add regression coverage that exercises the packaged subprocess facade path so this class of failure is caught in CI.

### Description
- Move YaRN/RoPE capability decision-making toward the real subprocess by extending the subprocess capability probe to return constructor support details, signature classification, `**kwargs` presence, yarn resolver source/value, and a qwen-64k support classification. (changes in `utils/llm/model_manager.py`)
- Treat `**kwargs` and `unknown` constructor-support results conservatively by preserving `unknown` (not collapsing to False) and attempting numeric fallback or safe constructor validation only when child probe indicates it is permissible. (changes in `utils/llm/model_manager.py`)
- Propagate the worker probe payload through `_SubprocessLlamaCppModule` into the configured subprocess proxy so `_runtime_init_kwargs()` uses real child-probe diagnostics rather than parent-proxy introspection. (changes in `utils/llm/model_manager.py`)
- Add regression/unit tests that simulate the packaged subprocess facade path: a positive packaged-facade test that uses child probe data to accept YaRN kwargs, a test where child reports `unknown` (and the manager attempts init), and a negative test where the child rejects `rope_scaling_type` and numeric fallback is not used. (changes in `tests/unit/test_model_manager.py`)

### Testing
- Installed focused test deps: `python -m pip install -r config/requirements_codex_verification.txt` (succeeded).
- Ran the focused unit and integration suites: `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/unit/test_compute_node_runtime.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, `python -m pytest tests/unit/test_desktop_runtime_setup.py -q`, `python -m pytest tests/unit/test_desktop_gpu_packaging.py -q`, and `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, and all reported passing.
- Ran lint/pre-commit checks: `pre-commit run --all-files` and `git diff --check` and they completed without blocking failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47ed931040832f8df8a9308af7bdf3)