### PR TITLE
Qwen3 64K: Metal init retry profiles, safe diagnostics, and packaged-runtime e2e

### DIFF
--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -123,3 +123,61 @@ def test_packaged_subprocess_qwen64k_child_unsupported_fails_before_ready(tmp_pa
     assert manager.last_yarn_rope_diagnostics['child_probe_reprobe_attempted'] is True
     assert 'Qwen 64K requires YaRN/RoPE support' in manager.last_runtime_init_error
     assert 'missing constructor kwargs' in manager.last_runtime_init_error
+
+
+def test_packaged_subprocess_qwen64k_retries_after_child_context_create_failure(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+    import json
+
+    site_dir = tmp_path / 'fake-site-retry'
+    package_dir = site_dir / 'llama_cpp'
+    package_dir.mkdir(parents=True)
+    fake_module_path = package_dir / '__init__.py'
+    state_path = tmp_path / 'state.json'
+    capture_path = tmp_path / 'captured_attempts.jsonl'
+    fake_module_path.write_text(
+        "import json, os, sys\n"
+        "__version__ = '0.3.32'\n"
+        "GGML_USE_METAL = True\n"
+        "LLAMA_ROPE_SCALING_TYPE_YARN = 2\n"
+        "GGML_TYPE_Q8_0 = 8\n"
+        "GGML_TYPE_Q4_0 = 2\n"
+        "def llama_supports_gpu_offload(): return True\n"
+        "class Llama:\n"
+        "    def __init__(self, model_path, n_gpu_layers, n_ctx, verbose, rope_scaling_type, yarn_ext_factor, yarn_orig_ctx, type_k=None, type_v=None, flash_attn=None, offload_kqv=None, n_batch=None, n_ubatch=None):\n"
+        "        attempt = 0\n"
+        "        state_path = os.environ['TOKEN_PLACE_FAKE_LLAMA_STATE']\n"
+        "        if os.path.exists(state_path):\n"
+        "            attempt = json.load(open(state_path)).get('attempt', 0)\n"
+        "        attempt += 1\n"
+        "        json.dump({'attempt': attempt}, open(state_path, 'w'))\n"
+        "        payload = {'attempt': attempt, 'n_ctx': n_ctx, 'type_k': type_k, 'type_v': type_v, 'flash_attn': flash_attn, 'n_batch': n_batch, 'n_ubatch': n_ubatch}\n"
+        "        with open(os.environ['TOKEN_PLACE_CAPTURE_LLAMA_KWARGS'], 'a') as fh: fh.write(json.dumps(payload) + '\\n')\n"
+        "        if attempt == 1:\n"
+        "            print('ggml_metal: failed to allocate KV cache buffer for 64K context', file=sys.stderr)\n"
+        "            raise ValueError('Failed to create llama_context')\n"
+        "    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):\n"
+        "        return [1, 2, 3] if tokenize else '<qwen>'\n"
+    )
+    monkeypatch.syspath_prepend(str(site_dir))
+    monkeypatch.setenv('TOKEN_PLACE_FAKE_LLAMA_STATE', str(state_path))
+    monkeypatch.setenv('TOKEN_PLACE_CAPTURE_LLAMA_KWARGS', str(capture_path))
+
+    manager = ModelManager(_config(tmp_path))
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+    facade = model_manager_module._SubprocessLlamaCppModule(str(fake_module_path))
+
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=facade), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'metal', 'gpu_offload_supported': True, 'error': None}):
+        assert manager.get_llm_instance() is not None
+
+    attempts = [json.loads(line) for line in capture_path.read_text().splitlines()]
+    assert attempts[0]['n_ctx'] == 65536
+    assert attempts[0]['type_k'] is None
+    assert attempts[1]['type_k'] == 8
+    assert attempts[1]['type_v'] == 8
+    assert manager.last_compute_diagnostics['selected_runtime_profile'] == 'qwen64k_kv_q8'
+    first_diag = manager.last_compute_diagnostics['runtime_init_attempts'][0]
+    assert first_diag['safe_error_category'] == 'runtime_context_create_kv_cache_allocation'
+    assert 'KV cache buffer' in first_diag['child_stderr_tail']

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -4969,13 +4969,9 @@ def test_qwen_64k_runtime_applies_memory_profile_only_to_64k(tmp_path):
          patch.object(manager, '_runtime_capabilities', return_value={'backend': 'metal', 'gpu_offload_supported': True, 'error': None}):
         assert manager.get_llm_instance() is not None
 
