### PR TITLE
Add Qwen 64K Metal runtime fallback profiles and packaged-subprocess e2e for context-create failures

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -833,8 +833,8 @@ def run_llama_cpp_facade_early_exit_diagnostics_probe(
     fake_init = fake_pkg / "__init__.py"
     fake_init.write_text(
         "import sys\n"
-        "print('facade stdout clue before exit')\n"
-        "print('facade stderr clue before exit', file=sys.stderr)\n"
+        "print('llama_context facade stdout clue before exit')\n"
+        "print('llama_context facade stderr clue before exit', file=sys.stderr)\n"
         "sys.exit(7)\n",
         encoding="utf-8",
     )
@@ -879,7 +879,8 @@ def run_llama_cpp_facade_early_exit_diagnostics_probe(
     assert "facade stdout clue before exit" in combined, combined
     assert "facade stderr clue before exit" in combined, combined
     assert "import_root=" in combined, combined
-    assert str(fake_init) in combined, combined
+    assert str(fake_init) not in combined, combined
+    assert "module_path_hint=<path>" in combined, combined
 
 
 def run_llama_cpp_watchdog_packaged_bridge_lifecycle_probe(

--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -31,7 +31,7 @@ def _write_fake_llama_cpp_runtime(root: Path) -> None:
 import json, os, sys
 __version__ = '0.3.32-test'
 GGML_USE_METAL = True
-GGML_TYPE_Q8_0 = 18
+GGML_TYPE_Q8_0 = 8
 GGML_TYPE_Q4_0 = 2
 LLAMA_ROPE_SCALING_TYPE_YARN = 2
 
@@ -76,7 +76,7 @@ def test_packaged_subprocess_qwen64k_retries_after_context_create_failure(tmp_pa
             },
             'yarn_enum_value': 2,
             'qwen_64k_yarn_support': 'supported',
-            'q8_kv_cache_type_value': 18,
+            'q8_kv_cache_type_value': 8,
             'q4_kv_cache_type_value': 2,
             'llama_cpp_python_version': '0.3.32-test',
         },
@@ -89,7 +89,7 @@ def test_packaged_subprocess_qwen64k_retries_after_context_create_failure(tmp_pa
     attempts = [json.loads(line) for line in attempts_file.read_text().splitlines()]
     assert len(attempts) == 2
     assert 'type_k' not in attempts[0]
-    assert attempts[1]['type_k'] == 18
+    assert attempts[1]['type_k'] == 8
     assert manager.last_compute_diagnostics['qwen_64k_memory_profile']['profile_id'] == 'qwen64k_kv_q8'
 
 
@@ -115,7 +115,7 @@ def test_packaged_subprocess_qwen64k_profile_exhaustion_fails_closed(tmp_path, m
                 'n_batch': True, 'n_ubatch': True,
             },
             'yarn_enum_value': 2, 'qwen_64k_yarn_support': 'supported',
-            'q8_kv_cache_type_value': 18, 'q4_kv_cache_type_value': 2,
+            'q8_kv_cache_type_value': 8, 'q4_kv_cache_type_value': 2,
         },
     )
 

--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -1,7 +1,12 @@
+import json
+import os
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from utils.context_profiles import apply_context_profile
+from utils.llm import model_manager as model_manager_module
 from utils.llm.model_manager import ModelManager
 
 
@@ -11,115 +16,116 @@ def _config(tmp_path):
         'model.profile_id': 'qwen3-8b-q4-k-m',
         'model.context_size': 8192,
         'model.use_mock': False,
-        'model.n_gpu_layers': 0,
+        'model.n_gpu_layers': -1,
+        'model.gpu_mode': 'gpu',
         'model.enforce_gpu_memory_headroom': False,
-        'paths.models_dir': str(tmp_path),
+        'paths.models_dir': str(tmp_path / 'models'),
     }
     config.get.side_effect = lambda key, default=None: values.get(key, default)
     config.set.side_effect = lambda key, value: values.__setitem__(key, value)
     return config
 
 
-def _write_fake_llama_cpp(site_dir, *, supports_yarn):
-    package_dir = site_dir / 'llama_cpp'
-    package_dir.mkdir(parents=True)
-    init_file = package_dir / '__init__.py'
-    if supports_yarn:
-        init_file.write_text(
-            "import json, os\n"
-            "__version__ = '0.3.32'\n"
-            "GGML_USE_METAL = True\n"
-            "LLAMA_TYPE_Q8_0 = 8\n"
-            "def llama_supports_gpu_offload(): return True\n"
-            "class Llama:\n"
-            "    def __init__(self, model_path, n_gpu_layers, n_ctx, verbose, rope_scaling_type, yarn_ext_factor, yarn_orig_ctx):\n"
-            "        with open(os.environ['TOKEN_PLACE_CAPTURE_LLAMA_KWARGS'], 'w') as fh:\n"
-            "            json.dump({\n"
-            "                'model_path': model_path, 'n_gpu_layers': n_gpu_layers, 'n_ctx': n_ctx, 'verbose': verbose,\n"
-            "                'rope_scaling_type': rope_scaling_type, 'yarn_ext_factor': yarn_ext_factor,\n"
-            "                'yarn_orig_ctx': yarn_orig_ctx,\n"
-            "            }, fh)\n"
-            "    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):\n"
-            "        return [1, 2, 3] if tokenize else '<qwen>'\n"
-        )
-    else:
-        init_file.write_text(
-            "__version__ = '0.3.32'\n"
-            "GGML_USE_METAL = True\n"
-            "def llama_supports_gpu_offload(): return True\n"
-            "class Llama:\n"
-            "    def __init__(self, model_path, n_gpu_layers, n_ctx, verbose):\n"
-            "        pass\n"
-        )
-    return init_file
+def _write_fake_llama_cpp_runtime(root: Path) -> None:
+    package = root / 'llama_cpp'
+    package.mkdir(parents=True)
+    (package / '__init__.py').write_text(
+        """
+import json, os, sys
+__version__ = '0.3.32-test'
+GGML_USE_METAL = True
+GGML_TYPE_Q8_0 = 18
+GGML_TYPE_Q4_0 = 2
+LLAMA_ROPE_SCALING_TYPE_YARN = 2
+
+def llama_supports_gpu_offload():
+    return True
+
+class Llama:
+    def __init__(self, **kwargs):
+        path = os.environ['TOKEN_PLACE_ATTEMPTS_JSONL']
+        with open(path, 'a', encoding='utf-8') as handle:
+            handle.write(json.dumps(kwargs, sort_keys=True) + '\\n')
+        if os.environ.get('TOKEN_PLACE_FAIL_ALL_PROFILES') == '1' or 'type_k' not in kwargs:
+            print('ggml_metal: KV cache allocation failed while creating llama_context', file=sys.stderr, flush=True)
+            raise ValueError('Failed to create llama_context')
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+        return '<qwen>'
+""",
+        encoding='utf-8',
+    )
 
 
-def test_packaged_subprocess_qwen64k_child_probe_prevents_parent_false_negative(tmp_path, monkeypatch):
-    from utils.llm import model_manager as model_manager_module
-
-    site_dir = tmp_path / 'fake-site'
-    fake_module_path = _write_fake_llama_cpp(site_dir, supports_yarn=True)
-    capture_path = tmp_path / 'captured_kwargs.json'
-    monkeypatch.syspath_prepend(str(site_dir))
-    monkeypatch.setenv('TOKEN_PLACE_CAPTURE_LLAMA_KWARGS', str(capture_path))
+def test_packaged_subprocess_qwen64k_retries_after_context_create_failure(tmp_path, monkeypatch):
+    runtime_root = tmp_path / 'runtime'
+    _write_fake_llama_cpp_runtime(runtime_root)
+    attempts_file = tmp_path / 'attempts.jsonl'
+    monkeypatch.syspath_prepend(str(runtime_root))
+    monkeypatch.setenv('TOKEN_PLACE_ATTEMPTS_JSONL', str(attempts_file))
 
     manager = ModelManager(_config(tmp_path))
     apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).parent.mkdir(parents=True, exist_ok=True)
     Path(manager.model_path).write_text('fake')
-
-    stale_parent_probe = {
-        'backend': 'metal',
-        'gpu_offload_supported': True,
-        'runtime_action': 'metal_already_supported',
-        'llama_module_path': str(fake_module_path),
-        'constructor_kwarg_support': {
-            'rope_scaling_type': False,
-            'yarn_ext_factor': False,
-            'yarn_orig_ctx': False,
-        },
-        'capability_source': 'parent_facade_signature',
-    }
-
     facade = model_manager_module._SubprocessLlamaCppModule(
-        str(fake_module_path),
-        desktop_runtime_probe=stale_parent_probe,
+        str(runtime_root / 'llama_cpp' / '__init__.py'),
+        desktop_runtime_probe={
+            'backend': 'metal',
+            'gpu_offload_supported': True,
+            'constructor_kwarg_support': {
+                'rope_scaling_type': True, 'yarn_ext_factor': True, 'yarn_orig_ctx': True,
+                'type_k': True, 'type_v': True, 'flash_attn': True, 'offload_kqv': True,
+                'n_batch': True, 'n_ubatch': True,
+            },
+            'yarn_enum_value': 2,
+            'qwen_64k_yarn_support': 'supported',
+            'q8_kv_cache_type_value': 18,
+            'q4_kv_cache_type_value': 2,
+            'llama_cpp_python_version': '0.3.32-test',
+        },
     )
 
     with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=facade), \
          patch.object(manager, '_runtime_capabilities', return_value={'backend': 'metal', 'gpu_offload_supported': True, 'error': None}):
         assert manager.get_llm_instance() is not None
 
-    import json
-    captured = json.loads(capture_path.read_text())
-    assert captured['n_ctx'] == 65536
-    assert captured['rope_scaling_type'] is not None
-    assert captured['yarn_ext_factor'] == 2.0
-    assert captured['yarn_orig_ctx'] == 32768
-    assert manager.last_yarn_rope_diagnostics['capability_source'] == 'worker_probe'
-    assert manager.last_yarn_rope_diagnostics['parent_facade_type'] == '_SubprocessLlamaCppModule'
+    attempts = [json.loads(line) for line in attempts_file.read_text().splitlines()]
+    assert len(attempts) == 2
+    assert 'type_k' not in attempts[0]
+    assert attempts[1]['type_k'] == 18
+    assert manager.last_compute_diagnostics['qwen_64k_memory_profile']['profile_id'] == 'qwen64k_kv_q8'
 
 
-def test_packaged_subprocess_qwen64k_child_unsupported_fails_before_ready(tmp_path, monkeypatch):
-    from utils.llm import model_manager as model_manager_module
-
-    site_dir = tmp_path / 'fake-site-unsupported'
-    fake_module_path = _write_fake_llama_cpp(site_dir, supports_yarn=False)
-    capture_path = tmp_path / 'captured_kwargs.json'
-    monkeypatch.syspath_prepend(str(site_dir))
-    monkeypatch.setenv('TOKEN_PLACE_CAPTURE_LLAMA_KWARGS', str(capture_path))
+def test_packaged_subprocess_qwen64k_profile_exhaustion_fails_closed(tmp_path, monkeypatch):
+    runtime_root = tmp_path / 'runtime'
+    _write_fake_llama_cpp_runtime(runtime_root)
+    attempts_file = tmp_path / 'attempts.jsonl'
+    monkeypatch.syspath_prepend(str(runtime_root))
+    monkeypatch.setenv('TOKEN_PLACE_ATTEMPTS_JSONL', str(attempts_file))
+    monkeypatch.setenv('TOKEN_PLACE_FAIL_ALL_PROFILES', '1')
 
     manager = ModelManager(_config(tmp_path))
     apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).parent.mkdir(parents=True, exist_ok=True)
     Path(manager.model_path).write_text('fake')
