### PR TITLE
Filter unsupported API v1 generation kwargs against real packaged runtime

### DIFF
--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -258,3 +258,38 @@ def test_qwen64k_packaged_fake_runtime_valid_generation_passes_readiness():
     assert diagnostics["api_v1_readiness_result"] == "passed"
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert diagnostics["api_v1_readiness_completion_smoke_path"] == "shared_api_v1_generation"
+
+
+def test_qwen64k_packaged_fake_runtime_filters_unsupported_internal_kwarg_then_registers():
+    class RejectTopKOnceRuntime(_Qwen64kFakeRuntime):
+        def __init__(self):
+            self.calls = []
+
+        def create_chat_completion(self, **kwargs):
+            self.calls.append(sorted(kwargs))
+            if "top_k" in kwargs:
+                raise LlamaCppInferenceRequestError(
+                    "llama_cpp request failed",
+                    diagnostics={
+                        "reason": "unsupported_generation_option",
+                        "code": "compute_node_options_unsupported",
+                        "generation_exception_category": "unsupported_generation_kwarg",
+                        "exception_type": "TypeError",
+                        "method": "create_chat_completion",
+                        "rejected_option": "top_k",
+                        "attempted_generation_kwargs": "max_tokens,messages,stream,temperature,top_k,top_p",
+                    },
+                )
+            return {"choices": [{"message": {"content": "<think>\n\n</think>\n\nok"}}]}
+
+    fake = RejectTopKOnceRuntime()
+    runtime, manager = _runtime_for(fake)
+    manager.model_profile["generation_defaults"] = {"top_k": 40}
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    diagnostics = manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_result"] == "passed"
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
+    assert diagnostics["api_v1_generation_kwargs_filtered"] == ["top_k"]
+    assert "top_k" in fake.calls[0]
+    assert "top_k" not in fake.calls[1]

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3192,6 +3192,7 @@ def test_subprocess_llama_proxy_nonstreaming_error_does_not_poison_worker(reques
         'exception_type': 'RuntimeError',
         'sanitized_error_summary': 'RuntimeError:redacted',
         'generation_exception_category': 'unknown_generation_exception',
+        'attempted_generation_kwargs': 'stream',
     }
 
     result = proxy.create_chat_completion(messages=[], stream=False)

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5396,8 +5396,9 @@ def test_qwen_profile_generation_defaults_include_top_k():
     manager.model_profile = {'generation_defaults': {'temperature': 0.7, 'top_p': 0.8, 'top_k': 20}}
     client = _api_v1_validation_client(manager)
 
-    kwargs = client._api_v1_runtime_completion_kwargs({})
+    kwargs, internal_names = client._api_v1_runtime_completion_kwargs({})
 
+    assert {'temperature', 'top_p', 'top_k'} <= internal_names
     assert kwargs['temperature'] == 0.7
     assert kwargs['top_p'] == 0.8
     assert kwargs['top_k'] == 20
@@ -5740,3 +5741,109 @@ def test_api_v1_invalid_output_reason_clears_before_unavailable_completion_calla
     error = envelope["api_v1_response"]["error"]
     assert error["code"] == "compute_node_invalid_model_output"
     assert error["internal_reason"] == "unsupported_completion_shape"