-    assert captured['type_k'] == 8
-    assert captured['type_v'] == 8
-    assert 'flash_attn' not in captured
-    assert 'offload_kqv' not in captured
-    assert captured['n_batch'] == 256
-    assert captured['n_ubatch'] == 128
-    assert manager.last_compute_diagnostics['kv_cache_mode']['type_k'] == 8
+    assert 'type_k' not in captured
+    assert manager.last_compute_diagnostics['selected_runtime_profile'] == 'qwen64k_default'
+    assert manager.last_compute_diagnostics.get('kv_cache_mode') == {}
 
 
 def test_qwen_64k_runtime_omits_memory_profile_when_kwargs_unsupported(tmp_path):
@@ -5025,7 +5021,7 @@ def test_qwen_64k_memory_profile_does_not_trust_subprocess_proxy_kwargs():
 
     assert facade.LLAMA_TYPE_Q8_0 == 8
     assert kwargs == {}
-    assert diagnostics['kv_cache_type_name'] == 'LLAMA_TYPE_Q8_0'
+    assert diagnostics['kv_cache_type_name'] == 'Q8'
     assert diagnostics['constructor_kwarg_support']['type_k'] is False
 
 
@@ -5499,3 +5495,86 @@ def test_subprocess_worker_error_summary_keeps_safe_category_hint():
     summary = namespace['_sanitize_error_summary'](RuntimeError('Metal failed to allocate KV cache for /tmp/model.gguf'))
 
     assert summary == 'RuntimeError:metal_memory_allocation'
+
+
+def test_qwen_64k_context_create_failure_retries_q8_profile(tmp_path):
+    from utils.context_profiles import apply_context_profile
+
+    attempts = []
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': -1,
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    class FakeLlama:
+        def __init__(self, **kwargs):
+            attempts.append(dict(kwargs))
+            if 'type_k' not in kwargs:
+                raise ValueError('Failed to create llama_context: Metal KV cache allocation failed')
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+            return '<qwen>'
+
+    fake_llama_cpp = SimpleNamespace(
+        Llama=FakeLlama,
+        LLAMA_ROPE_SCALING_TYPE_YARN=2,
+        GGML_TYPE_Q8_0=8,
+        GGML_USE_METAL=True,
+        __file__='/opt/token.place/llama_cpp/__init__.py',
+    )
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama_cpp), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'metal', 'gpu_offload_supported': True, 'error': None}):
+        assert manager.get_llm_instance() is not None
+
+    assert [a.get('type_k') for a in attempts] == [None, 8]
+    assert manager.last_compute_diagnostics['selected_runtime_profile'] == 'qwen64k_kv_q8'
+    assert manager.last_compute_diagnostics['runtime_init_attempts'][0]['safe_error_category'] == 'runtime_context_create_kv_cache_allocation'
+
+
+def test_qwen_64k_context_create_all_profiles_fail_closed(tmp_path):
+    from utils.context_profiles import apply_context_profile
+
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': -1,
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    class FakeLlama:
+        def __init__(self, **kwargs):
+            raise ValueError('Failed to create llama_context: Metal buffer too large for KV cache')
+
+    fake_llama_cpp = SimpleNamespace(
+        Llama=FakeLlama,
+        LLAMA_ROPE_SCALING_TYPE_YARN=2,
+        GGML_TYPE_Q8_0=8,
+        GGML_TYPE_Q4_0=2,
+        GGML_USE_METAL=True,
+        __file__='/opt/token.place/llama_cpp/__init__.py',
+    )
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama_cpp), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'metal', 'gpu_offload_supported': True, 'error': None}):
+        assert manager.get_llm_instance() is None
+
+    assert manager.llm is None
+    assert 'profile exhaustion' in manager.last_runtime_init_error
+    assert len(manager.last_runtime_init_attempts) == 3

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -6,6 +6,7 @@ import time
 import logging
 from utils.networking.http_requests_compat import requests
 import json
+import re
 import sys
 import importlib
 import importlib.metadata