-    facade = model_manager_module._SubprocessLlamaCppModule(str(fake_module_path))
+    facade = model_manager_module._SubprocessLlamaCppModule(
+        str(runtime_root / 'llama_cpp' / '__init__.py'),
+        desktop_runtime_probe={
+            'backend': 'metal', 'gpu_offload_supported': True,
+            'constructor_kwarg_support': {
+                'rope_scaling_type': True, 'yarn_ext_factor': True, 'yarn_orig_ctx': True,
+                'type_k': True, 'type_v': True, 'flash_attn': True, 'offload_kqv': True,
+                'n_batch': True, 'n_ubatch': True,
+            },
+            'yarn_enum_value': 2, 'qwen_64k_yarn_support': 'supported',
+            'q8_kv_cache_type_value': 18, 'q4_kv_cache_type_value': 2,
+        },
+    )
 
     with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=facade), \
          patch.object(manager, '_runtime_capabilities', return_value={'backend': 'metal', 'gpu_offload_supported': True, 'error': None}):
         assert manager.get_llm_instance() is None
 
-    assert not capture_path.exists()
-    assert manager.last_yarn_rope_diagnostics['supported'] is False
-    assert manager.last_yarn_rope_diagnostics['capability_source'] == 'worker_probe'
-    assert manager.last_yarn_rope_diagnostics['child_probe_reprobe_attempted'] is True
-    assert 'Qwen 64K requires YaRN/RoPE support' in manager.last_runtime_init_error
-    assert 'missing constructor kwargs' in manager.last_runtime_init_error
+    assert manager.llm is None
+    assert 'profile exhaustion before registration' in manager.last_runtime_init_error
+    assert 'runtime_context_create' in manager.last_runtime_init_error

--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -1,8 +1,5 @@
 import json
-import os
-import sys
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from utils.context_profiles import apply_context_profile

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -5705,7 +5705,7 @@ def test_unrecognized_init_failure_is_not_context_create_retryable():
     assert category not in model_manager_module.QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES
 
 
-def test_generic_context_create_failure_is_retryable():
+def test_generic_context_create_failure_is_not_retryable_without_memory_kv_or_buffer_evidence():
     from utils.llm import model_manager as model_manager_module
 
     category = model_manager_module._classify_runtime_context_create_error(
@@ -5713,7 +5713,7 @@ def test_generic_context_create_failure_is_retryable():
     )
 
     assert category == 'runtime_context_create_failed'
-    assert category in model_manager_module.QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES
+    assert category not in model_manager_module.QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES
 
 
 def test_path_redaction_handles_spaces_and_traceback_paths():

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3138,7 +3138,7 @@ def test_subprocess_llama_proxy_initialization_failure_still_terminates_worker(t
         )
 
     message = str(exc_info.value)
-    assert 'init failed clearly' in message
+    assert 'safe_error_category=' in message
     assert not isinstance(exc_info.value, model_manager_module.LlamaCppInferenceRequestError)
 
 
@@ -3161,7 +3161,10 @@ def test_llama_subprocess_request_error_is_typed_only_for_inference_stage():
             stage='llama_cpp_init',
         )
 
-    assert str(exc_info.value) == 'init failed'
+    assert str(exc_info.value) == (
+        'llama_cpp_init failed; child_exception_type=RuntimeError; '
+        'safe_error_category=runtime_init_unclassified'
+    )
     assert not isinstance(exc_info.value, model_manager_module.LlamaCppInferenceRequestError)
 
 
@@ -5050,7 +5053,7 @@ def test_qwen_64k_subprocess_worker_probe_preserves_yarn_constructor_support():
             'gpu_offload_supported': True,
             'runtime_action': 'already_supported',
             'constructor_kwarg_support': support,
-            'q8_kv_cache_type_value': 18,
+            'q8_kv_cache_type_value': 8,
             'capability_source': 'worker_probe',
         },
     )
@@ -5408,8 +5411,8 @@ def test_qwen_64k_memory_profile_disables_kqv_offload_for_cpu_fallback():
         enable_kqv_offload=False,
     )
 
-    assert kwargs['type_k'] == 18
-    assert kwargs['type_v'] == 18
+    assert kwargs['type_k'] == 8
+    assert kwargs['type_v'] == 8
     assert 'flash_attn' not in kwargs
     assert 'offload_kqv' not in kwargs
     assert diagnostics['kqv_offload_allowed'] is False
@@ -5434,7 +5437,7 @@ def test_qwen_64k_memory_profile_uses_worker_probe_numeric_q8():
             'gpu_offload_supported': True,
             'runtime_action': 'already_supported',
             'constructor_kwarg_support': support,
-            'q8_kv_cache_type_value': 18,
+            'q8_kv_cache_type_value': 8,
             'capability_source': 'worker_probe',
         },
     )
@@ -5445,11 +5448,57 @@ def test_qwen_64k_memory_profile_uses_worker_probe_numeric_q8():
         enable_kqv_offload=True,
     )
 
-    assert kwargs['type_k'] == 18
-    assert kwargs['type_v'] == 18
+    assert kwargs['type_k'] == 8
+    assert kwargs['type_v'] == 8
     assert kwargs['flash_attn'] is True
     assert kwargs['offload_kqv'] is True
     assert diagnostics['capability_source'] == 'worker_probe'
+
+
+def test_qwen_64k_memory_profiles_skip_missing_kv_constants_without_noop_profile():
+    from utils.llm import model_manager as model_manager_module
+
+    class NoKvEnumLlama:
+        __token_place_supported_constructor_kwargs__ = ('flash_attn', 'offload_kqv', 'n_batch', 'n_ubatch')
+
+    profiles = model_manager_module._build_qwen_64k_runtime_profiles(
+        SimpleNamespace(),
+        NoKvEnumLlama,
+        model_path='model.gguf',
+        n_ctx=65536,
+    )
+
+    assert [profile['profile_id'] for profile in profiles] == ['qwen64k_default']
+    skipped = profiles[0]['diagnostics']['skipped_profiles']
+    assert skipped
+    assert all(not item['enabled'] for item in skipped)
+    assert all('flash_attn' not in item['applied'] for item in skipped)
+    assert all('type_k' not in item['applied'] and 'type_v' not in item['applied'] for item in skipped)
+
+
+def test_child_diagnostics_drop_payloads_keys_and_arbitrary_stderr():
+    from utils.llm import model_manager as model_manager_module
+
+    text = """
+prompt: reveal SECRET_PROMPT_123
+assistant: SECRET_ASSISTANT_456
+ciphertext_body=abc123 key=sk-token decrypted payload
+random child stderr snippet survives?
+/Users/Alice/Application Support/token.place/model.gguf
+ggml_metal: KV cache allocation failed for llama_context
+"""
+
+    sanitized = model_manager_module._sanitize_child_diagnostic_text(text)
+
+    assert 'SECRET_PROMPT_123' not in sanitized
+    assert 'SECRET_ASSISTANT_456' not in sanitized
+    assert 'ciphertext_body' not in sanitized
+    assert 'decrypted payload' not in sanitized
+    assert 'sk-token' not in sanitized
+    assert 'random child stderr snippet' not in sanitized
+    assert '/Users/Alice' not in sanitized
+    assert 'Application Support' not in sanitized
+    assert 'KV cache allocation failed' in sanitized
 
 
 def test_qwen_64k_memory_profile_omits_kwargs_when_worker_probe_lacks_support():
@@ -5532,7 +5581,7 @@ def test_qwen_64k_context_create_failure_retries_q8_profile(tmp_path):
     fake_llama_cpp = SimpleNamespace(
         Llama=FakeLlama,
         LLAMA_ROPE_SCALING_TYPE_YARN=2,
-        GGML_TYPE_Q8_0=18,
+        GGML_TYPE_Q8_0=8,
         __file__='/opt/token.place/llama_cpp/__init__.py',
         __version__='0.3.32',
     )
@@ -5544,8 +5593,8 @@ def test_qwen_64k_context_create_failure_retries_q8_profile(tmp_path):
     assert len(attempts) == 2
     assert attempts[0]['n_ctx'] == 65536
     assert 'type_k' not in attempts[0]
-    assert attempts[1]['type_k'] == 18
-    assert attempts[1]['type_v'] == 18
+    assert attempts[1]['type_k'] == 8
+    assert attempts[1]['type_v'] == 8
     assert attempts[1]['flash_attn'] is True
     assert attempts[1]['offload_kqv'] is True
     assert manager.last_compute_diagnostics['qwen_64k_memory_profile']['profile_id'] == 'qwen64k_kv_q8'
@@ -5580,7 +5629,7 @@ def test_qwen_64k_all_profiles_fail_closed_before_registration(tmp_path):
     fake_llama_cpp = SimpleNamespace(
         Llama=FakeLlama,
         LLAMA_ROPE_SCALING_TYPE_YARN=2,
-        GGML_TYPE_Q8_0=18,
+        GGML_TYPE_Q8_0=8,
         GGML_TYPE_Q4_0=2,
         __file__='/opt/token.place/llama_cpp/__init__.py',
     )
@@ -5602,7 +5651,7 @@ def test_qwen_64k_kv_constants_resolve_top_level_nested_and_numeric_fallback():
             pass
 
     top_value, top_diag = model_manager_module._resolve_ggml_kv_cache_type(
-        SimpleNamespace(GGML_TYPE_Q8_0=18), KwargsLlama, 'q8'
+        SimpleNamespace(GGML_TYPE_Q8_0=8), KwargsLlama, 'q8'
     )
     nested_value, nested_diag = model_manager_module._resolve_ggml_kv_cache_type(
         SimpleNamespace(llama_cpp=SimpleNamespace(LLAMA_TYPE_Q4_0=2)), KwargsLlama, 'q4'
@@ -5611,9 +5660,9 @@ def test_qwen_64k_kv_constants_resolve_top_level_nested_and_numeric_fallback():
         SimpleNamespace(), KwargsLlama, 'q8'
     )
 
-    assert (top_value, top_diag['source']) == (18, 'top_level')
+    assert (top_value, top_diag['source']) == (8, 'top_level')
     assert (nested_value, nested_diag['source']) == (2, 'nested')
-    assert (fallback_value, fallback_diag['source']) == (18, 'verified_numeric_fallback')
+    assert (fallback_value, fallback_diag['source']) == (8, 'verified_numeric_fallback')
 
 
 def test_child_context_create_error_classification_and_stderr_redaction():

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -5721,7 +5721,7 @@ def test_child_diagnostic_sanitizer_redacts_secret_values_on_allowlisted_lines()
 
     raw = (
         'ggml_metal: KV cache allocation failed; prompt=SECRET_PROMPT assistant=SECRET_ASSISTANT '
-        'ciphertext=CIPHERTEXT_BODY key=API_KEY_VALUE token=TOKEN_VALUE\n'
+        'ciphertext=CIPHERTEXT_BODY key=API_KEY_VALUE token=TOKEN_VALUE user_token=SK_LIVE_VALUE\n'
         'llama_context failed with decrypted_payload=PLAINTEXT_PAYLOAD and arbitrary SECRET_SNIPPET\n'
     )
 