+
+
+def _runtime_filter_client(runtime):
+    manager = SimpleNamespace(
+        config=SimpleNamespace(get=lambda key, default=None: {
+            "model.max_tokens": 16,
+            "model.temperature": 0.7,
+            "model.top_p": 0.9,
+            "model.stop_tokens": [],
+        }.get(key, default)),
+        model_profile={"generation_defaults": {"top_k": 40}},
+        last_compute_diagnostics={},
+    )
+    client = RelayClient("http://relay.test", 80, MagicMock(), manager, include_configured_servers=False)
+    return client, manager
+
+
+def test_api_v1_generation_filters_unsupported_internal_top_k_and_caches():
+    calls = []
+
+    def runtime(**kwargs):
+        calls.append(sorted(kwargs))
+        if "top_k" in kwargs:
+            raise TypeError("create_chat_completion() got an unexpected keyword argument 'top_k'")
+        return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+
+    client, manager = _runtime_filter_client(runtime)
+    kwargs, internal = client._api_v1_runtime_completion_kwargs({})
+    result = client._api_v1_call_runtime_completion_filtered(
+        runtime,
+        messages=[{"role": "user", "content": "secret prompt must not be logged"}],
+        completion_kwargs=kwargs,
+        internal_kwarg_names=internal,
+    )
+    assert result["choices"][0]["message"]["content"] == "ok"
+    assert "top_k" in calls[0]
+    assert "top_k" not in calls[1]
+    assert manager.api_v1_generation_kwargs_filtered == ["top_k"]
+
+    kwargs2, internal2 = client._api_v1_runtime_completion_kwargs({})
+    assert "top_k" not in kwargs2
+    client._api_v1_call_runtime_completion_filtered(
+        runtime,
+        messages=[{"role": "user", "content": "secret prompt must not be logged"}],
+        completion_kwargs=kwargs2,
+        internal_kwarg_names=internal2,
+    )
+    assert "top_k" not in calls[-1]
+
+
+def test_api_v1_generation_filters_empty_internal_stop():
+    calls = []
+
+    def runtime(**kwargs):
+        calls.append(sorted(kwargs))
+        if "stop" in kwargs:
+            raise ValueError("unsupported option 'stop'")
+        return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+
+    client, manager = _runtime_filter_client(runtime)
+    kwargs, internal = client._api_v1_runtime_completion_kwargs({})
+    client._api_v1_call_runtime_completion_filtered(
+        runtime,
+        messages=[{"role": "user", "content": "secret prompt must not be logged"}],
+        completion_kwargs=kwargs,
+        internal_kwarg_names=internal,
+    )
+    assert "stop" in calls[0]
+    assert "stop" not in calls[1]
+    assert manager.api_v1_generation_kwargs_filtered == ["stop"]
+
+
+def test_api_v1_generation_does_not_drop_client_supplied_unsupported_runtime_option():
+    def runtime(**kwargs):
+        assert "temperature" in kwargs
+        raise TypeError("unexpected keyword argument 'temperature'")
+
+    client, _manager = _runtime_filter_client(runtime)
+    kwargs, internal = client._api_v1_runtime_completion_kwargs({"temperature": 0.2})
+    with pytest.raises(TypeError, match="temperature"):
+        client._api_v1_call_runtime_completion_filtered(
+            runtime,
+            messages=[{"role": "user", "content": "secret prompt must not be logged"}],
+            completion_kwargs=kwargs,
+            internal_kwarg_names=internal,
+        )
+
+
+def test_api_v1_generation_bounded_retry_fails_closed_after_three_internal_kwargs():
+    rejected = iter(["top_k", "stop", "temperature", "top_p"])
+
+    def runtime(**_kwargs):
+        key = next(rejected)
+        raise TypeError(f"unexpected keyword argument '{key}'")
+
+    client, manager = _runtime_filter_client(runtime)
+    kwargs, internal = client._api_v1_runtime_completion_kwargs({})
+    with pytest.raises(TypeError, match="top_p"):
+        client._api_v1_call_runtime_completion_filtered(
+            runtime,
+            messages=[{"role": "user", "content": "secret prompt must not be logged"}],
+            completion_kwargs=kwargs,
+            internal_kwarg_names=internal,
+            max_removed_kwargs=3,
+        )
+    assert manager.api_v1_generation_kwargs_filtered == ["stop", "temperature", "top_k"]

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -77,6 +77,11 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_KEYS = {
     "stderr_tail",
     "child_stderr_tail",
     "sanitized_error_summary",
+    "attempted_generation_kwargs",
+    "max_tokens",
+    "temperature",
+    "top_p",
+    "top_k",
 }
 
 
@@ -146,6 +151,11 @@ def _safe_completion_smoke_worker_diagnostic_value(key: str, value: Any) -> Any:
         return bounded if _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_CLASS_RE.fullmatch(bounded) else None
     if key in {"rejected_option", "profile_id", "context_tier", "type_k", "type_v"}:
         return bounded if _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(bounded) else None
+    if key == "attempted_generation_kwargs":
+        names = bounded.split(",") if bounded else []
+        if all(_SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(name) for name in names):
+            return bounded
+        return None
     if key == "sanitized_error_summary":
         return (
             bounded
@@ -799,6 +809,12 @@ class ComputeNodeRuntime:
                 ):
                     diagnostics["api_v1_readiness_completion_smoke_result"] = "passed"
                     diagnostics["api_v1_readiness_completion_smoke_shape"] = "api_v1_assistant_message"