@@ -36,10 +37,15 @@ QWEN_64K_YARN_UNSUPPORTED_MESSAGE = (
 # wheels accept rope_scaling_type as a constructor kwarg but do not export the
 # generated enum symbol, so this is only used after constructor support is verified.
 LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK = 2
-QWEN_64K_KV_CACHE_TYPE_NAME = 'LLAMA_TYPE_Q8_0'
+QWEN_64K_KV_CACHE_TYPE_NAMES = {
+    'f16': ('GGML_TYPE_F16', 'LLAMA_TYPE_F16'),
+    'q8': ('GGML_TYPE_Q8_0', 'LLAMA_TYPE_Q8_0'),
+    'q4': ('GGML_TYPE_Q4_0', 'LLAMA_TYPE_Q4_0'),
+}
+QWEN_64K_KV_NUMERIC_FALLBACKS = {'f16': 1, 'q4': 2, 'q8': 8}
 QWEN_64K_BATCH_TOKENS = 256
 QWEN_64K_UBATCH_TOKENS = 128
-QWEN_64K_MEMORY_PROFILE_ID = 'qwen3-64k-q8-kv'
+QWEN_64K_MEMORY_PROFILE_ID = 'qwen64k_kv_q8'
 
 CRITICAL_STDLIB_IMPORT_MODULES = (
     'collections',
@@ -51,6 +57,40 @@ CRITICAL_STDLIB_IMPORT_MODULES = (
     'pathlib',
 )
 
+
+
+
+def _sanitize_runtime_diagnostic_text(value: Any, *, limit: int = 2000) -> str:
+    text = str(value or '')[-limit:]
+    # Redact absolute-looking paths while preserving safe basename context.
+    text = re.sub(r'(?i)(?:[A-Z]:)?[\\/](?:[^\s:;]+[\\/])+([^\s:;]+)', r'<path>/\1', text)
+    return text.strip()
+
+
+def _classify_context_create_failure(exc: BaseException, *, child_stderr_tail: str = '') -> str:
+    text = f'{type(exc).__name__}: {exc} {child_stderr_tail}'.lower()
+    if re.search(r'(unexpected keyword argument|got an unexpected keyword argument|unsupported.*(?:type_k|type_v|flash_attn|offload_kqv|yarn|rope))', text):
+        return 'runtime_context_create_unsupported_kwarg'
+    if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'orig', 'ext'))):
+        return 'runtime_context_create_rope_yarn_config'
+    if 'kv' in text and any(term in text for term in ('alloc', 'cache', 'memory', 'failed', 'oom', 'out of memory')):
+        return 'runtime_context_create_kv_cache_allocation'
+    if 'metal' in text and any(term in text for term in ('buffer', 'graph', 'maximum', 'too large')):
+        return 'runtime_context_create_metal_buffer_limit'
+    if 'metal' in text and any(term in text for term in ('alloc', 'memory', 'oom', 'out of memory', 'failed')):
+        return 'runtime_context_create_metal_memory'
+    if 'failed to create llama_context' in text or 'llamacontext' in text:
+        return 'runtime_context_create_failed'
+    return 'runtime_context_create_failed'
+
+
+def _is_retryable_qwen64k_context_create_failure(category: str) -> bool:
+    return category in {
+        'runtime_context_create_metal_memory',
+        'runtime_context_create_kv_cache_allocation',
+        'runtime_context_create_metal_buffer_limit',
+        'runtime_context_create_failed',
+    }
 
 def _safe_signature_parameters(callable_obj: Any) -> Dict[str, inspect.Parameter]:
     try:
@@ -188,11 +228,36 @@ def _safe_llama_cpp_enum(llama_cpp_module: Any, name: str) -> Any:
     return None
 
 
