### PR TITLE
Filter unsupported generation kwargs for Qwen3 packaged runtime readiness

### DIFF
--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -9,6 +9,7 @@ from utils.compute_node_runtime import ComputeNodeRuntime, ComputeNodeRuntimeCon
 from utils.context_profiles import apply_context_profile
 from utils.llm import model_manager as model_manager_module
 from utils.llm.model_manager import LlamaCppInferenceRequestError, ModelManager
+from utils.networking.relay_client import RelayClient
 
 
 def _config(tmp_path):
@@ -258,3 +259,83 @@ def test_qwen64k_packaged_fake_runtime_valid_generation_passes_readiness():
     assert diagnostics["api_v1_readiness_result"] == "passed"
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert diagnostics["api_v1_readiness_completion_smoke_path"] == "shared_api_v1_generation"
+
+class _RejectInternalKwargOnceRuntime(_Qwen64kFakeRuntime):
+    def __init__(self, rejected):
+        self.rejected = list(rejected)
+        self.calls = []
+
+    def create_chat_completion(self, **kwargs):
+        self.calls.append(sorted(kwargs))
+        for key in list(self.rejected):
+            if key in kwargs:
+                self.rejected.remove(key)
+                raise TypeError(f"create_chat_completion() got an unexpected keyword argument '{key}'")
+        return {"choices": [{"message": {"content": "<think></think>ok"}}]}
+
+
+def test_qwen64k_readiness_filters_unsupported_internal_top_k_and_caches():
+    fake = _RejectInternalKwargOnceRuntime(["top_k"])
+    runtime, manager = _runtime_for(fake)
+    manager.model_profile["generation_defaults"] = {"top_k": 40, "temperature": 0.6, "top_p": 0.9}
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+
+    diagnostics = manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
+    assert diagnostics["api_v1_generation_kwargs_rejected"] == ["top_k"]
+    assert diagnostics["api_v1_generation_kwargs_filtered"] == ["top_k"]
+    assert "top_k" in fake.calls[0]
+    assert "top_k" not in fake.calls[1]
+    assert manager._api_v1_generation_kwargs_capability_cache["rejected"] == {"top_k"}
+
+
+def test_qwen64k_readiness_filters_unsupported_empty_stop_default():
+    fake = _RejectInternalKwargOnceRuntime(["stop"])
+    runtime, manager = _runtime_for(fake)
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+
+    diagnostics = manager.last_compute_diagnostics
+    assert diagnostics["api_v1_generation_kwargs_rejected"] == ["stop"]
+    assert "stop" in fake.calls[0]
+    assert "stop" not in fake.calls[1]
+
+
+def test_qwen64k_readiness_bounded_retry_fails_closed_after_internal_kwargs_exhaustion():
+    fake = _RejectInternalKwargOnceRuntime(["top_k", "temperature", "top_p", "stop"])
+    runtime, manager = _runtime_for(fake)
+    manager.model_profile["generation_defaults"] = {"top_k": 40, "temperature": 0.6, "top_p": 0.9}
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+
+    diagnostics = manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_unsupported_generation_kwarg"
+    assert sorted(diagnostics["api_v1_generation_kwargs_rejected"]) == ["stop", "temperature", "top_k", "top_p"]
+
+
+def test_qwen64k_real_request_rejects_client_supplied_unsupported_runtime_option():
+    fake = _RejectInternalKwargOnceRuntime(["temperature"])
+    runtime, manager = _runtime_for(fake)
+    client = RelayClient(
+        "https://token.place",
+        None,
+        MagicMock(),
+        manager,
+        include_configured_servers=False,
+    )
+    client._runtime_mode = True
+    manager.model_profile["generation_defaults"] = {}
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="real-request",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hi"}],
+        options={"temperature": 0.5, "max_tokens": 4, "stream": False},
+        requested_context_tier="64k-full",
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_options_unsupported"
+    assert error["internal_reason"] == "unsupported_generation_option"
+    assert error["rejected_option"] == "temperature"

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -61,6 +61,8 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_KEYS = {
     "generation_exception_category",
     "exception_type",
     "rejected_option",
+    "rejected_generation_kwargs",
+    "attempted_generation_kwargs",
     "method",
     "stream",
     "retryable",
@@ -136,6 +138,12 @@ def _is_controlled_redacted_completion_smoke_diagnostic_tail(value: str) -> bool
 def _safe_completion_smoke_worker_diagnostic_value(key: str, value: Any) -> Any:
     if isinstance(value, (bool, int, float)) or value is None:
         return value
+    if key in {"rejected_generation_kwargs", "attempted_generation_kwargs"} and isinstance(value, list):
+        safe_items = []
+        for item in value[:32]:
+            if isinstance(item, str) and _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(item[:128]):
+                safe_items.append(item[:128])
+        return safe_items
     if not isinstance(value, str):
         return None
     bounded = value[:256]
@@ -799,6 +807,11 @@ class ComputeNodeRuntime:
                 ):
                     diagnostics["api_v1_readiness_completion_smoke_result"] = "passed"
                     diagnostics["api_v1_readiness_completion_smoke_shape"] = "api_v1_assistant_message"