@@ -5738,11 +5738,13 @@ def test_child_diagnostic_sanitizer_redacts_secret_values_on_allowlisted_lines()
         'TOKEN_VALUE',
         'PLAINTEXT_PAYLOAD',
         'SECRET_SNIPPET',
+        'SK_LIVE_VALUE',
     ):
         assert leaked not in sanitized
     assert 'prompt=<redacted>' in sanitized
     assert 'ciphertext=<redacted>' in sanitized
     assert 'decrypted_payload=<redacted>' in sanitized
+    assert 'user_token=<redacted>' in sanitized
 
 def test_path_redaction_handles_spaces_and_traceback_paths():
     from utils.llm import model_manager as model_manager_module

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4969,13 +4969,13 @@ def test_qwen_64k_runtime_applies_memory_profile_only_to_64k(tmp_path):
          patch.object(manager, '_runtime_capabilities', return_value={'backend': 'metal', 'gpu_offload_supported': True, 'error': None}):
         assert manager.get_llm_instance() is not None
 
-    assert captured['type_k'] == 8
-    assert captured['type_v'] == 8
+    assert 'type_k' not in captured
+    assert 'type_v' not in captured
     assert 'flash_attn' not in captured
     assert 'offload_kqv' not in captured
-    assert captured['n_batch'] == 256
-    assert captured['n_ubatch'] == 128
-    assert manager.last_compute_diagnostics['kv_cache_mode']['type_k'] == 8
+    assert 'n_batch' not in captured
+    assert 'n_ubatch' not in captured
+    assert manager.last_compute_diagnostics['qwen_64k_memory_profile']['profile_id'] == 'qwen64k_default'
 
 
 def test_qwen_64k_runtime_omits_memory_profile_when_kwargs_unsupported(tmp_path):
@@ -5025,7 +5025,7 @@ def test_qwen_64k_memory_profile_does_not_trust_subprocess_proxy_kwargs():
 
     assert facade.LLAMA_TYPE_Q8_0 == 8
     assert kwargs == {}
-    assert diagnostics['kv_cache_type_name'] == 'LLAMA_TYPE_Q8_0'
+    assert diagnostics['kv_precision'] == 'q8'
     assert diagnostics['constructor_kwarg_support']['type_k'] is False
 
 
@@ -5499,3 +5499,130 @@ def test_subprocess_worker_error_summary_keeps_safe_category_hint():
     summary = namespace['_sanitize_error_summary'](RuntimeError('Metal failed to allocate KV cache for /tmp/model.gguf'))
 
     assert summary == 'RuntimeError:metal_memory_allocation'
+
+def test_qwen_64k_context_create_failure_retries_q8_profile(tmp_path):
+    from utils.context_profiles import apply_context_profile
+
+    attempts = []
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': -1,
+        'model.gpu_mode': 'gpu',
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    class FakeLlama:
+        def __init__(self, **kwargs):
+            attempts.append(dict(kwargs))
+            if 'type_k' not in kwargs:
+                raise ValueError('Failed to create llama_context: Metal KV cache allocation failed')
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+            return '<qwen>'
+
+    fake_llama_cpp = SimpleNamespace(
+        Llama=FakeLlama,
+        LLAMA_ROPE_SCALING_TYPE_YARN=2,
+        GGML_TYPE_Q8_0=18,
+        __file__='/opt/token.place/llama_cpp/__init__.py',
+        __version__='0.3.32',
+    )
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama_cpp), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'metal', 'gpu_offload_supported': True, 'error': None}):
+        llm = manager.get_llm_instance()
+
+    assert llm is not None
+    assert len(attempts) == 2
+    assert attempts[0]['n_ctx'] == 65536
+    assert 'type_k' not in attempts[0]
+    assert attempts[1]['type_k'] == 18
+    assert attempts[1]['type_v'] == 18
+    assert attempts[1]['flash_attn'] is True
+    assert attempts[1]['offload_kqv'] is True
+    assert manager.last_compute_diagnostics['qwen_64k_memory_profile']['profile_id'] == 'qwen64k_kv_q8'
+    assert manager.last_qwen_64k_init_failures[0]['safe_error_category'] == 'runtime_context_create_kv_cache_allocation'
+
+
+def test_qwen_64k_all_profiles_fail_closed_before_registration(tmp_path):
+    from utils.context_profiles import apply_context_profile
+
+    attempts = []
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': -1,
+        'model.gpu_mode': 'gpu',
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    class FakeLlama:
+        def __init__(self, **kwargs):
+            attempts.append(dict(kwargs))
+            raise ValueError('Failed to create llama_context: Metal buffer size too large')
+
+    fake_llama_cpp = SimpleNamespace(
+        Llama=FakeLlama,
+        LLAMA_ROPE_SCALING_TYPE_YARN=2,
+        GGML_TYPE_Q8_0=18,
+        GGML_TYPE_Q4_0=2,
+        __file__='/opt/token.place/llama_cpp/__init__.py',
+    )
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama_cpp), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'metal', 'gpu_offload_supported': True, 'error': None}):
+        assert manager.get_llm_instance() is None
+
+    assert len(attempts) == 3
+    assert manager.llm is None
+    assert 'Qwen 64K memory/KV/cache profile exhaustion before registration' in manager.last_runtime_init_error
+    assert 'runtime_context_create_metal_buffer_limit' in manager.last_runtime_init_error
+
+
+def test_qwen_64k_kv_constants_resolve_top_level_nested_and_numeric_fallback():
+    from utils.llm import model_manager as model_manager_module
+
+    class KwargsLlama:
+        def __init__(self, **kwargs):
+            pass
+
+    top_value, top_diag = model_manager_module._resolve_ggml_kv_cache_type(
+        SimpleNamespace(GGML_TYPE_Q8_0=18), KwargsLlama, 'q8'
+    )
+    nested_value, nested_diag = model_manager_module._resolve_ggml_kv_cache_type(
+        SimpleNamespace(llama_cpp=SimpleNamespace(LLAMA_TYPE_Q4_0=2)), KwargsLlama, 'q4'
+    )
+    fallback_value, fallback_diag = model_manager_module._resolve_ggml_kv_cache_type(
+        SimpleNamespace(), KwargsLlama, 'q8'
+    )
+
+    assert (top_value, top_diag['source']) == (18, 'top_level')
+    assert (nested_value, nested_diag['source']) == (2, 'nested')
+    assert (fallback_value, fallback_diag['source']) == (8, 'verified_numeric_fallback')
+
+
+def test_child_context_create_error_classification_and_stderr_redaction():
+    from utils.llm import model_manager as model_manager_module
+
+    stderr = '/Users/alice/app/model.gguf ggml_metal: failed to allocate KV cache buffer'
+    assert model_manager_module._classify_runtime_context_create_error(
+        ValueError('Failed to create llama_context'), stderr
+    ) == 'runtime_context_create_kv_cache_allocation'
+    redacted = model_manager_module._redact_paths_from_text(stderr)
+    assert '/Users/alice' not in redacted
+    assert '<path>' in redacted

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3579,6 +3579,37 @@ def test_llama_subprocess_transport_error_payload_raises_restartable_eof():
         )
 
 
+def test_llama_subprocess_transport_error_omits_unsafely_unallowlisted_secret():
+    from utils.llm import model_manager as model_manager_module
+
+    class _Stdout:
+        def __iter__(self):
+            return iter((
+                'TOKEN_PLACE_LLAMA_CPP_JSON:'
+                '{"status":"transport_error","error":"prompt=SECRET_PROMPT authorization=Bearer SECRET_TOKEN"}\n',
+            ))
+
+    process = SimpleNamespace(
+        stdout=_Stdout(),
+        stderr=None,
+        wait=MagicMock(return_value=7),
+        poll=lambda: None,
+        returncode=None,
+    )
+
+    with pytest.raises(model_manager_module.LlamaCppWorkerEOFError) as exc_info:
+        model_manager_module._read_llama_subprocess_message(
+            process,
+            timeout_seconds=0.2,
+            stage='llama_cpp_import',
+        )
+
+    error = str(exc_info.value)
+    assert 'unsafe child diagnostic omitted' in error
+    assert 'SECRET_PROMPT' not in error
+    assert 'SECRET_TOKEN' not in error
+    assert 'authorization' not in error
+
 def test_subprocess_llama_proxy_liveness_and_close_edge_cases():
     from utils.llm import model_manager as model_manager_module
 

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -5403,13 +5403,13 @@ def test_qwen_64k_memory_profile_disables_kqv_offload_for_cpu_fallback():
             }
 
     kwargs, diagnostics = model_manager_module._qwen_64k_memory_profile_kwargs(
-        SimpleNamespace(LLAMA_TYPE_Q8_0=8),
+        SimpleNamespace(),
         FakeLlama,
         enable_kqv_offload=False,
     )
 
-    assert kwargs['type_k'] == 8
-    assert kwargs['type_v'] == 8
+    assert kwargs['type_k'] == 18
+    assert kwargs['type_v'] == 18
     assert 'flash_attn' not in kwargs
     assert 'offload_kqv' not in kwargs
     assert diagnostics['kqv_offload_allowed'] is False
@@ -5613,7 +5613,7 @@ def test_qwen_64k_kv_constants_resolve_top_level_nested_and_numeric_fallback():
 
     assert (top_value, top_diag['source']) == (18, 'top_level')
     assert (nested_value, nested_diag['source']) == (2, 'nested')
-    assert (fallback_value, fallback_diag['source']) == (8, 'verified_numeric_fallback')
+    assert (fallback_value, fallback_diag['source']) == (18, 'verified_numeric_fallback')
 
 
 def test_child_context_create_error_classification_and_stderr_redaction():
@@ -5625,4 +5625,41 @@ def test_child_context_create_error_classification_and_stderr_redaction():
     ) == 'runtime_context_create_kv_cache_allocation'
     redacted = model_manager_module._redact_paths_from_text(stderr)
     assert '/Users/alice' not in redacted
+    assert '<path>' in redacted
+
+
+def test_safe_constructor_capability_payload_rejects_bool_kv_values():
+    from utils.llm import model_manager as model_manager_module
+
+    module = SimpleNamespace(__token_place_worker_capabilities__={
+        'constructor_kwarg_support': {'type_k': True},
+        'q8_kv_cache_type_value': True,
+        'q4_kv_cache_type_value': 2,
+    })
+
+    payload = model_manager_module._safe_constructor_capability_payload(module)
+
+    assert 'q8_kv_cache_type_value' not in payload
+    assert payload['q4_kv_cache_type_value'] == 2
+
+
+def test_unrecognized_init_failure_is_not_context_create_retryable():
+    from utils.llm import model_manager as model_manager_module
+
+    category = model_manager_module._classify_runtime_context_create_error(
+        RuntimeError('invalid gguf header: missing tensor metadata')
+    )
+
+    assert category == 'runtime_init_unclassified'
+    assert category not in model_manager_module.QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES
+
+
+def test_path_redaction_handles_spaces_and_traceback_paths():
+    from utils.llm import model_manager as model_manager_module
+
+    text = 'File "/Users/Alice/Application Support/token.place/model.gguf", line 10, in <module>'
+    redacted = model_manager_module._redact_paths_from_text(text)
+
+    assert '/Users/Alice' not in redacted
+    assert 'Application Support' not in redacted
     assert '<path>' in redacted

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -5716,6 +5716,34 @@ def test_generic_context_create_failure_is_not_retryable_without_memory_kv_or_bu
     assert category not in model_manager_module.QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES
 
 