+                    supported_kwargs = getattr(self.model_manager, "api_v1_generation_kwargs_supported", None)
+                    filtered_kwargs = getattr(self.model_manager, "api_v1_generation_kwargs_filtered", None)
+                    if isinstance(supported_kwargs, list):
+                        diagnostics["api_v1_generation_kwargs_supported"] = supported_kwargs
+                    if isinstance(filtered_kwargs, list):
+                        diagnostics["api_v1_generation_kwargs_filtered"] = filtered_kwargs
                 else:
                     admitted = False
                     admission_error = {

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1784,7 +1784,7 @@ def _classify_generation_exception(exc):
         return 'kv_cache_allocation'
     if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'eval'))):
         return 'rope_yarn_eval_failure'
-    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument)', str(exc or '')):
+    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument|unsupported option|invalid keyword)', str(exc or ''), flags=re.IGNORECASE):
         return 'unsupported_generation_kwarg'
     return 'unknown_generation_exception'
 
@@ -1803,13 +1803,20 @@ def _safe_request_error(reason, *, request=None, exc=None, extra=None):
         kwargs = request.get('kwargs')
         if isinstance(kwargs, dict):
             diagnostics['stream'] = bool(kwargs.get('stream'))
+            if request.get('method') == 'create_chat_completion':
+                attempted = sorted(str(key) for key in kwargs if isinstance(key, str) and key != 'messages')
+                diagnostics['attempted_generation_kwargs'] = ','.join(attempted[:32])
+                for safe_key in ('max_tokens', 'temperature', 'top_p', 'top_k'):
+                    value = kwargs.get(safe_key)
+                    if isinstance(value, (int, float)) and not isinstance(value, bool):
+                        diagnostics[safe_key] = value
     if exc is not None:
         diagnostics['exception_type'] = type(exc).__name__
         diagnostics['sanitized_error_summary'] = _sanitize_error_summary(exc)
         if reason == 'inference_exception':
             diagnostics['generation_exception_category'] = _classify_generation_exception(exc)
             message = str(exc)
-            match = re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument) [\\'"]?([A-Za-z_][A-Za-z0-9_]*)', message)
+            match = re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument|unsupported option|invalid keyword) [\\'"]?([A-Za-z_][A-Za-z0-9_]*)', message, flags=re.IGNORECASE)
             if match:
                 diagnostics['reason'] = 'unsupported_generation_option'
                 diagnostics['code'] = 'compute_node_options_unsupported'

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -56,7 +56,12 @@ def _classify_safe_generation_exception(exc: BaseException) -> str:
         return "worker_timeout"
     if any(term in text for term in ("worker dead", "broken pipe", "eof", "exited before")):
         return "worker_dead"
-    if "unexpected keyword argument" in text or "got an unexpected keyword argument" in text:
+    if any(pattern in text for pattern in (
+        "unexpected keyword argument",
+        "got an unexpected keyword argument",
+        "unsupported option",
+        "invalid keyword",
+    )):
         return "unsupported_generation_kwarg"
     return "unknown_generation_exception"
 
@@ -83,6 +88,11 @@ _SAFE_WORKER_DIAGNOSTIC_KEYS = {
     "stderr_tail",
     "child_stderr_tail",
     "sanitized_error_summary",
+    "attempted_generation_kwargs",
+    "max_tokens",
+    "temperature",
+    "top_p",
+    "top_k",
 }
 
 
@@ -150,6 +160,11 @@ def _safe_worker_diagnostic_value(key: str, value: Any) -> Any:
         return bounded if _SAFE_WORKER_DIAGNOSTIC_CLASS_RE.fullmatch(bounded) else None
     if key in {"rejected_option", "profile_id", "context_tier", "type_k", "type_v"}:
         return bounded if _SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(bounded) else None
+    if key == "attempted_generation_kwargs":
+        names = bounded.split(",") if bounded else []
+        if all(_SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(name) for name in names):
+            return bounded
+        return None
     if key == "sanitized_error_summary":
         return bounded if _SAFE_WORKER_DIAGNOSTIC_REDACTED_SUMMARY_RE.fullmatch(bounded) else None
     if key in {"stderr_tail", "child_stderr_tail"}:
@@ -3087,8 +3102,13 @@ class RelayClient:
 
     def _api_v1_runtime_completion_kwargs(
         self, safe_options: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """Merge API v1 options with model-manager defaults for direct completions."""
+    ) -> Tuple[Dict[str, Any], Set[str]]:
+        """Merge API v1 options with model-manager defaults for direct completions.
+
+        Returns the kwargs plus the names that came from internal defaults.
+        Internal names may be dropped after probing the real packaged runtime;
+        client supplied safe_options must never be silently removed.
+        """
 
         config = getattr(self.model_manager, "config", None)
         config_get = getattr(config, "get", None)