+                    cache = getattr(self.model_manager, "_api_v1_generation_kwargs_capability_cache", {})
+                    if isinstance(cache, dict):
+                        diagnostics["api_v1_generation_kwargs_supported"] = sorted(cache.get("supported") or [])
+                        diagnostics["api_v1_generation_kwargs_filtered"] = sorted(cache.get("filtered") or [])
+                        diagnostics["api_v1_generation_kwargs_rejected"] = sorted(cache.get("rejected") or [])
                 else:
                     admitted = False
                     admission_error = {

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1772,7 +1772,7 @@ def _sanitize_error_summary(message):
         return type(message).__name__ + ':kv_cache_allocation'
     if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'eval'))):
         return type(message).__name__ + ':rope_yarn_eval_failure'
-    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument)', str(message or '')):
+    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument|unsupported option|invalid keyword)', str(message or ''), re.IGNORECASE):
         return type(message).__name__ + ':unsupported_kwarg'
     return type(message).__name__ + ':redacted'
 
@@ -1784,7 +1784,7 @@ def _classify_generation_exception(exc):
         return 'kv_cache_allocation'
     if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'eval'))):
         return 'rope_yarn_eval_failure'
-    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument)', str(exc or '')):
+    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument|unsupported option|invalid keyword)', str(exc or ''), re.IGNORECASE):
         return 'unsupported_generation_kwarg'
     return 'unknown_generation_exception'
 
@@ -1803,18 +1803,36 @@ def _safe_request_error(reason, *, request=None, exc=None, extra=None):
         kwargs = request.get('kwargs')
         if isinstance(kwargs, dict):
             diagnostics['stream'] = bool(kwargs.get('stream'))
+            if method == 'create_chat_completion':
+                diagnostics['_attempted_generation_kwargs'] = sorted(
+                    str(key) for key in kwargs.keys()
+                    if isinstance(key, str) and key != 'messages'
+                )[:32]
+                for safe_scalar_key in ('max_tokens', 'temperature', 'top_p', 'top_k'):
+                    value = kwargs.get(safe_scalar_key)
+                    if isinstance(value, (bool, int, float)):
+                        diagnostics[safe_scalar_key] = value
     if exc is not None:
         diagnostics['exception_type'] = type(exc).__name__
         diagnostics['sanitized_error_summary'] = _sanitize_error_summary(exc)
         if reason == 'inference_exception':
             diagnostics['generation_exception_category'] = _classify_generation_exception(exc)
             message = str(exc)