+def _resolve_ggml_kv_cache_type(
+    llama_cpp_module: Any,
+    llama_cls: Any,
+    precision: str,
+    kwarg_support: Optional[Dict[str, bool]] = None,
+) -> tuple[Optional[int], str]:
+    precision_key = str(precision).lower()
+    worker_capabilities = _safe_constructor_capability_payload(llama_cpp_module)
+    capability_key = f'{precision_key}_kv_cache_type_value'
+    value = worker_capabilities.get(capability_key)
+    if isinstance(value, int):
+        return value, 'worker_probe'
+    for name in QWEN_64K_KV_CACHE_TYPE_NAMES.get(precision_key, ()):
+        resolved = _safe_llama_cpp_enum(llama_cpp_module, name)
+        coerced = _coerce_optional_int_enum(resolved)
+        if coerced is not None:
+            return coerced, name
+    if precision_key in QWEN_64K_KV_NUMERIC_FALLBACKS:
+        support = kwarg_support or _llama_constructor_supports_kwargs(llama_cls, ('type_k', 'type_v'))
+        if support.get('type_k') or support.get('type_v'):
+            return QWEN_64K_KV_NUMERIC_FALLBACKS[precision_key], 'verified_numeric_fallback'
+    return None, 'unavailable'
+
+
 def _qwen_64k_memory_profile_kwargs(
     llama_cpp_module: Any,
     llama_cls: Any,
     *,
     enable_kqv_offload: bool = True,
+    profile_name: str = QWEN_64K_MEMORY_PROFILE_ID,
 ) -> tuple[Dict[str, Any], Dict[str, Any]]:
     probe_kwargs = ('type_k', 'type_v', 'flash_attn', 'offload_kqv', 'n_batch', 'n_ubatch')
     worker_capabilities = _safe_constructor_capability_payload(llama_cpp_module)
@@ -203,36 +268,49 @@ def _qwen_64k_memory_profile_kwargs(
         else _llama_constructor_supports_kwargs(llama_cls, probe_kwargs)
     )
     kwargs: Dict[str, Any] = {}
+    omitted: Dict[str, str] = {}
     diagnostics: Dict[str, Any] = {
-        'profile_id': QWEN_64K_MEMORY_PROFILE_ID,
+        'profile_id': profile_name,
         'constructor_kwarg_support': kwarg_support,
         'capability_source': worker_capabilities.get('capability_source') or (
             'worker_probe' if isinstance(worker_kwarg_support, dict) else 'local_constructor_signature'
         ),
         'applied': {},
-        'omitted': {},
+        'omitted': omitted,
     }
-    q8_type = worker_capabilities.get('q8_kv_cache_type_value')
-    if q8_type is None:
-        q8_type = _safe_llama_cpp_enum(llama_cpp_module, QWEN_64K_KV_CACHE_TYPE_NAME)
-    diagnostics['kv_cache_type_name'] = QWEN_64K_KV_CACHE_TYPE_NAME if q8_type is not None else None
-    omitted: Dict[str, str] = {}
-    if q8_type is not None:
+    if profile_name == 'qwen64k_default':
+        diagnostics['enabled'] = True
+        return kwargs, diagnostics
+
+    precision = 'q4' if profile_name == 'qwen64k_kv_q4' else 'q8'
+    kv_type, kv_source = _resolve_ggml_kv_cache_type(llama_cpp_module, llama_cls, precision, kwarg_support)
+    diagnostics['kv_cache_type_name'] = precision.upper()
+    diagnostics['kv_cache_type_source'] = kv_source
+    if kv_type is None:
+        omitted['type_k'] = f'{precision}_enum_unavailable'
+        omitted['type_v'] = f'{precision}_enum_unavailable'
+    else:
         if kwarg_support.get('type_k'):
-            kwargs['type_k'] = q8_type
+            kwargs['type_k'] = kv_type
         else:
             omitted['type_k'] = 'worker_capability_unsupported'
         if kwarg_support.get('type_v'):
-            kwargs['type_v'] = q8_type
+            kwargs['type_v'] = kv_type
         else:
             omitted['type_v'] = 'worker_capability_unsupported'
-    else:
-        omitted['type_k'] = 'q8_enum_unavailable'
-        omitted['type_v'] = 'q8_enum_unavailable'
-    if enable_kqv_offload and kwarg_support.get('flash_attn'):
-        kwargs['flash_attn'] = True
-    else:
-        omitted['flash_attn'] = 'gpu_offload_disabled' if not enable_kqv_offload else 'worker_capability_unsupported'
+    type_v_quantized = 'type_v' in kwargs and precision in {'q8', 'q4'}
+    if enable_kqv_offload and (type_v_quantized or precision in {'q8', 'q4'}):
+        if kwarg_support.get('flash_attn'):
+            kwargs['flash_attn'] = True
+        elif type_v_quantized:
+            # Some llama.cpp builds require flash attention for quantized V cache; do not risk it.
+            kwargs.pop('type_v', None)
+            omitted['type_v'] = 'flash_attn_required_but_unsupported'
+            omitted['flash_attn'] = 'worker_capability_unsupported'
+        else:
+            omitted['flash_attn'] = 'worker_capability_unsupported'
+    elif not enable_kqv_offload:
+        omitted['flash_attn'] = 'gpu_offload_disabled'
     diagnostics['kqv_offload_allowed'] = bool(enable_kqv_offload)
     if enable_kqv_offload and kwarg_support.get('offload_kqv'):
         kwargs['offload_kqv'] = True