@@ -3111,8 +3131,100 @@ class RelayClient:
         for key in ("temperature", "top_p", "top_k"):
             if key in profile_defaults:
                 completion_kwargs[key] = profile_defaults[key]
+        internal_names = set(completion_kwargs)
         completion_kwargs.update(safe_options)
-        return completion_kwargs
+        internal_names.difference_update(safe_options)
+        rejected_cached = getattr(self.model_manager, "_api_v1_generation_kwargs_rejected", set())
+        if not isinstance(rejected_cached, set):
+            rejected_cached = set(rejected_cached) if isinstance(rejected_cached, (list, tuple)) else set()
+        for key in list(rejected_cached):
+            if key in internal_names and key not in {"max_tokens", "stream"}:
+                completion_kwargs.pop(key, None)
+        if completion_kwargs.get("stop") == [] and "stop" in internal_names and "stop" in rejected_cached:
+            completion_kwargs.pop("stop", None)
+        return completion_kwargs, internal_names
+
+    @staticmethod
+    def _api_v1_rejected_generation_kwarg_from_exception(exc: BaseException) -> Optional[str]:
+        diagnostics = getattr(exc, "diagnostics", None)
+        if isinstance(diagnostics, dict) and isinstance(diagnostics.get("rejected_option"), str):
+            return diagnostics["rejected_option"]
+        text = str(exc or "")
+        patterns = (
+            r"(?:unexpected keyword argument|got an unexpected keyword argument) [\'\"]?([A-Za-z_][A-Za-z0-9_]*)",
+            r"unsupported option [\'\"]?([A-Za-z_][A-Za-z0-9_]*)",
+            r"invalid keyword [\'\"]?([A-Za-z_][A-Za-z0-9_]*)",
+        )
+        for pattern in patterns:
+            match = re.search(pattern, text, flags=re.IGNORECASE)
+            if match:
+                return match.group(1)
+        return None
+
+    def _api_v1_record_generation_kwargs_capability(
+        self, *, attempted: Set[str], rejected: Set[str]
+    ) -> None:
+        existing = getattr(self.model_manager, "_api_v1_generation_kwargs_rejected", set())
+        if not isinstance(existing, set):
+            existing = set(existing) if isinstance(existing, (list, tuple)) else set()
+        existing.update(rejected)
+        setattr(self.model_manager, "_api_v1_generation_kwargs_rejected", existing)
+        supported = sorted(name for name in attempted if name not in existing)
+        filtered = sorted(existing)
+        setattr(self.model_manager, "api_v1_generation_kwargs_supported", supported)
+        setattr(self.model_manager, "api_v1_generation_kwargs_filtered", filtered)
+        diagnostics = getattr(self.model_manager, "last_compute_diagnostics", None)
+        if isinstance(diagnostics, dict):
+            diagnostics["api_v1_generation_kwargs_supported"] = supported
+            diagnostics["api_v1_generation_kwargs_filtered"] = filtered
+
+    def _api_v1_call_runtime_completion_filtered(
+        self,
+        create_chat_completion: Any,
+        *,
+        messages: List[Dict[str, Any]],
+        completion_kwargs: Dict[str, Any],
+        internal_kwarg_names: Set[str],
+        max_removed_kwargs: int = 3,
+    ) -> Any:
+        """Call create_chat_completion, dropping only rejected internal defaults."""
+
+        kwargs = dict(completion_kwargs)
+        attempted = set(kwargs) | {"messages"}
+        removed: Set[str] = set()
+        while True:
+            try:
+                result = create_chat_completion(messages=messages, **kwargs)
+                self._api_v1_record_generation_kwargs_capability(
+                    attempted=set(kwargs) | {"messages"}, rejected=removed
+                )
+                return result
+            except Exception as exc:
+                rejected = self._api_v1_rejected_generation_kwarg_from_exception(exc)
+                if (
+                    rejected
+                    and rejected in internal_kwarg_names
+                    and rejected not in {"messages", "max_tokens", "stream"}
+                    and rejected in kwargs
+                    and len(removed) < max_removed_kwargs
+                ):
+                    kwargs.pop(rejected, None)
+                    removed.add(rejected)
+                    self._api_v1_record_generation_kwargs_capability(
+                        attempted=attempted, rejected=removed
+                    )
+                    log_info(
+                        "api_v1.generation_kwargs_filtered rejected_generation_kwarg={} filtered_generation_kwargs={} attempted_generation_kwargs={}",
+                        rejected,
+                        sorted(removed),
+                        sorted(attempted),
+                    )
+                    continue
+                if removed:
+                    self._api_v1_record_generation_kwargs_capability(
+                        attempted=attempted, rejected=removed
+                    )
+                raise
 
     def _api_v1_enrich_safe_error(
         self,
@@ -3407,7 +3519,7 @@ class RelayClient:
                     ),
                 )
 