+def test_child_diagnostic_sanitizer_redacts_secret_values_on_allowlisted_lines():
+    from utils.llm import model_manager as model_manager_module
+
+    raw = (
+        'ggml_metal: KV cache allocation failed; prompt=SECRET_PROMPT assistant=SECRET_ASSISTANT '
+        'ciphertext=CIPHERTEXT_BODY key=API_KEY_VALUE token=TOKEN_VALUE\n'
+        'llama_context failed with decrypted_payload=PLAINTEXT_PAYLOAD and arbitrary SECRET_SNIPPET\n'
+    )
+
+    sanitized = model_manager_module._sanitize_child_diagnostic_text(raw)
+
+    assert 'ggml_metal' in sanitized
+    assert 'KV cache allocation failed' in sanitized
+    assert 'llama_context failed' in sanitized
+    for leaked in (
+        'SECRET_PROMPT',
+        'SECRET_ASSISTANT',
+        'CIPHERTEXT_BODY',
+        'API_KEY_VALUE',
+        'TOKEN_VALUE',
+        'PLAINTEXT_PAYLOAD',
+        'SECRET_SNIPPET',
+    ):
+        assert leaked not in sanitized
+    assert 'prompt=<redacted>' in sanitized
+    assert 'ciphertext=<redacted>' in sanitized
+    assert 'decrypted_payload=<redacted>' in sanitized
+
 def test_path_redaction_handles_spaces_and_traceback_paths():
     from utils.llm import model_manager as model_manager_module
 

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -2634,8 +2634,8 @@ def test_subprocess_llama_proxy_early_exit_reports_process_diagnostics(tmp_path,
     fake_pkg.mkdir(parents=True)
     (fake_pkg / '__init__.py').write_text(
         "import sys\n"
-        "print('stdout clue before exit')\n"
-        "print('stderr clue before exit', file=sys.stderr)\n"
+        "print('stdout llama_context clue before exit')\n"
+        "print('stderr llama_context clue before exit', file=sys.stderr)\n"
         "sys.exit(7)\n",
         encoding='utf-8',
     )
@@ -2649,10 +2649,10 @@ def test_subprocess_llama_proxy_early_exit_reports_process_diagnostics(tmp_path,
     assert 'llama_cpp_import subprocess exited before JSON handshake' in message
     assert 'llama_cpp_import subprocess ended' not in message
     assert 'exit_code=7' in message
-    assert 'stdout clue before exit' in message
-    assert 'stderr clue before exit' in message
-    assert 'import_root=C:' in message
-    assert 'token.place desktop' in message
+    assert 'stdout llama_context clue before exit' in message
+    assert 'stderr llama_context clue before exit' in message
+    assert 'import_root=<path>' in message
+    assert 'token.place desktop' not in message
 
 
 def test_subprocess_llama_proxy_initial_write_early_exit_reports_diagnostic(monkeypatch):
@@ -2678,7 +2678,7 @@ def test_subprocess_llama_proxy_initial_write_early_exit_reports_diagnostic(monk
                 'TOKEN_PLACE_LLAMA_CPP_JSON:{"status":"ok","prompt":"secret prompt","chunk":"generated text"}\n',
                 'native loader clue\n',
             ]
-            self._token_place_stderr_tail = ['stderr clue\n']
+            self._token_place_stderr_tail = ['stderr llama_context clue\n']
 
         def poll(self):
             return 9
@@ -2708,6 +2708,8 @@ def test_subprocess_llama_proxy_initial_write_early_exit_reports_diagnostic(monk
     assert 'TOKEN_PLACE_LLAMA_CPP_JSON' not in message
     assert 'secret prompt' not in message
     assert 'generated text' not in message
+    assert 'native loader clue' not in message
+    assert 'stderr_tail=' in message
     assert created
 
 
@@ -5701,6 +5703,17 @@ def test_unrecognized_init_failure_is_not_context_create_retryable():
 
     assert category == 'runtime_init_unclassified'
     assert category not in model_manager_module.QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES
+
+
+def test_generic_context_create_failure_is_retryable():
+    from utils.llm import model_manager as model_manager_module
+
+    category = model_manager_module._classify_runtime_context_create_error(
+        ValueError('Failed to create llama_context')
+    )
+
+    assert category == 'runtime_context_create_failed'
+    assert category in model_manager_module.QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES
 
 
 def test_path_redaction_handles_spaces_and_traceback_paths():

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -405,17 +405,40 @@ _CHILD_DIAGNOSTIC_ALLOWLIST = re.compile(
     r'flash_attn|type_k|type_v|n_ctx|context|unsupported|keyword|argument|failed)',
     re.IGNORECASE,
 )
+_CHILD_DIAGNOSTIC_SENSITIVE_FIELD_RE = re.compile(
+    r'(?i)(?<![\w-])('
+    r'prompt|assistant|message|content|(?:decrypted[_-]?)?payload|ciphertext|plaintext|decrypted|secret|'
+    r'key|token|authorization|api[_-]?key'
+    r')(?![\w-])\s*[:=]\s*(?:"[^"]*"|\'[^\']*\'|[^\s,;]+)'
+)
+_CHILD_DIAGNOSTIC_SENSITIVE_TOKEN_RE = re.compile(
+    r'(?i)\b(?!(?:secret|ciphertext|plaintext|decrypted|(?:decrypted[_-]?)?payload|'
+    r'key|token|api[_-]?key)\b)[^\s,;:=]*(?:secret|ciphertext|plaintext|decrypted|payload|'
+    r'api[_-]?key)[^\s,;:=]*\b'
+)
+_CHILD_DIAGNOSTIC_PROTOCOL_PREFIXES = (
+    'TOKEN_PLACE_LLAMA_CPP_JSON:',
+)
+
+
+def _sanitize_child_diagnostic_line(line: str) -> str:
+    stripped = line.strip()
+    if not stripped or stripped.startswith(_CHILD_DIAGNOSTIC_PROTOCOL_PREFIXES):
+        return ''
+    if not _CHILD_DIAGNOSTIC_ALLOWLIST.search(stripped):
+        return ''
+    sanitized = _CHILD_DIAGNOSTIC_SENSITIVE_FIELD_RE.sub(lambda match: f'{match.group(1)}=<redacted>', stripped)
+    sanitized = _CHILD_DIAGNOSTIC_SENSITIVE_TOKEN_RE.sub('<redacted>', sanitized)
+    return sanitized[:300]
 
 
 def _sanitize_child_diagnostic_text(text: Any, *, limit: int = 1200) -> str:
     redacted = _redact_paths_from_text(text, limit=limit * 2)
     safe_lines = []
     for line in redacted.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            continue
-        if _CHILD_DIAGNOSTIC_ALLOWLIST.search(stripped):
-            safe_lines.append(stripped[:300])
+        sanitized = _sanitize_child_diagnostic_line(line)
+        if sanitized:
+            safe_lines.append(sanitized)
         if len('\n'.join(safe_lines)) >= limit:
             break
     return '\n'.join(safe_lines)[-limit:].strip()

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -47,6 +47,12 @@ QWEN_64K_UBATCH_TOKENS = 128
 QWEN_64K_RUNTIME_PROFILE_DEFAULT = 'qwen64k_default'
 QWEN_64K_RUNTIME_PROFILE_Q8 = 'qwen64k_kv_q8'
 QWEN_64K_RUNTIME_PROFILE_Q4 = 'qwen64k_kv_q4'
+# Only retry context-create failures backed by safe Metal/KV/cache/buffer
+# evidence. A bare ``Failed to create llama_context`` remains classified as
+# ``runtime_context_create_failed`` but is intentionally non-retryable so corrupt
+# GGUF/runtime/ABI init causes are not masked as memory-profile exhaustion. The
+# packaged-runtime retry regression supplies sanitized ggml_metal/KV stderr
+# diagnostics, which exercises the intended bounded recovery path.
 QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES = {
     'runtime_context_create_metal_memory',
     'runtime_context_create_kv_cache_allocation',

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -51,6 +51,7 @@ QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES = {
     'runtime_context_create_metal_memory',
     'runtime_context_create_kv_cache_allocation',
     'runtime_context_create_metal_buffer_limit',
+    'runtime_context_create_failed',
 }
 
 CRITICAL_STDLIB_IMPORT_MODULES = (
@@ -1330,13 +1331,22 @@ def _format_llama_subprocess_early_exit_detail(process: subprocess.Popen, *, sta
     cwd = getattr(process, '_token_place_cwd', None)
     import_root = getattr(process, '_token_place_import_root', None)
     module_path_hint = getattr(process, '_token_place_module_path_hint', None)
+    stdout_tail = _sanitize_child_diagnostic_text(_llama_subprocess_tail(process, '_token_place_stdout_tail'))
+    stderr_tail = _sanitize_child_diagnostic_text(_llama_subprocess_tail(process, '_token_place_stderr_tail'))
+    safe_command = (
+        [_redact_paths_from_text(part) for part in command]
+        if isinstance(command, list)
+        else _redact_paths_from_text(command or 'unknown')
+    )
     return (
         f"{stage} subprocess exited before JSON handshake; "
         f"exit_code={exit_code if exit_code is not None else 'running'} "
-        f"program={sys.executable} command={command or 'unknown'} cwd={cwd or 'unknown'} "
-        f"import_root={import_root or 'unknown'} module_path_hint={module_path_hint or 'unknown'} "
-        f"stage={stage} stdout_tail={_llama_subprocess_tail(process, '_token_place_stdout_tail') or '<empty>'} "
-        f"stderr_tail={_llama_subprocess_tail(process, '_token_place_stderr_tail') or '<empty>'}"
+        f"program={_redact_paths_from_text(sys.executable)} command={safe_command} "
+        f"cwd={_redact_paths_from_text(cwd or 'unknown')} "
+        f"import_root={_redact_paths_from_text(import_root or 'unknown')} "
+        f"module_path_hint={_redact_paths_from_text(module_path_hint or 'unknown')} "
+        f"stage={stage} stdout_tail={stdout_tail or '<empty>'} "
+        f"stderr_tail={stderr_tail or '<empty>'}"
     )
 
 
@@ -1394,7 +1404,10 @@ def _read_llama_subprocess_message(
     if not isinstance(message, dict):
         raise RuntimeError(f'{stage} returned non-object JSON')
     if message.get('status') == 'transport_error':
-        raise LlamaCppWorkerEOFError(str(message.get('error') or f'{stage} worker exited before response'))
+        safe_error = _sanitize_child_diagnostic_text(message.get('error')) or _redact_paths_from_text(
+            message.get('error') or f'{stage} worker exited before response'
+        )
+        raise LlamaCppWorkerEOFError(safe_error)
     if message.get('status') == 'error':
         raw_error = str(message.get('error') or f'{stage} failed')
         error = raw_error

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -411,6 +411,12 @@ _CHILD_DIAGNOSTIC_SENSITIVE_FIELD_RE = re.compile(
     r'key|token|authorization|api[_-]?key'
     r')(?![\w-])\s*[:=]\s*(?:"[^"]*"|\'[^\']*\'|[^\s,;]+)'
 )
+_CHILD_DIAGNOSTIC_SENSITIVE_PREFIXED_FIELD_RE = re.compile(
+    r'(?i)(?<![\w-])('
+    r'[A-Za-z0-9_-]*(?:secret|ciphertext|plaintext|decrypted|payload|token|authorization|'
+    r'api[_-]?key|[_-]key|key[_-])[A-Za-z0-9_-]*'
+    r')\s*[:=]\s*(?:"[^"]*"|\'[^\']*\'|[^\s,;]+)'
+)
 _CHILD_DIAGNOSTIC_SENSITIVE_TOKEN_RE = re.compile(
     r'(?i)\b(?!(?:secret|ciphertext|plaintext|decrypted|(?:decrypted[_-]?)?payload|'
     r'key|token|api[_-]?key)\b)[^\s,;:=]*(?:secret|ciphertext|plaintext|decrypted|payload|'
@@ -428,6 +434,10 @@ def _sanitize_child_diagnostic_line(line: str) -> str:
     if not _CHILD_DIAGNOSTIC_ALLOWLIST.search(stripped):
         return ''
     sanitized = _CHILD_DIAGNOSTIC_SENSITIVE_FIELD_RE.sub(lambda match: f'{match.group(1)}=<redacted>', stripped)
+    sanitized = _CHILD_DIAGNOSTIC_SENSITIVE_PREFIXED_FIELD_RE.sub(
+        lambda match: f'{match.group(1)}=<redacted>',
+        sanitized,
+    )
     sanitized = _CHILD_DIAGNOSTIC_SENSITIVE_TOKEN_RE.sub('<redacted>', sanitized)
     return sanitized[:300]
 

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -51,7 +51,6 @@ QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES = {
     'runtime_context_create_metal_memory',
     'runtime_context_create_kv_cache_allocation',
     'runtime_context_create_metal_buffer_limit',
-    'runtime_context_create_failed',
 }
 
 CRITICAL_STDLIB_IMPORT_MODULES = (
@@ -115,7 +114,7 @@ def _safe_constructor_capability_payload(llama_cpp_module: Any) -> Dict[str, Any
         }
     for key in ('q8_kv_cache_type_value', 'q4_kv_cache_type_value', 'f16_kv_cache_type_value'):
         value = capabilities.get(key)
-        if isinstance(value, int):
+        if isinstance(value, int) and not isinstance(value, bool):
             payload[key] = value
     for field in (
         'capability_source',
@@ -231,7 +230,7 @@ def _resolve_ggml_kv_cache_type(
         diagnostics.update({'source': 'worker_probe', 'name': capability_key, 'value': capability_value})
         return capability_value, diagnostics
 
-    numeric_fallbacks = {'f16': 1, 'q4': 2, 'q8': 8}
+    numeric_fallbacks = {'f16': 1, 'q4': 2, 'q8': 18}
     support = kwarg_support or _llama_constructor_supports_kwargs(llama_cls, ('type_k', 'type_v'))
     if precision in numeric_fallbacks and (support.get('type_k') or support.get('type_v')):
         diagnostics.update({
@@ -385,13 +384,14 @@ def _classify_runtime_context_create_error(error: Any, child_stderr: str = '') -
         return 'runtime_context_create_metal_memory'
     if 'failed to create llama_context' in text or 'llamacontext' in text:
         return 'runtime_context_create_failed'
-    return 'runtime_context_create_failed'
+    return 'runtime_init_unclassified'
 
 
 def _redact_paths_from_text(text: Any, *, limit: int = 2000) -> str:
     redacted = str(text or '')
-    redacted = re.sub(r'([A-Za-z]:)?[/\\][^\s:;]+(?:[/\\][^\s:;]+)+', '<path>', redacted)
-    redacted = re.sub(r'\b(?:[A-Za-z]:)?(?:[A-Za-z0-9_.-]+[/\\]){2,}[A-Za-z0-9_.-]+', '<path>', redacted)
+    path_chars = r'[^\n\r\t<>|*?";]+'
+    redacted = re.sub(rf'(?<!\w)(?:[A-Za-z]:)?[/\\]{path_chars}(?:[/\\]{path_chars})+', '<path>', redacted)
+    redacted = re.sub(r'\b(?:[A-Za-z]:)?(?:[A-Za-z0-9_. -]+[/\\]){2,}[A-Za-z0-9_. -]+', '<path>', redacted)
     return redacted[-limit:].strip()
 
 
@@ -1370,7 +1370,7 @@ def _read_llama_subprocess_message(
             raise LlamaCppInferenceRequestError(error, diagnostics=safe_diagnostics)
         traceback_text = str(message.get('traceback') or '').strip()
         if traceback_text:
-            error = f"{error}; child_traceback_tail={traceback_text[-2000:]}"
+            error = f"{error}; child_traceback_tail={_redact_paths_from_text(traceback_text)}"
         raise RuntimeError(error)
     return message
 
@@ -1432,6 +1432,7 @@ class _SubprocessLlamaProxy:
         try:
             self._send({'method': '__init__', 'args': args, 'kwargs': kwargs}, check_health=False)
         except (LlamaCppWorkerBrokenPipeError, BrokenPipeError, OSError) as exc:
+            self.close()
             raise RuntimeError(
                 _format_llama_subprocess_early_exit_detail(self._process, stage='llama_cpp_import')
             ) from exc
@@ -1442,12 +1443,18 @@ class _SubprocessLlamaProxy:
                 stage='llama_cpp_import',
             )
         except LlamaCppRuntimeStageTimeout:
+            self.close()
             raise
         except Exception as exc:
             stderr_tail = _redact_paths_from_text(_llama_subprocess_tail(self._process, '_token_place_stderr_tail'))
             category = _classify_runtime_context_create_error(exc, stderr_tail)
+            if isinstance(exc, LlamaCppWorkerEOFError):
+                safe_exc = _format_llama_subprocess_early_exit_detail(self._process, stage='llama_cpp_import')
+            else:
+                safe_exc = _redact_paths_from_text(exc)
+            self.close()
             raise RuntimeError(
-                f"{exc}; child_exception_type={type(exc).__name__}; "
+                f"{safe_exc}; child_exception_type={type(exc).__name__}; "
                 f"safe_error_category={category}; child_stderr_tail={stderr_tail or '<empty>'}"
             ) from exc
 
@@ -3178,6 +3185,8 @@ class ModelManager:
                                 and int(self.config.get('model.context_size', 8192)) == 65536
                             )
                             if is_qwen_64k:
+                                _runtime_supports_qwen_yarn_rope(llama_cpp, Llama)
+                                Llama = llama_cpp.Llama
                                 runtime_profiles = _build_qwen_64k_runtime_profiles(
                                     llama_cpp,
                                     Llama,

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1442,9 +1442,9 @@ def _read_llama_subprocess_message(
     if not isinstance(message, dict):
         raise RuntimeError(f'{stage} returned non-object JSON')
     if message.get('status') == 'transport_error':
-        safe_error = _sanitize_child_diagnostic_text(message.get('error')) or _redact_paths_from_text(
-            message.get('error') or f'{stage} worker exited before response'
-        )
+        safe_error = _sanitize_child_diagnostic_text(message.get('error'))
+        if not safe_error:
+            safe_error = f'{stage} worker transport error; unsafe child diagnostic omitted'
         raise LlamaCppWorkerEOFError(safe_error)
     if message.get('status') == 'error':
         raw_error = str(message.get('error') or f'{stage} failed')

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -6,6 +6,7 @@ import time
 import logging
 from utils.networking.http_requests_compat import requests
 import json
+import re
 import sys
 import importlib
 import importlib.metadata
@@ -36,10 +37,22 @@ QWEN_64K_YARN_UNSUPPORTED_MESSAGE = (
 # wheels accept rope_scaling_type as a constructor kwarg but do not export the
 # generated enum symbol, so this is only used after constructor support is verified.
 LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK = 2
-QWEN_64K_KV_CACHE_TYPE_NAME = 'LLAMA_TYPE_Q8_0'
+QWEN_64K_KV_CACHE_TYPE_NAMES = {
+    'f16': ('GGML_TYPE_F16', 'LLAMA_TYPE_F16'),
+    'q8': ('GGML_TYPE_Q8_0', 'LLAMA_TYPE_Q8_0'),
+    'q4': ('GGML_TYPE_Q4_0', 'LLAMA_TYPE_Q4_0'),
+}
 QWEN_64K_BATCH_TOKENS = 256
 QWEN_64K_UBATCH_TOKENS = 128
-QWEN_64K_MEMORY_PROFILE_ID = 'qwen3-64k-q8-kv'
+QWEN_64K_RUNTIME_PROFILE_DEFAULT = 'qwen64k_default'
+QWEN_64K_RUNTIME_PROFILE_Q8 = 'qwen64k_kv_q8'
+QWEN_64K_RUNTIME_PROFILE_Q4 = 'qwen64k_kv_q4'
+QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES = {
+    'runtime_context_create_metal_memory',
+    'runtime_context_create_kv_cache_allocation',
+    'runtime_context_create_metal_buffer_limit',
+    'runtime_context_create_failed',
+}
 
 CRITICAL_STDLIB_IMPORT_MODULES = (
     'collections',
@@ -100,9 +113,10 @@ def _safe_constructor_capability_payload(llama_cpp_module: Any) -> Dict[str, Any
         payload['constructor_kwarg_support'] = {
             str(name): bool(value) for name, value in support.items() if isinstance(name, str)
         }
-    q8_value = capabilities.get('q8_kv_cache_type_value')
-    if isinstance(q8_value, int):
-        payload['q8_kv_cache_type_value'] = q8_value
+    for key in ('q8_kv_cache_type_value', 'q4_kv_cache_type_value', 'f16_kv_cache_type_value'):
+        value = capabilities.get(key)
+        if isinstance(value, int):
+            payload[key] = value
     for field in (
         'capability_source',
         'backend',
@@ -188,12 +202,51 @@ def _safe_llama_cpp_enum(llama_cpp_module: Any, name: str) -> Any:
     return None
 
 
-def _qwen_64k_memory_profile_kwargs(
+def _resolve_ggml_kv_cache_type(
     llama_cpp_module: Any,
     llama_cls: Any,
-    *,
-    enable_kqv_offload: bool = True,
-) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    precision: str,
+    kwarg_support: Optional[Dict[str, bool]] = None,
+) -> tuple[Optional[int], Dict[str, Any]]:
+    """Resolve a GGML/llama.cpp KV cache type constant without passing guesses blindly."""
+
+    names = QWEN_64K_KV_CACHE_TYPE_NAMES.get(precision, ())
+    diagnostics: Dict[str, Any] = {'precision': precision, 'names': list(names), 'source': None}
+    for owner, source in (
+        (llama_cpp_module, 'top_level'),
+        (getattr(llama_cpp_module, 'llama_cpp', None), 'nested'),
+    ):
+        if owner is None:
+            continue
+        for name in names:
+            value = getattr(owner, name, None)
+            if isinstance(value, int) and not isinstance(value, bool):
+                diagnostics.update({'source': source, 'name': name, 'value': value})
+                return value, diagnostics
+
+    worker_capabilities = _safe_constructor_capability_payload(llama_cpp_module)
+    capability_key = f'{precision}_kv_cache_type_value'
+    capability_value = worker_capabilities.get(capability_key)
+    if isinstance(capability_value, int) and not isinstance(capability_value, bool):
+        diagnostics.update({'source': 'worker_probe', 'name': capability_key, 'value': capability_value})
+        return capability_value, diagnostics
+
+    numeric_fallbacks = {'f16': 1, 'q4': 2, 'q8': 8}
+    support = kwarg_support or _llama_constructor_supports_kwargs(llama_cls, ('type_k', 'type_v'))
+    if precision in numeric_fallbacks and (support.get('type_k') or support.get('type_v')):
+        diagnostics.update({
+            'source': 'verified_numeric_fallback',
+            'name': f'{precision}_numeric_fallback',
+            'value': numeric_fallbacks[precision],
+        })
+        return numeric_fallbacks[precision], diagnostics
+
+    diagnostics['source'] = 'unavailable'
+    diagnostics['reason'] = 'constant_unavailable_or_constructor_support_unverified'
+    return None, diagnostics
+
+
+def _qwen_64k_runtime_capabilities(llama_cpp_module: Any, llama_cls: Any) -> Dict[str, Any]:
     probe_kwargs = ('type_k', 'type_v', 'flash_attn', 'offload_kqv', 'n_batch', 'n_ubatch')
     worker_capabilities = _safe_constructor_capability_payload(llama_cpp_module)
     worker_kwarg_support = worker_capabilities.get('constructor_kwarg_support')
@@ -202,54 +255,176 @@ def _qwen_64k_memory_profile_kwargs(
         if isinstance(worker_kwarg_support, dict)
         else _llama_constructor_supports_kwargs(llama_cls, probe_kwargs)
     )
-    kwargs: Dict[str, Any] = {}
-    diagnostics: Dict[str, Any] = {
-        'profile_id': QWEN_64K_MEMORY_PROFILE_ID,
+    constants = {}
+    for precision in ('f16', 'q8', 'q4'):
+        value, diag = _resolve_ggml_kv_cache_type(llama_cpp_module, llama_cls, precision, kwarg_support)
+        constants[precision] = {'value': value, **diag}
+    return {
         'constructor_kwarg_support': kwarg_support,
         'capability_source': worker_capabilities.get('capability_source') or (
             'worker_probe' if isinstance(worker_kwarg_support, dict) else 'local_constructor_signature'
         ),
-        'applied': {},
-        'omitted': {},
+        'backend': worker_capabilities.get('backend'),
+        'llama_cpp_python_version': worker_capabilities.get('llama_cpp_python_version') or _llama_cpp_python_version(llama_cpp_module),
+        'kv_constants': constants,
     }
-    q8_type = worker_capabilities.get('q8_kv_cache_type_value')
-    if q8_type is None:
-        q8_type = _safe_llama_cpp_enum(llama_cpp_module, QWEN_64K_KV_CACHE_TYPE_NAME)
-    diagnostics['kv_cache_type_name'] = QWEN_64K_KV_CACHE_TYPE_NAME if q8_type is not None else None
-    omitted: Dict[str, str] = {}
-    if q8_type is not None:
-        if kwarg_support.get('type_k'):
-            kwargs['type_k'] = q8_type
-        else:
-            omitted['type_k'] = 'worker_capability_unsupported'
-        if kwarg_support.get('type_v'):
-            kwargs['type_v'] = q8_type
-        else:
-            omitted['type_v'] = 'worker_capability_unsupported'
-    else:
-        omitted['type_k'] = 'q8_enum_unavailable'
-        omitted['type_v'] = 'q8_enum_unavailable'
-    if enable_kqv_offload and kwarg_support.get('flash_attn'):
-        kwargs['flash_attn'] = True
-    else:
-        omitted['flash_attn'] = 'gpu_offload_disabled' if not enable_kqv_offload else 'worker_capability_unsupported'
-    diagnostics['kqv_offload_allowed'] = bool(enable_kqv_offload)
-    if enable_kqv_offload and kwarg_support.get('offload_kqv'):
-        kwargs['offload_kqv'] = True
-    else:
-        omitted['offload_kqv'] = 'gpu_offload_disabled' if not enable_kqv_offload else 'worker_capability_unsupported'
-    if kwarg_support.get('n_batch'):
-        kwargs['n_batch'] = QWEN_64K_BATCH_TOKENS
-    if kwarg_support.get('n_ubatch'):
-        kwargs['n_ubatch'] = QWEN_64K_UBATCH_TOKENS
-    for name in ('n_batch', 'n_ubatch'):
-        if name not in kwargs and not kwarg_support.get(name):
-            omitted[name] = 'worker_capability_unsupported'
-    diagnostics['applied'] = dict(kwargs)
-    diagnostics['omitted'] = omitted
-    diagnostics['enabled'] = bool(kwargs)
-    return kwargs, diagnostics
 
+
+def _qwen_64k_memory_estimate(model_path: Any, n_ctx: int, kv_precision: str, backend: str) -> Dict[str, Any]:
+    model_size = None
+    try:
+        model_size = os.path.getsize(str(model_path))
+    except OSError:
+        pass
+    bytes_per_token_by_precision = {'f16': 524288, 'q8': 262144, 'q4': 131072}
+    kv_bytes = int(n_ctx) * bytes_per_token_by_precision.get(kv_precision, bytes_per_token_by_precision['f16'])
+    total = (model_size or 0) + kv_bytes
+    return {
+        'model_file_size_bytes': model_size,
+        'estimated_kv_cache_bytes': kv_bytes,
+        'estimated_total_model_plus_kv_bytes': total if model_size is not None else None,
+        'context_size_tokens': int(n_ctx),
+        'backend': backend or 'unknown',
+        'kv_precision': kv_precision,
+    }
+
+
+def _build_qwen_64k_runtime_profiles(
+    llama_cpp_module: Any,
+    llama_cls: Any,
+    *,
+    model_path: Any,
+    n_ctx: int,
+    enable_kqv_offload: bool = True,
+) -> list[Dict[str, Any]]:
+    capabilities = _qwen_64k_runtime_capabilities(llama_cpp_module, llama_cls)
+    support = capabilities['constructor_kwarg_support']
+    profiles: list[Dict[str, Any]] = [{
+        'profile_id': QWEN_64K_RUNTIME_PROFILE_DEFAULT,
+        'kwargs': {},
+        'diagnostics': {
+            'profile_id': QWEN_64K_RUNTIME_PROFILE_DEFAULT,
+            'enabled': True,
+            'applied': {},
+            'omitted': {},
+            'constructor_kwarg_support': support,
+            'capability_source': capabilities['capability_source'],
+            'llama_cpp_python_version': capabilities.get('llama_cpp_python_version'),
+            'memory_estimate': _qwen_64k_memory_estimate(model_path, n_ctx, 'f16', capabilities.get('backend') or ''),
+            'kqv_offload_allowed': bool(enable_kqv_offload),
+        },
+    }]
+    for precision, profile_id in (('q8', QWEN_64K_RUNTIME_PROFILE_Q8), ('q4', QWEN_64K_RUNTIME_PROFILE_Q4)):
+        omitted: Dict[str, str] = {}
+        kwargs: Dict[str, Any] = {}
+        kv_info = capabilities['kv_constants'].get(precision) or {}
+        kv_value = kv_info.get('value')
+        if kv_value is None:
+            omitted['type_k'] = omitted['type_v'] = 'kv_type_constant_unavailable'
+        if kv_value is not None and support.get('type_k'):
+            kwargs['type_k'] = kv_value
+        elif kv_value is not None:
+            omitted['type_k'] = 'constructor_kwarg_unsupported'
+        if kv_value is not None and support.get('type_v'):
+            kwargs['type_v'] = kv_value
+        elif kv_value is not None:
+            omitted['type_v'] = 'constructor_kwarg_unsupported'
+        if 'type_v' in kwargs and precision != 'f16' and not enable_kqv_offload:
+            omitted['flash_attn'] = 'gpu_offload_disabled'
+        if 'type_v' in kwargs and precision != 'f16' and enable_kqv_offload:
+            if support.get('flash_attn'):
+                kwargs['flash_attn'] = True
+            else:
+                omitted['flash_attn'] = 'required_for_quantized_v_but_unsupported'
+                kwargs.pop('type_v', None)
+                if 'type_k' not in kwargs:
+                    omitted['profile'] = 'no_supported_quantized_kv_kwargs'
+        if enable_kqv_offload and support.get('offload_kqv'):
+            kwargs['offload_kqv'] = True
+        elif enable_kqv_offload:
+            omitted['offload_kqv'] = 'constructor_kwarg_unsupported'
+        if support.get('n_batch'):
+            kwargs['n_batch'] = QWEN_64K_BATCH_TOKENS
+        else:
+            omitted['n_batch'] = 'constructor_kwarg_unsupported'
+        if support.get('n_ubatch'):
+            kwargs['n_ubatch'] = QWEN_64K_UBATCH_TOKENS
+        else:
+            omitted['n_ubatch'] = 'constructor_kwarg_unsupported'
+        diagnostics = {
+            'profile_id': profile_id,
+            'enabled': bool(kwargs) and 'profile' not in omitted,
+            'applied': dict(kwargs),
+            'omitted': omitted,
+            'kv_precision': precision,
+            'kv_cache_type': kv_info,
+            'constructor_kwarg_support': support,
+            'capability_source': capabilities['capability_source'],
+            'llama_cpp_python_version': capabilities.get('llama_cpp_python_version'),
+            'memory_estimate': _qwen_64k_memory_estimate(model_path, n_ctx, precision, capabilities.get('backend') or ''),
+            'kqv_offload_allowed': bool(enable_kqv_offload),
+        }
+        if diagnostics['enabled']:
+            profiles.append({'profile_id': profile_id, 'kwargs': kwargs, 'diagnostics': diagnostics})
+        else:
+            profiles[0]['diagnostics'].setdefault('skipped_profiles', []).append(diagnostics)
+    return profiles
+
+
+def _classify_runtime_context_create_error(error: Any, child_stderr: str = '') -> str:
+    text = f'{error or ""}\n{child_stderr or ""}'.lower()
+    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument|unsupported (?:parameter|kwarg|argument))', text):
+        return 'runtime_context_create_unsupported_kwarg'
+    if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'orig', 'context'))):
+        return 'runtime_context_create_rope_yarn_config'
+    if 'kv' in text and any(term in text for term in ('alloc', 'cache', 'memory', 'oom', 'failed')):
+        return 'runtime_context_create_kv_cache_allocation'
+    if 'metal' in text and any(term in text for term in ('buffer', 'graph', 'max size', 'too large')):
+        return 'runtime_context_create_metal_buffer_limit'
+    if 'metal' in text and any(term in text for term in ('alloc', 'memory', 'oom', 'out of memory', 'failed to create llama_context')):
+        return 'runtime_context_create_metal_memory'
+    if 'failed to create llama_context' in text or 'llamacontext' in text:
+        return 'runtime_context_create_failed'
+    return 'runtime_context_create_failed'
+
+
+def _redact_paths_from_text(text: Any, *, limit: int = 2000) -> str:
+    redacted = str(text or '')
+    redacted = re.sub(r'([A-Za-z]:)?[/\\][^\s:;]+(?:[/\\][^\s:;]+)+', '<path>', redacted)
+    redacted = re.sub(r'\b(?:[A-Za-z]:)?(?:[A-Za-z0-9_.-]+[/\\]){2,}[A-Za-z0-9_.-]+', '<path>', redacted)
+    return redacted[-limit:].strip()
+
+
+
+def _qwen_64k_memory_profile_kwargs(
+    llama_cpp_module: Any,
+    llama_cls: Any,
+    *,
+    enable_kqv_offload: bool = True,
+) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    """Backward-compatible helper returning the first quantized Qwen 64K profile."""
+    profiles = _build_qwen_64k_runtime_profiles(
+        llama_cpp_module,
+        llama_cls,
+        model_path='',
+        n_ctx=65536,
+        enable_kqv_offload=enable_kqv_offload,
+    )
+    for profile in profiles:
+        if profile.get('profile_id') != QWEN_64K_RUNTIME_PROFILE_DEFAULT:
+            return dict(profile.get('kwargs') or {}), dict(profile.get('diagnostics') or {})
+    default_diag = dict(profiles[0].get('diagnostics') or {}) if profiles else {'enabled': False, 'applied': {}}
+    skipped = default_diag.get('skipped_profiles')
+    if isinstance(skipped, list) and skipped:
+        diag = dict(skipped[0])
+        if diag.get('capability_source') == 'worker_probe':
+            omitted = dict(diag.get('omitted') or {})
+            for key, value in list(omitted.items()):
+                if value == 'constructor_kwarg_unsupported':
+                    omitted[key] = 'worker_capability_unsupported'
+            diag['omitted'] = omitted
+        return {}, diag
+    return {}, default_diag
 
 def _format_qwen_yarn_unsupported_diagnostics(diagnostics: Dict[str, Any]) -> str:
     safe_fields = (
@@ -877,9 +1052,18 @@ def _probe_llama_cpp_capabilities_in_subprocess(*, timeout_seconds: Optional[flo
         "    qwen_yarn_support = 'unknown'\n"
         "else:\n"
         "    qwen_yarn_support = 'unsupported'\n"
-        "q8_value = getattr(llama_cpp, 'LLAMA_TYPE_Q8_0', None)\n"
-        "if q8_value is None:\n"
-        "    q8_value = getattr(getattr(llama_cpp, 'llama_cpp', None), 'LLAMA_TYPE_Q8_0', None)\n"
+        "def _const(*names):\n"
+        "    for owner in (llama_cpp, getattr(llama_cpp, 'llama_cpp', None)):\n"
+        "        if owner is None:\n"
+        "            continue\n"
+        "        for name in names:\n"
+        "            value = getattr(owner, name, None)\n"
+        "            if isinstance(value, int):\n"
+        "                return value\n"
+        "    return None\n"
+        "q8_value = _const('GGML_TYPE_Q8_0', 'LLAMA_TYPE_Q8_0')\n"
+        "q4_value = _const('GGML_TYPE_Q4_0', 'LLAMA_TYPE_Q4_0')\n"
+        "f16_value = _const('GGML_TYPE_F16', 'LLAMA_TYPE_F16')\n"
         "cuda_markers = ('GGML_USE_CUDA', 'GGML_CUDA', 'LLAMA_CUDA', 'GGML_USE_CUBLAS', 'LLAMA_CUBLAS')\n"
         "metal_markers = ('GGML_USE_METAL', 'GGML_METAL', 'LLAMA_METAL')\n"
         "backend = 'cpu'\n"
@@ -909,6 +1093,8 @@ def _probe_llama_cpp_capabilities_in_subprocess(*, timeout_seconds: Optional[flo
         "    'yarn_enum_value': yarn_value if isinstance(yarn_value, (int, float, str)) else None,\n"
         "    'qwen_64k_yarn_support': qwen_yarn_support,\n"
         "    'q8_kv_cache_type_value': q8_value if isinstance(q8_value, int) else None,\n"
+        "    'q4_kv_cache_type_value': q4_value if isinstance(q4_value, int) else None,\n"
+        "    'f16_kv_cache_type_value': f16_value if isinstance(f16_value, int) else None,\n"
         "    'capability_source': 'worker_probe',\n"
         "    'llama_cpp_python_version': getattr(llama_cpp, '__version__', None),\n"
         "    'error': None,\n"
@@ -1249,11 +1435,21 @@ class _SubprocessLlamaProxy:
             raise RuntimeError(
                 _format_llama_subprocess_early_exit_detail(self._process, stage='llama_cpp_import')
             ) from exc
-        _read_llama_subprocess_message(
-            self._process,
-            timeout_seconds=self._timeout_seconds,
-            stage='llama_cpp_import',
-        )
+        try:
+            _read_llama_subprocess_message(
+                self._process,
+                timeout_seconds=self._timeout_seconds,
+                stage='llama_cpp_import',
+            )
+        except LlamaCppRuntimeStageTimeout:
+            raise
+        except Exception as exc:
+            stderr_tail = _redact_paths_from_text(_llama_subprocess_tail(self._process, '_token_place_stderr_tail'))
+            category = _classify_runtime_context_create_error(exc, stderr_tail)
+            raise RuntimeError(
+                f"{exc}; child_exception_type={type(exc).__name__}; "
+                f"safe_error_category={category}; child_stderr_tail={stderr_tail or '<empty>'}"
+            ) from exc
 
     def _start_stderr_tail_reader(self) -> None:
         def _reader() -> None:
@@ -1761,7 +1957,7 @@ try:
     llama = llama_cpp.Llama(*init_payload.get('args', []), **init_payload.get('kwargs', {}))
     _emit({'status': 'ok', 'module_path': getattr(llama_cpp, '__file__', None)})
 except Exception as exc:
-    _emit({'status': 'error', 'error': str(exc), 'traceback': traceback.format_exc()})
+    _emit({'status': 'error', 'error': str(exc), 'exception_type': type(exc).__name__, 'safe_error_category': _classify_generation_exception(exc), 'traceback': traceback.format_exc()})
     raise SystemExit(1)
 
 for line in sys.stdin:
@@ -2581,7 +2777,7 @@ class ModelManager:
     def _qwen_non_thinking_required(self) -> bool:
         return self.model_profile.get('provider') == 'qwen' and self.model_profile.get('thinking_mode') == 'disabled'
 
-    def _runtime_init_kwargs(self, llama_cls: Any, n_gpu_layers: int, llama_cpp_module: Any = None) -> Dict[str, Any]:
+    def _runtime_init_kwargs(self, llama_cls: Any, n_gpu_layers: int, llama_cpp_module: Any = None, runtime_profile: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Build verified llama-cpp-python runtime kwargs for the selected profile.
 
         llama-cpp-python uses the GGUF/Jinja chat template when ``chat_format`` is
@@ -2664,13 +2860,23 @@ class ModelManager:
                     'yarn_orig_ctx': int(rope_policy.get('original_context_tokens', native_context)),
                 }
             )
-            memory_kwargs, memory_diagnostics = _qwen_64k_memory_profile_kwargs(
-                llama_module,
-                llama_cls,
-                enable_kqv_offload=n_gpu_layers > 0,
-            )
-            kwargs.update(memory_kwargs)
-            self.last_qwen_64k_memory_profile_diagnostics = memory_diagnostics
+            if runtime_profile is None:
+                runtime_profile = _build_qwen_64k_runtime_profiles(
+                    llama_module,
+                    llama_cls,
+                    model_path=self.model_path,
+                    n_ctx=n_ctx,
+                    enable_kqv_offload=n_gpu_layers != 0,
+                )[0]
+            profile_kwargs = runtime_profile.get('kwargs') if isinstance(runtime_profile, dict) else {}
+            if isinstance(profile_kwargs, dict):
+                kwargs.update(profile_kwargs)
+            profile_diagnostics = runtime_profile.get('diagnostics') if isinstance(runtime_profile, dict) else None
+            self.last_qwen_64k_memory_profile_diagnostics = dict(profile_diagnostics) if isinstance(profile_diagnostics, dict) else {
+                'profile_id': QWEN_64K_RUNTIME_PROFILE_DEFAULT,
+                'enabled': True,
+                'applied': {},
+            }
         else:
             self.last_qwen_64k_memory_profile_diagnostics = {'enabled': False, 'applied': {}}
             self.last_yarn_rope_diagnostics = {
@@ -2965,8 +3171,63 @@ class ModelManager:
 
                             self.log_info(f"About to instantiate Llama model from {self.model_path}...")
                             self.log_info(f"Llama init started for {self.model_path}.")
-                            runtime_kwargs = self._runtime_init_kwargs(Llama, n_gpu_layers, llama_cpp)
-                            llm_instance = Llama(**runtime_kwargs)
+                            runtime_profiles = [None]
+                            is_qwen_64k = (
+                                self.model_profile.get('provider') == 'qwen'
+                                and getattr(self, 'context_tier', '8k-fast') == '64k-full'
+                                and int(self.config.get('model.context_size', 8192)) == 65536
+                            )
+                            if is_qwen_64k:
+                                runtime_profiles = _build_qwen_64k_runtime_profiles(
+                                    llama_cpp,
+                                    Llama,
+                                    model_path=self.model_path,
+                                    n_ctx=int(self.config.get('model.context_size', 65536)),
+                                    enable_kqv_offload=n_gpu_layers != 0,
+                                )
+                            profile_failures = []
+                            llm_instance = None
+                            runtime_kwargs = {}
+                            for runtime_profile in runtime_profiles:
+                                runtime_kwargs = self._runtime_init_kwargs(Llama, n_gpu_layers, llama_cpp, runtime_profile)
+                                profile_diag = getattr(self, 'last_qwen_64k_memory_profile_diagnostics', {})
+                                profile_id = profile_diag.get('profile_id') if isinstance(profile_diag, dict) else 'default'
+                                try:
+                                    llm_instance = Llama(**runtime_kwargs)
+                                    if isinstance(profile_diag, dict):
+                                        profile_diag['selected'] = True
+                                        self.last_qwen_64k_memory_profile_diagnostics = profile_diag
+                                    break
+                                except Exception as init_exc:
+                                    category = _classify_runtime_context_create_error(init_exc)
+                                    safe_failure = {
+                                        'profile_id': profile_id,
+                                        'safe_error_category': category,
+                                        'exception_type': type(init_exc).__name__,
+                                        'context_tier': getattr(self, 'context_tier', '8k-fast'),
+                                        'n_ctx': runtime_kwargs.get('n_ctx'),
+                                        'backend': compute_plan.get('backend_used'),
+                                        'attempted_runtime_kwargs': {
+                                            key: runtime_kwargs.get(key)
+                                            for key in ('n_ctx', 'type_k', 'type_v', 'flash_attn', 'offload_kqv', 'n_batch', 'n_ubatch', 'rope_scaling_type', 'yarn_ext_factor', 'yarn_orig_ctx')
+                                            if key in runtime_kwargs
+                                        },
+                                    }
+                                    profile_failures.append(safe_failure)
+                                    if not is_qwen_64k or category not in QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES:
+                                        raise
+                                    close = getattr(init_exc, 'close', None)
+                                    if callable(close):
+                                        close()
+                                    continue
+                            if llm_instance is None:
+                                self.last_qwen_64k_init_failures = profile_failures
+                                raise RuntimeError(
+                                    'Qwen 64K memory/KV/cache profile exhaustion before registration; '
+                                    f'failures={profile_failures}'
+                                )
+                            if profile_failures:
+                                self.last_qwen_64k_init_failures = profile_failures
                             if self.model_profile.get('provider') == 'qwen':
                                 llm_type_module = type(llm_instance).__module__
                                 is_unit_test_fake = llm_type_module.startswith('tests.') and not os.path.basename(str(self.model_path)).startswith('Qwen3-')

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -230,7 +230,10 @@ def _resolve_ggml_kv_cache_type(
         diagnostics.update({'source': 'worker_probe', 'name': capability_key, 'value': capability_value})
         return capability_value, diagnostics
 
-    numeric_fallbacks = {'f16': 1, 'q4': 2, 'q8': 18}
+    # llama.cpp GGML enum fallback values. These are only used after the
+    # constructor is verified to support type_k/type_v, so a runtime that cannot
+    # accept KV-cache enum kwargs never receives guessed numeric values.
+    numeric_fallbacks = {'f16': 1, 'q4': 2, 'q8': 8}
     support = kwarg_support or _llama_constructor_supports_kwargs(llama_cls, ('type_k', 'type_v'))
     if precision in numeric_fallbacks and (support.get('type_k') or support.get('type_v')):
         diagnostics.update({
@@ -338,6 +341,8 @@ def _build_qwen_64k_runtime_profiles(
                 kwargs.pop('type_v', None)
                 if 'type_k' not in kwargs:
                     omitted['profile'] = 'no_supported_quantized_kv_kwargs'
+        if 'type_k' not in kwargs and 'type_v' not in kwargs:
+            omitted['profile'] = omitted.get('profile') or 'no_applied_quantized_kv_kwargs'
         if enable_kqv_offload and support.get('offload_kqv'):
             kwargs['offload_kqv'] = True
         elif enable_kqv_offload:
@@ -391,9 +396,37 @@ def _redact_paths_from_text(text: Any, *, limit: int = 2000) -> str:
     redacted = str(text or '')
     path_chars = r'[^\n\r\t<>|*?";]+'
     redacted = re.sub(rf'(?<!\w)(?:[A-Za-z]:)?[/\\]{path_chars}(?:[/\\]{path_chars})+', '<path>', redacted)
-    redacted = re.sub(r'\b(?:[A-Za-z]:)?(?:[A-Za-z0-9_. -]+[/\\]){2,}[A-Za-z0-9_. -]+', '<path>', redacted)
+    redacted = re.sub(r'\b[A-Za-z]:\\[^\n\r\t<>|*?";]+(?:\\[^\n\r\t<>|*?";]+)+', '<path>', redacted)
     return redacted[-limit:].strip()
 
+
+_CHILD_DIAGNOSTIC_ALLOWLIST = re.compile(
+    r'(llama|llama_context|ggml|metal|kv|cache|alloc|memory|oom|buffer|rope|yarn|'
+    r'flash_attn|type_k|type_v|n_ctx|context|unsupported|keyword|argument|failed)',
+    re.IGNORECASE,
+)
+
+
+def _sanitize_child_diagnostic_text(text: Any, *, limit: int = 1200) -> str:
+    redacted = _redact_paths_from_text(text, limit=limit * 2)
+    safe_lines = []
+    for line in redacted.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _CHILD_DIAGNOSTIC_ALLOWLIST.search(stripped):
+            safe_lines.append(stripped[:300])
+        if len('\n'.join(safe_lines)) >= limit:
+            break
+    return '\n'.join(safe_lines)[-limit:].strip()
+
+
+def _safe_parent_exception_message(error: Any, *, child_stderr: str = '') -> str:
+    category = _classify_runtime_context_create_error(error, child_stderr)
+    return (
+        f"{type(error).__name__ if isinstance(error, BaseException) else 'RuntimeError'}; "
+        f"safe_error_category={category}"
+    )
 
 
 def _qwen_64k_memory_profile_kwargs(
@@ -1363,14 +1396,19 @@ def _read_llama_subprocess_message(
     if message.get('status') == 'transport_error':
         raise LlamaCppWorkerEOFError(str(message.get('error') or f'{stage} worker exited before response'))
     if message.get('status') == 'error':
-        error = str(message.get('error') or f'{stage} failed')
+        raw_error = str(message.get('error') or f'{stage} failed')
+        error = raw_error
         if stage in {'llama_cpp_inference', 'llama_cpp_prompt_render_tokenize'} and message.get('request_error'):
             diagnostics = message.get('diagnostics')
             safe_diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
             raise LlamaCppInferenceRequestError(error, diagnostics=safe_diagnostics)
+        category = _classify_runtime_context_create_error(raw_error, str(message.get('stderr') or ''))
+        error = f'{stage} failed; child_exception_type={message.get("exception_type") or "RuntimeError"}; safe_error_category={category}'
         traceback_text = str(message.get('traceback') or '').strip()
         if traceback_text:
-            error = f"{error}; child_traceback_tail={_redact_paths_from_text(traceback_text)}"
+            safe_tail = _sanitize_child_diagnostic_text(traceback_text)
+            if safe_tail:
+                error = f"{error}; child_traceback_tail={safe_tail}"
         raise RuntimeError(error)
     return message
 
@@ -1446,12 +1484,12 @@ class _SubprocessLlamaProxy:
             self.close()
             raise
         except Exception as exc:
-            stderr_tail = _redact_paths_from_text(_llama_subprocess_tail(self._process, '_token_place_stderr_tail'))
+            stderr_tail = _sanitize_child_diagnostic_text(_llama_subprocess_tail(self._process, '_token_place_stderr_tail'))
             category = _classify_runtime_context_create_error(exc, stderr_tail)
             if isinstance(exc, LlamaCppWorkerEOFError):
                 safe_exc = _format_llama_subprocess_early_exit_detail(self._process, stage='llama_cpp_import')
             else:
-                safe_exc = _redact_paths_from_text(exc)
+                safe_exc = _safe_parent_exception_message(exc, child_stderr=stderr_tail)
             self.close()
             raise RuntimeError(
                 f"{safe_exc}; child_exception_type={type(exc).__name__}; "
@@ -3211,11 +3249,28 @@ class ModelManager:
                                     category = _classify_runtime_context_create_error(init_exc)
                                     safe_failure = {
                                         'profile_id': profile_id,
+                                        'model_profile_id': self.profile_id,
                                         'safe_error_category': category,
                                         'exception_type': type(init_exc).__name__,
                                         'context_tier': getattr(self, 'context_tier', '8k-fast'),
                                         'n_ctx': runtime_kwargs.get('n_ctx'),
                                         'backend': compute_plan.get('backend_used'),
+                                        'llama_cpp_python_version': (
+                                            profile_diag.get('llama_cpp_python_version')
+                                            if isinstance(profile_diag, dict) else None
+                                        ),
+                                        'yarn_resolver_source': (
+                                            getattr(self, 'last_yarn_rope_diagnostics', {}) or {}
+                                        ).get('yarn_resolver_source'),
+                                        'kv_cache_settings': (
+                                            profile_diag.get('applied')
+                                            if isinstance(profile_diag, dict) else {}
+                                        ),
+                                        'memory_estimate': (
+                                            profile_diag.get('memory_estimate')
+                                            if isinstance(profile_diag, dict) else {}
+                                        ),
+                                        'child_stderr_tail': _sanitize_child_diagnostic_text(init_exc),
                                         'attempted_runtime_kwargs': {
                                             key: runtime_kwargs.get(key)
                                             for key in ('n_ctx', 'type_k', 'type_v', 'flash_attn', 'offload_kqv', 'n_batch', 'n_ubatch', 'rope_scaling_type', 'yarn_ext_factor', 'yarn_orig_ctx')
@@ -3324,7 +3379,7 @@ class ModelManager:
                             self.log_info("Llama model initialized successfully.")
                         except Exception as e:
                             self.llm = None
-                            self.last_runtime_init_error = str(e)
+                            self.last_runtime_init_error = _redact_paths_from_text(e, limit=12000)
                             if isinstance(e, LlamaCppRuntimeStageTimeout):
                                 self.last_runtime_init_error = _format_runtime_stage_timeout(e)
                             self.worker_state = 'failed'

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -51,7 +51,6 @@ QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES = {
     'runtime_context_create_metal_memory',
     'runtime_context_create_kv_cache_allocation',
     'runtime_context_create_metal_buffer_limit',
-    'runtime_context_create_failed',
 }
 
 CRITICAL_STDLIB_IMPORT_MODULES = (


### PR DESCRIPTION
### Motivation
- Qwen3 `64k-full` operators can fail inside the child `llama.cpp` context creation on Metal (e.g. `ValueError: Failed to create llama_context`), producing opaque init failures and preventing safe operator registration. The goal is to classify such failures, preserve safe child diagnostics, and retry with bounded 64K-only KV/cache memory profiles so supported machines can start.
- The change must be capability-aware, not change model weights or context-tier identifiers, and exercise the packaged subprocess runtime path in CI with a fake runtime that reproduces the context-create failure path.

### Description
- Added robust GGML KV-constant resolution helpers and a verified numeric-fallback path in `utils/llm/model_manager.py` so `type_k`/`type_v` numeric values are discovered from top-level, nested, or worker-probe sources before use.
- Implemented a Qwen 64K runtime profile ladder (`qwen64k_default`, `qwen64k_kv_q8`, `qwen64k_kv_q4`) via `_build_qwen_64k_runtime_profiles`, with capability-gated `type_k`, `type_v`, `flash_attn`, `offload_kqv`, `n_batch`, and `n_ubatch` kwargs and conservative memory estimates; added a backward-compatible `_qwen_64k_memory_profile_kwargs` wrapper.
- Added child-init diagnostics: path-redacted child stderr tail, safe sanitized fields, and a classifier `_classify_runtime_context_create_error` that maps child failures into bounded safe categories (metal memory, KV allocation, buffer limit, RoPE/YaRN, unsupported kwarg, fallback failed).
- Added bounded init retry in `ModelManager.get_llm_instance` for Qwen `64k-full`: probe profiles in order, close failing child and retry only for classified context-creation categories, persist selected profile diagnostics, and fail closed with an actionable safe reason if all profiles fail.
- Ensured YaRN/RoPE mapping and constructor gating remain unchanged for non-Qwen models and for `8k-fast` profiles; profile selection only applies to Qwen 64K scenarios and does not alter model weights.
- Improved subprocess proxy error handling to surface safe child diagnostics on init failures (child exception type, safe category, redacted stderr tail, attempted runtime kwargs, llama-cpp-python version, profile id, and context tier).
- Added a packaged-subprocess integration test `tests/integration/test_desktop_qwen64k_packaged_runtime.py` that reproduces a child `Failed to create llama_context` on first attempt and validates retry to `qwen64k_kv_q8`, and a negative test that asserts fail-closed when all profiles fail.
- Added unit tests covering: profile retry behavior, profile exhaustion fail-closed, KV constant resolution top/nested/numeric-fallback, child stderr redaction and classification, and the existing YaRN/RoPE checks adapted to the runtime-profile flow.

### Testing
- Ran targeted unit and integration suites locally; all targeted tests passed:
  - `python -m pytest tests/unit/test_model_manager.py -q` — passed
  - `python -m pytest tests/unit/test_compute_node_runtime.py -q` — passed
  - `python -m pytest tests/unit/test_context_profiles.py -q` — passed
  - `python -m pytest tests/unit/test_desktop_runtime_setup.py -q` — passed
  - `python -m pytest tests/unit/test_desktop_gpu_packaging.py -q` — passed
  - `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q` — passed (fake packaged runtime exercises subprocess facade path and validates retry & exhaustion paths)
  - `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` — passed
  - `pre-commit run --all-files` — passed
  - `git diff --check` — no issues
- The changes were exercised end-to-end under CI-like runs (unit + focused integration tests) and demonstrate: Qwen 64K will attempt bounded fallback profiles on context-create failures, safe child diagnostics are preserved and redacted, and nodes do not register unless an init+admission+completion smoke chain succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a481288cd60832f94b66c36d03e2579)