@@ -240,13 +318,13 @@ def _qwen_64k_memory_profile_kwargs(
         omitted['offload_kqv'] = 'gpu_offload_disabled' if not enable_kqv_offload else 'worker_capability_unsupported'
     if kwarg_support.get('n_batch'):
         kwargs['n_batch'] = QWEN_64K_BATCH_TOKENS
+    else:
+        omitted['n_batch'] = 'worker_capability_unsupported'
     if kwarg_support.get('n_ubatch'):
         kwargs['n_ubatch'] = QWEN_64K_UBATCH_TOKENS
-    for name in ('n_batch', 'n_ubatch'):
-        if name not in kwargs and not kwarg_support.get(name):
-            omitted[name] = 'worker_capability_unsupported'
+    else:
+        omitted['n_ubatch'] = 'worker_capability_unsupported'
     diagnostics['applied'] = dict(kwargs)
-    diagnostics['omitted'] = omitted
     diagnostics['enabled'] = bool(kwargs)
     return kwargs, diagnostics
 
@@ -1183,9 +1261,14 @@ def _read_llama_subprocess_message(
             safe_diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
             raise LlamaCppInferenceRequestError(error, diagnostics=safe_diagnostics)
         traceback_text = str(message.get('traceback') or '').strip()
+        stderr_tail = _sanitize_runtime_diagnostic_text(_llama_subprocess_tail(process, '_token_place_stderr_tail'))
         if traceback_text:
-            error = f"{error}; child_traceback_tail={traceback_text[-2000:]}"
-        raise RuntimeError(error)
+            error = f"{error}; child_traceback_tail={_sanitize_runtime_diagnostic_text(traceback_text)}"
+        if stderr_tail:
+            error = f"{error}; child_stderr_tail={stderr_tail}"
+        exc = RuntimeError(error)
+        setattr(exc, '_token_place_process', process)
+        raise exc
     return message
 
 
@@ -2581,7 +2664,7 @@ class ModelManager:
     def _qwen_non_thinking_required(self) -> bool:
         return self.model_profile.get('provider') == 'qwen' and self.model_profile.get('thinking_mode') == 'disabled'
 
-    def _runtime_init_kwargs(self, llama_cls: Any, n_gpu_layers: int, llama_cpp_module: Any = None) -> Dict[str, Any]:
+    def _runtime_init_kwargs(self, llama_cls: Any, n_gpu_layers: int, llama_cpp_module: Any = None, *, runtime_profile_name: Optional[str] = None) -> Dict[str, Any]:
         """Build verified llama-cpp-python runtime kwargs for the selected profile.
 
         llama-cpp-python uses the GGUF/Jinja chat template when ``chat_format`` is
@@ -2667,7 +2750,8 @@ class ModelManager:
             memory_kwargs, memory_diagnostics = _qwen_64k_memory_profile_kwargs(
                 llama_module,
                 llama_cls,
-                enable_kqv_offload=n_gpu_layers > 0,
+                enable_kqv_offload=n_gpu_layers != 0,
+                profile_name=runtime_profile_name or 'qwen64k_default',
             )
             kwargs.update(memory_kwargs)
             self.last_qwen_64k_memory_profile_diagnostics = memory_diagnostics
@@ -2845,6 +2929,83 @@ class ModelManager:
             self.log_info(f"Model file {self.file_name} already exists.")
             return True
 
+    def _qwen64k_runtime_profile_ladder(self, llama_cpp_module: Any, llama_cls: Any, n_gpu_layers: int) -> list[str]:
+        context_tier = getattr(self, 'context_tier', '8k-fast')
+        if self.model_profile.get('provider') != 'qwen' or context_tier != '64k-full':
+            return ['default']
+        return ['qwen64k_default', 'qwen64k_kv_q8', 'qwen64k_kv_q4']
+
+    def _safe_runtime_kwargs_diagnostics(self, runtime_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        safe_names = (
+            'n_ctx', 'n_gpu_layers', 'verbose', 'rope_scaling_type', 'yarn_ext_factor',
+            'yarn_orig_ctx', 'type_k', 'type_v', 'flash_attn', 'offload_kqv', 'n_batch', 'n_ubatch'
+        )
+        return {name: runtime_kwargs.get(name) for name in safe_names if name in runtime_kwargs}
+
+    def _instantiate_llama_with_qwen64k_retry(self, Llama: Any, n_gpu_layers: int, llama_cpp: Any) -> tuple[Any, Dict[str, Any], list[Dict[str, Any]]]:
+        attempts: list[Dict[str, Any]] = []
+        ladder = self._qwen64k_runtime_profile_ladder(llama_cpp, Llama, n_gpu_layers)
+        last_exc: Optional[BaseException] = None
+        for profile_name in ladder:
+            effective_profile = None if profile_name == 'default' else profile_name
+            runtime_kwargs = self._runtime_init_kwargs(
+                Llama,
+                n_gpu_layers,
+                llama_cpp,
+                runtime_profile_name=effective_profile,
+            )
+            diagnostics = {
+                'attempted_runtime_profile': profile_name,
+                'attempted_runtime_kwargs': self._safe_runtime_kwargs_diagnostics(runtime_kwargs),
+                'model_profile_id': self.profile_id,
+                'context_tier': getattr(self, 'context_tier', '8k-fast'),
+                'n_ctx': runtime_kwargs.get('n_ctx'),
+                'llama_cpp_python_version': _llama_cpp_python_version(llama_cpp),
+                'yarn_resolver_source': (getattr(self, 'last_yarn_rope_diagnostics', {}) or {}).get('yarn_resolver_source'),
+            }
+            try:
+                instance = Llama(**runtime_kwargs)
+                diagnostics['status'] = 'ok'
+                self.selected_runtime_profile = profile_name
+                self.last_runtime_init_attempts = attempts + [diagnostics]
+                if isinstance(getattr(self, 'last_qwen_64k_memory_profile_diagnostics', None), dict):
+                    self.last_qwen_64k_memory_profile_diagnostics['selected_runtime_profile'] = profile_name
+                return instance, runtime_kwargs, attempts + [diagnostics]
+            except Exception as exc:
+                last_exc = exc
+                child_stderr = ''
+                proc = getattr(exc, '_token_place_process', None)
+                if proc is not None:
+                    child_stderr = _llama_subprocess_tail(proc, '_token_place_stderr_tail')
+                child_stderr = _sanitize_runtime_diagnostic_text(child_stderr or str(exc))
+                category = _classify_context_create_failure(exc, child_stderr_tail=child_stderr)
+                diagnostics.update({
+                    'status': 'failed',
+                    'exception_type': type(exc).__name__,
+                    'safe_error_category': category,
+                    'child_stderr_tail': child_stderr,
+                    'backend': 'metal' if getattr(llama_cpp, 'GGML_USE_METAL', False) else ('cuda' if getattr(llama_cpp, 'GGML_USE_CUDA', False) else 'cpu'),
+                })
+                attempts.append(diagnostics)
+                close = getattr(locals().get('instance', None), 'close', None)
+                if callable(close):
+                    close()
+                if not (
+                    self.model_profile.get('provider') == 'qwen'
+                    and getattr(self, 'context_tier', '8k-fast') == '64k-full'
+                    and _is_retryable_qwen64k_context_create_failure(category)
+                ):
+                    self.last_runtime_init_attempts = attempts
+                    raise
+                if profile_name == ladder[-1]:
+                    break
+        self.last_runtime_init_attempts = attempts
+        reason = attempts[-1].get('safe_error_category') if attempts else 'runtime_context_create_failed'
+        raise RuntimeError(
+            f'Qwen 64K runtime memory/KV/cache profile exhaustion before registration; '
+            f'last_category={reason}; attempts={len(attempts)}'
+        ) from last_exc
+
     def get_llm_instance(self):
         """
         Gets the Llama instance, initializing it if necessary (thread-safe),
@@ -2965,8 +3126,9 @@ class ModelManager:
 
                             self.log_info(f"About to instantiate Llama model from {self.model_path}...")
                             self.log_info(f"Llama init started for {self.model_path}.")
-                            runtime_kwargs = self._runtime_init_kwargs(Llama, n_gpu_layers, llama_cpp)
-                            llm_instance = Llama(**runtime_kwargs)
+                            llm_instance, runtime_kwargs, init_attempts = self._instantiate_llama_with_qwen64k_retry(
+                                Llama, n_gpu_layers, llama_cpp
+                            )
                             if self.model_profile.get('provider') == 'qwen':
                                 llm_type_module = type(llm_instance).__module__
                                 is_unit_test_fake = llm_type_module.startswith('tests.') and not os.path.basename(str(self.model_path)).startswith('Qwen3-')
@@ -3013,6 +3175,8 @@ class ModelManager:
                             memory_profile = getattr(self, 'last_qwen_64k_memory_profile_diagnostics', None)
                             if isinstance(memory_profile, dict):
                                 compute_plan['qwen_64k_memory_profile'] = dict(memory_profile)
+                                compute_plan['runtime_init_attempts'] = list(getattr(self, 'last_runtime_init_attempts', []))
+                                compute_plan['selected_runtime_profile'] = getattr(self, 'selected_runtime_profile', None)
                                 applied_memory = memory_profile.get('applied') if isinstance(memory_profile.get('applied'), dict) else {}
                                 compute_plan['kv_cache_mode'] = {
                                     key: applied_memory.get(key)


### PR DESCRIPTION
### Motivation
- Qwen3 64K packaged desktop nodes were failing during real child llama.cpp context creation with `Failed to create llama_context` and lacked safe, actionable diagnostics and bounded retry behavior. 
- Implement a conservative 64K-only memory profile ladder (default -> Q8 KV -> Q4 KV) that can be retried on init failures to unblock 24GB-class Metal/unified-memory machines without changing model weights.

### Description
- Add safe init-failure classification and sanitized child stderr/traceback tails to capture only allowed diagnostic fields for context-creation failures (categories include metal memory, KV allocation, metal buffer limits, RoPE/YaRN config, unsupported kwargs, and fallback). (file: `utils/llm/model_manager.py`)
- Implement robust GGML KV cache type resolution for F16/Q8/Q4 from top-level or nested `llama_cpp` exports and a verified numeric fallback only when constructor support exists. (file: `utils/llm/model_manager.py`)
- Introduce a Qwen 64K-only memory-profile ladder and guarded kwargs (`type_k`, `type_v`, `flash_attn`, `offload_kqv`, `n_batch`, `n_ubatch`) with runtime capability checks and flash-attn compatibility handling, and ensure these profiles are applied only for Qwen + `64k-full`. (file: `utils/llm/model_manager.py`)
- Add bounded init retry in `ModelManager` that iterates the profile ladder, preserves per-attempt sanitized diagnostics, selects/persists the successful profile, and fails closed with a clear "profile exhaustion" message if all profiles fail. (file: `utils/llm/model_manager.py`)
- Preserve and surface safe, redacted child stderr tail and selected profile info in compute diagnostics so operator-facing logs show `n_ctx=65536`, applied KV/cache settings, `flash_attn` usage, and `llama-cpp-python` version without exposing sensitive content. (file: `utils/llm/model_manager.py`)
- Add unit tests and a packaged-subprocess integration test that reproduces the packaged runtime path and simulates a child `ValueError('Failed to create llama_context')` with safe stderr; tests cover retry-to-Q8 success and full-profile exhaustion. (files: `tests/unit/test_model_manager.py`, `tests/integration/test_desktop_qwen64k_packaged_runtime.py`)

### Testing
- Installed verification deps: `python -m pip install -r config/requirements_codex_verification.txt` (ran successfully). 
- Ran unit test suite: `python -m pytest tests/unit/test_model_manager.py -q` and the broader unit sweep `python -m pytest tests/unit/test_compute_node_runtime.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, `python -m pytest tests/unit/test_desktop_runtime_setup.py -q`, and `python -m pytest tests/unit/test_desktop_gpu_packaging.py -q`; all unit tests passed. 
- Ran integration coverage: `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` and the new packaged-runtime e2e `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q`; all integration tests passed. 
- Ran repository checks: `pre-commit run --all-files` and `git diff --check` (both passed after trailing-whitespace fix). 

Residual notes and risks: the changes are scoped to 64K Qwen behavior and the allowed files list; behavior for 8K and non-Qwen models is unchanged, and no plaintext prompt or key material is captured in diagnostics. Follow-ups may tune the profile ladder order heuristics based on real macOS staging telemetry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a481295e154832fb6e4e63a48267bbb)