-            match = re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument) [\\'"]?([A-Za-z_][A-Za-z0-9_]*)', message)
+            match = re.search(
+                r'(?:unexpected keyword argument|got an unexpected keyword argument|unsupported option|invalid keyword)\\s*[\\'"]?([A-Za-z_][A-Za-z0-9_]*)',
+                message,
+                re.IGNORECASE,
+            )
             if match:
                 diagnostics['reason'] = 'unsupported_generation_option'
                 diagnostics['code'] = 'compute_node_options_unsupported'
                 diagnostics['rejected_option'] = match.group(1)
+                diagnostics['rejected_generation_kwargs'] = [match.group(1)]
+                attempted = diagnostics.pop('_attempted_generation_kwargs', None)
+                if isinstance(attempted, list):
+                    diagnostics['attempted_generation_kwargs'] = attempted
                 diagnostics['generation_exception_category'] = 'unsupported_generation_kwarg'
+    diagnostics.pop('_attempted_generation_kwargs', None)
     return {
         'status': 'error',
         'request_error': True,

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -44,6 +44,20 @@ def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
     return exc.__class__.__name__ == "LlamaCppInferenceRequestError"
 
 
+_UNSUPPORTED_GENERATION_KWARG_RE = re.compile(
+    r"(?:unexpected keyword argument|got an unexpected keyword argument|unsupported option|invalid keyword)\s*[\'\"]?([A-Za-z_][A-Za-z0-9_]*)",
+    re.IGNORECASE,
+)
+
+
+def _extract_unsupported_generation_kwarg(exc_or_text: Any) -> Optional[str]:
+    text = str(exc_or_text or "")
+    match = _UNSUPPORTED_GENERATION_KWARG_RE.search(text)
+    if not match:
+        return None
+    return match.group(1)
+
+
 def _classify_safe_generation_exception(exc: BaseException) -> str:
     text = f"{type(exc).__name__} {exc}".lower()
     if "metal" in text and any(term in text for term in ("alloc", "memory", "out of memory", "oom")):
@@ -56,7 +70,7 @@ def _classify_safe_generation_exception(exc: BaseException) -> str:
         return "worker_timeout"
     if any(term in text for term in ("worker dead", "broken pipe", "eof", "exited before")):
         return "worker_dead"
-    if "unexpected keyword argument" in text or "got an unexpected keyword argument" in text:
+    if _extract_unsupported_generation_kwarg(exc) is not None:
         return "unsupported_generation_kwarg"
     return "unknown_generation_exception"
 
@@ -67,6 +81,8 @@ _SAFE_WORKER_DIAGNOSTIC_KEYS = {
     "generation_exception_category",
     "exception_type",
     "rejected_option",
+    "rejected_generation_kwargs",
+    "attempted_generation_kwargs",
     "method",
     "stream",
     "retryable",
@@ -140,6 +156,12 @@ def _is_controlled_redacted_diagnostic_tail(value: str) -> bool:
 def _safe_worker_diagnostic_value(key: str, value: Any) -> Any:
     if isinstance(value, (bool, int, float)) or value is None:
         return value
+    if key in {"rejected_generation_kwargs", "attempted_generation_kwargs"} and isinstance(value, list):
+        safe_items = []
+        for item in value[:32]:
+            if isinstance(item, str) and _SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(item[:128]):
+                safe_items.append(item[:128])
+        return safe_items
     if not isinstance(value, str):
         return None
     bounded = value[:256]
@@ -3247,6 +3269,98 @@ class RelayClient:
                         shape["text_type"] = type(choice.get("text")).__name__
         return shape
 
+    @staticmethod
+    def _api_v1_completion_rejected_kwarg_from_exception(exc: BaseException) -> Optional[str]:
+        diagnostics = getattr(exc, "diagnostics", None)
+        if isinstance(diagnostics, dict):
+            rejected = diagnostics.get("rejected_option")
+            if isinstance(rejected, str) and _SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(rejected):
+                return rejected
+            rejected_list = diagnostics.get("rejected_generation_kwargs")
+            if isinstance(rejected_list, list) and rejected_list and isinstance(rejected_list[0], str):
+                return rejected_list[0]
+        return _extract_unsupported_generation_kwarg(exc)
+
+    def _api_v1_generation_kwargs_cache(self) -> Dict[str, Any]:
+        cache = getattr(self.model_manager, "_api_v1_generation_kwargs_capability_cache", None)
+        if not isinstance(cache, dict):
+            cache = {"rejected": set(), "supported": set(), "filtered": set()}
+            setattr(self.model_manager, "_api_v1_generation_kwargs_capability_cache", cache)
+        for key in ("rejected", "supported", "filtered"):
+            if not isinstance(cache.get(key), set):
+                cache[key] = set(cache.get(key) or [])
+        return cache
+
+    def _api_v1_filter_runtime_completion_kwargs(
+        self, completion_kwargs: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        cache = self._api_v1_generation_kwargs_cache()
+        rejected = cache["rejected"]
+        filtered: Dict[str, Any] = {}
+        for key, value in completion_kwargs.items():
+            if key in {"messages", "max_tokens", "stream"}:
+                filtered[key] = value
+                continue
+            if key in rejected:
+                cache["filtered"].add(key)
+                continue
+            if key == "stop" and value in (None, [], (), "") and "stop" in rejected:
+                cache["filtered"].add(key)
+                continue
+            filtered[key] = value
+        return filtered
+
+    def _api_v1_record_generation_kwargs_success(self, kwargs: Dict[str, Any]) -> None:
+        cache = self._api_v1_generation_kwargs_cache()
+        cache["supported"].update(str(key) for key in kwargs if key != "messages")
+        diagnostics = getattr(self.model_manager, "last_compute_diagnostics", None)
+        if isinstance(diagnostics, dict):
+            diagnostics["api_v1_generation_kwargs_supported"] = sorted(cache["supported"])
+            diagnostics["api_v1_generation_kwargs_filtered"] = sorted(cache["filtered"])
+            diagnostics["api_v1_generation_kwargs_rejected"] = sorted(cache["rejected"])
+
+    def _api_v1_create_chat_completion_filtered(
+        self,
+        create_chat_completion: Any,
+        *,
+        runtime_messages: List[Dict[str, Any]],
+        completion_kwargs: Dict[str, Any],
+        client_option_names: Set[str],
+    ) -> Tuple[Any, Dict[str, Any]]:
+        cache = self._api_v1_generation_kwargs_cache()
+        last_exc: Optional[BaseException] = None
+        for _attempt in range(4):
+            filtered_kwargs = self._api_v1_filter_runtime_completion_kwargs(completion_kwargs)
+            attempted_names = sorted({"messages", *filtered_kwargs.keys()})
+            try:
+                completion = create_chat_completion(messages=runtime_messages, **filtered_kwargs)
+                self._api_v1_record_generation_kwargs_success(filtered_kwargs)
+                return completion, filtered_kwargs
+            except Exception as exc:
+                rejected = self._api_v1_completion_rejected_kwarg_from_exception(exc)
+                category = _classify_safe_generation_exception(exc)
+                if _is_llama_cpp_inference_request_error(exc):
+                    diagnostics = _safe_worker_diagnostics(getattr(exc, "diagnostics", {}))
+                    category = str(diagnostics.get("generation_exception_category") or category)
+                if category != "unsupported_generation_kwarg" or not rejected:
+                    raise
+                last_exc = exc
+                if rejected in client_option_names:
+                    raise
+                cache["rejected"].add(rejected)
+                cache["filtered"].add(rejected)
+                diagnostics = getattr(self.model_manager, "last_compute_diagnostics", None)
+                if isinstance(diagnostics, dict):
+                    diagnostics["api_v1_generation_kwargs_attempted"] = attempted_names
+                    diagnostics["api_v1_generation_kwargs_rejected"] = sorted(cache["rejected"])
+                    diagnostics["api_v1_generation_kwargs_filtered"] = sorted(cache["filtered"])
+                    diagnostics["api_v1_generation_kwargs_last_exception_category"] = category
+                    diagnostics["api_v1_generation_kwargs_last_exception_type"] = type(exc).__name__
+                continue
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("runtime_generation_kwargs_filtering_failed")
+
     def _generate_api_v1_response_with_runtime_model(
         self,
         *,
@@ -3408,6 +3522,8 @@ class RelayClient:
                 )
 
             completion_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
+            client_option_names = set(safe_options.keys())
+            completion_kwargs = self._api_v1_filter_runtime_completion_kwargs(completion_kwargs)
             requested_output_tokens = int(completion_kwargs["max_tokens"])
             admitted, admission_error, prompt_tokens = self._api_v1_authoritative_context_admission(
                 llm_instance=llm_instance,
@@ -3447,9 +3563,11 @@ class RelayClient:
                     "direct_non_streaming_completion",
                 )
                 started = time.monotonic()
-                completion = create_chat_completion(
-                    messages=runtime_messages,
-                    **completion_kwargs,
+                completion, completion_kwargs = self._api_v1_create_chat_completion_filtered(
+                    create_chat_completion,
+                    runtime_messages=runtime_messages,
+                    completion_kwargs=completion_kwargs,
+                    client_option_names=client_option_names,
                 )
                 inference_duration = time.monotonic() - started
                 log_info(
@@ -3609,6 +3727,11 @@ class RelayClient:
                             "worker_dead",
                         }
                         else "runtime_inference_failed"
+                    ),
+                    rejected_option=(
+                        self._api_v1_completion_rejected_kwarg_from_exception(exc)
+                        if unsupported_generation_kwarg
+                        else None
                     ),
                 ),
             )


### PR DESCRIPTION
### Motivation
- Qwen 64K readiness was failing during the completion-smoke because the packaged llama-cpp-python runtime rejected internally supplied generation kwargs that the parent process assumed were supported. 
- The fix must avoid logging any prompt/response content while identifying the rejected kwarg names and ensuring readiness and real API v1 calls use only kwargs the real subprocess accepts.

### Description
- Add robust unsupported-kwarg extraction and safe diagnostic fields to worker->parent error payloads, detecting patterns like "unexpected keyword argument", "unsupported option", and "invalid keyword" and preserving only kwarg names and safe scalar config values. 
- Implement per-runtime cached capability tracking and filtering helpers in `RelayClient` to detect/reject internal defaults (keep required `messages`, `max_tokens`, `stream=False`) and to bounded-retry (cache and remove rejected internal kwargs, retry up to the bounded limit). 
- Wire the filtered generation path into both readiness smoke and real API v1 runtime generation so readiness and production use the same filtering logic, and record safe diagnostics (`api_v1_generation_kwargs_supported`, `_filtered`, `_rejected`, attempted/rejected lists, exception type/category). 
- Add packaged-runtime regression tests that reproduce the original failure and assert: internal `top_k`/empty `stop` defaults are filtered and retried, bounded retry fails closed when many internals are rejected, client-supplied unsupported options still return `compute_node_options_unsupported`, filtered kwargs are cached, and Qwen non-thinking checks remain intact.

### Testing
- Ran focused unit and integration suites used for verification with the commands below and observed all tests listed pass:
  - `python -m pytest tests/unit/test_relay_client.py -q` (passed)
  - `python -m pytest tests/unit/test_model_manager.py -q` (passed)
  - `python -m pytest tests/unit/test_compute_node_runtime.py -q` (passed)
  - `python -m pytest tests/unit/test_context_profiles.py -q` (passed)
  - `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (passed)
  - `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q` (passed)
- `python -m py_compile` was used to check modified modules and `pre-commit run --all-files` completed successfully; `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49b69a9524832f885384115b7e39f5)