-            completion_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
+            completion_kwargs, internal_kwarg_names = self._api_v1_runtime_completion_kwargs(safe_options)
             requested_output_tokens = int(completion_kwargs["max_tokens"])
             admitted, admission_error, prompt_tokens = self._api_v1_authoritative_context_admission(
                 llm_instance=llm_instance,
@@ -3447,9 +3559,11 @@ class RelayClient:
                     "direct_non_streaming_completion",
                 )
                 started = time.monotonic()
-                completion = create_chat_completion(
+                completion = self._api_v1_call_runtime_completion_filtered(
+                    create_chat_completion,
                     messages=runtime_messages,
-                    **completion_kwargs,
+                    completion_kwargs=completion_kwargs,
+                    internal_kwarg_names=internal_kwarg_names,
                 )
                 inference_duration = time.monotonic() - started
                 log_info(


### PR DESCRIPTION
### Motivation
- Qwen3 64K desktop readiness was failing because the packaged llama-cpp runtime rejected internally supplied generation kwargs that were accepted by direct/mocked runtimes.  This made nodes fail readiness and prevented registration.  
- The goal is to ensure API v1 readiness and real generation calls only send kwargs supported by the real packaged runtime while preserving safe diagnostics and Qwen non-thinking controls.

### Description
- Add runtime-aware generation-kwargs capability probing and filtering so internally supplied defaults are removed/translated when the packaged subprocess rejects them, and cache filtered/supported names on the model-manager instance; new helpers live in `utils/networking/relay_client.py` (`_api_v1_runtime_completion_kwargs`, `_api_v1_rejected_generation_kwarg_from_exception`, `_api_v1_call_runtime_completion_filtered`, `_api_v1_record_generation_kwargs_capability`).
- Extend subprocess/worker diagnostics parsing to detect unsupported-kwarg patterns (`unexpected keyword argument`, `unsupported option`, `invalid keyword`, etc.) and to safely surface only the rejected kwarg name and an allowlisted summary of attempted kwargs without message content; changes in `utils/llm/model_manager.py` and `utils/networking/relay_client.py` sanitize and record `attempted_generation_kwargs` and safe scalar config like `max_tokens/temperature/top_p/top_k`.
- Implement bounded retry logic for readiness smoke and real non-streaming generation: on a rejected internal kwarg remove it, retry once (bounded by a max removed kwargs limit), cache results if successful, and fail closed with a precise reason and safe rejected-kwarg list if retries exhaust.
- Ensure readiness smoke uses the same filtered generation path as real requests and record supported/filtered generation-kwarg diagnostics into `last_compute_diagnostics` for visibility; changes in `utils/compute_node_runtime.py` populate `api_v1_generation_kwargs_supported` and `api_v1_generation_kwargs_filtered` on success.
- Preserve non-thinking controls and message-level `/no_think` behavior; output normalization and think-wrapper checks are unchanged and exercised by tests.
- Add unit tests that reproduce and guard the behavior (filter `top_k`, filter empty `stop`, bounded retries, client-supplied unsupported option behavior, caching of filtered kwargs) in `tests/unit/test_relay_client.py`, adapt a few model-manager unit expectations in `tests/unit/test_model_manager.py`, and add a packaged runtime fake-runtime e2e regression in `tests/integration/test_desktop_qwen64k_packaged_runtime.py` that mimics the macOS packaged-exec behavior and verifies readiness success after filtering.

### Testing
- Ran focused unit and integration suites and all relevant tests passed locally: 
  - `python -m pytest tests/unit/test_relay_client.py -q` — passed
  - `python -m pytest tests/unit/test_model_manager.py -q` — passed
  - `python -m pytest tests/unit/test_compute_node_runtime.py -q` — passed
  - `python -m pytest tests/unit/test_context_profiles.py -q` — passed
  - `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` — passed
  - `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q` — passed (packaged fake-runtime e2e exercised the unsupported-kwarg retry + registration path)
- Pre-commit checks and repository static checks were run: `pre-commit run --all-files` and `git diff --check` — passed.
- These automated tests validate: filtering of unsupported internal kwargs, bounded retry behavior and caching, preserved client-supplied option error semantics, Qwen non-thinking normalization after filtering, and packaged-runtime readiness for Qwen 64K.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49b67f58f8832fa16032951f4d2bb1)