### PR TITLE
Filter unsupported API v1 generation kwargs for packaged Qwen runtimes

### DIFF
--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -283,4 +283,4 @@ def test_qwen64k_packaged_fake_runtime_filters_unsupported_internal_top_k_and_re
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert fake.calls[0]["top_k"] == 20
     assert "top_k" not in fake.calls[1]
-    assert "top_k" in manager.api_v1_generation_kwargs_filtered
+    assert "top_k" in diagnostics["api_v1_generation_kwargs_filtered"]

--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -258,3 +258,29 @@ def test_qwen64k_packaged_fake_runtime_valid_generation_passes_readiness():
     assert diagnostics["api_v1_readiness_result"] == "passed"
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert diagnostics["api_v1_readiness_completion_smoke_path"] == "shared_api_v1_generation"
+
+
+def test_qwen64k_packaged_fake_runtime_filters_unsupported_internal_top_k_and_registers():
+    class TopKRejectingRuntime(_Qwen64kFakeRuntime):
+        def __init__(self):
+            self.calls = []
+            self.rejected = False
+
+        def create_chat_completion(self, **kwargs):
+            self.calls.append(dict(kwargs))
+            if "top_k" in kwargs and not self.rejected:
+                self.rejected = True
+                raise TypeError("got an unexpected keyword argument 'top_k'")
+            return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+
+    fake = TopKRejectingRuntime()
+    runtime, manager = _runtime_for(fake)
+    manager.model_profile["generation_defaults"] = {"top_k": 20}
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    diagnostics = manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_result"] == "passed"
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
+    assert fake.calls[0]["top_k"] == 20
+    assert "top_k" not in fake.calls[1]
+    assert "top_k" in manager.api_v1_generation_kwargs_filtered

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5711,6 +5711,50 @@ def test_api_v1_generic_unsupported_generation_kwarg_uses_options_error():
     assert error["exception_category"] == "unsupported_generation_kwarg"
 
 
+def test_extract_unsupported_generation_kwarg_requires_attempted_name():
+    from utils.networking.relay_client import _extract_unsupported_generation_kwarg
+
+    attempted = ["temperature", "top_k", "top_p", "stop"]
+    assert _extract_unsupported_generation_kwarg("unexpected keyword argument 'top_k'", attempted) == "top_k"
+    assert _extract_unsupported_generation_kwarg("got an unexpected keyword argument 'top_k'", attempted) == "top_k"
+    assert _extract_unsupported_generation_kwarg("unsupported option 'top_k'", attempted) == "top_k"
+    assert _extract_unsupported_generation_kwarg("unsupported option: top_k", attempted) == "top_k"
+    assert _extract_unsupported_generation_kwarg("invalid keyword 'top_k'", attempted) == "top_k"
+    assert _extract_unsupported_generation_kwarg("invalid keyword=top_k", attempted) == "top_k"
+    assert _extract_unsupported_generation_kwarg("invalid keyword argument 'top_k'", attempted) == "top_k"
+    assert _extract_unsupported_generation_kwarg("unsupported option in model configuration", attempted) is None
+    assert _extract_unsupported_generation_kwarg("unsupported option 'mirostat'", attempted) is None
+
+
+def test_api_v1_cached_internal_filter_does_not_drop_later_explicit_client_option():
+    manager = _RejectingAdmissionManager(["temperature", "temperature"], window=256)
+    manager.model_profile["generation_defaults"] = {"temperature": 0.3}
+    client = _api_v1_validation_client(manager)
+
+    first = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-filter-internal-temperature",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5, "stream": False},
+        requested_context_tier="8k-fast",
+    )
+    assert first["api_v1_response"]["message"]["content"] == "ok"
+
+    second = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-explicit-temperature",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5, "stream": False, "temperature": 0.3},
+        requested_context_tier="8k-fast",
+    )
+
+    error = second["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_options_unsupported"
+    assert error["internal_reason"] == "unsupported_generation_option"
+    assert error["rejected_option"] == "temperature"
+    assert manager.runtime.calls[-1]["temperature"] == 0.3
+
+
 def test_api_v1_invalid_output_reason_clears_before_unavailable_completion_callable():
     class RuntimeWithoutCompletion:
         def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5740,3 +5740,125 @@ def test_api_v1_invalid_output_reason_clears_before_unavailable_completion_calla
     error = envelope["api_v1_response"]["error"]
     assert error["code"] == "compute_node_invalid_model_output"
     assert error["internal_reason"] == "unsupported_completion_shape"
+
+
+class _RejectingAdmissionRuntime(_AdmissionRuntime):
+    def __init__(self, rejected_sequence):
+        super().__init__()
+        self.rejected_sequence = list(rejected_sequence)
+
+    def create_chat_completion(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        for rejected in list(self.rejected_sequence):
+            if rejected in kwargs:
+                self.rejected_sequence.remove(rejected)
+                raise TypeError(f"got an unexpected keyword argument '{rejected}'")
+        return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+
+
+class _RejectingAdmissionManager(_AdmissionManager):
+    def __init__(self, rejected_sequence, **kwargs):
+        super().__init__(**kwargs)
+        self.runtime = _RejectingAdmissionRuntime(rejected_sequence)
+        self.model_profile = {
+            "provider": "qwen",
+            "thinking_mode": "disabled",
+            "generation_defaults": {"top_k": 20},
+        }
+        self.api_model_id = "qwen3-8b-instruct"
+
+
+def test_api_v1_internal_top_k_default_is_filtered_and_cached_after_runtime_rejection():
+    manager = _RejectingAdmissionManager(["top_k"], window=256)
+    client = _api_v1_validation_client(manager)
+
+    first = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-filter-top-k",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5, "stream": False},
+        requested_context_tier="8k-fast",
+    )
+    second = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-filter-top-k-cached",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5, "stream": False},
+        requested_context_tier="8k-fast",
+    )
+
+    assert first["api_v1_response"]["message"]["content"] == "ok"
+    assert second["api_v1_response"]["message"]["content"] == "ok"
+    assert manager.runtime.calls[0]["top_k"] == 20
+    assert "top_k" not in manager.runtime.calls[1]
+    assert "top_k" not in manager.runtime.calls[-1]
+    assert "top_k" in manager.api_v1_generation_kwargs_filtered
+
+
+def test_api_v1_internal_empty_stop_default_is_filtered_after_runtime_rejection():
+    manager = _RejectingAdmissionManager(["stop"], window=256)
+    manager.model_profile["generation_defaults"] = {}
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-filter-stop",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5, "stream": False},
+        requested_context_tier="8k-fast",
+    )
+
+    assert envelope["api_v1_response"]["message"]["content"] == "ok"
+    assert manager.runtime.calls[0]["stop"] == []
+    assert "stop" not in manager.runtime.calls[1]
+
+
+def test_api_v1_client_supplied_runtime_unsupported_option_is_not_silently_dropped():
+    manager = _RejectingAdmissionManager(["temperature"], window=256)
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-client-temperature",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5, "stream": False, "temperature": 0.2},
+        requested_context_tier="8k-fast",
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_options_unsupported"
+    assert error["rejected_option"] == "temperature"
+
+
+def test_api_v1_generation_kwarg_filtering_stops_after_bounded_internal_retries():
+    manager = _RejectingAdmissionManager(["top_k", "temperature", "top_p", "stop"], window=256)
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-bounded-filtering",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5, "stream": False},
+        requested_context_tier="8k-fast",
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] in {"compute_node_options_unsupported", "compute_node_internal_error"}
+    assert error["rejected_option"] == "stop"
+    assert len(manager.runtime.calls) == 4
+
+
+def test_api_v1_qwen_no_think_survives_generation_kwarg_filtering():
+    manager = _RejectingAdmissionManager(["top_k"], window=256)
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-no-think-filtered",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5, "stream": False},
+        requested_context_tier="8k-fast",
+    )
+
+    assert envelope["api_v1_response"]["message"]["content"] == "ok"
+    assert manager.runtime.calls[-1]["messages"][-1]["content"].startswith("/no_think")

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5768,7 +5768,7 @@ class _RejectingAdmissionManager(_AdmissionManager):
         self.api_model_id = "qwen3-8b-instruct"
 
 
-def test_api_v1_internal_top_k_default_is_filtered_and_cached_after_runtime_rejection():
+def test_api_v1_internal_top_k_default_is_filtered_and_cached_per_client_after_runtime_rejection():
     manager = _RejectingAdmissionManager(["top_k"], window=256)
     client = _api_v1_validation_client(manager)
 
@@ -5792,7 +5792,20 @@ def test_api_v1_internal_top_k_default_is_filtered_and_cached_after_runtime_reje
     assert manager.runtime.calls[0]["top_k"] == 20
     assert "top_k" not in manager.runtime.calls[1]
     assert "top_k" not in manager.runtime.calls[-1]
-    assert "top_k" in manager.api_v1_generation_kwargs_filtered
+    assert "top_k" in client._api_v1_generation_kwargs_filtered
+
+    fresh_client = _api_v1_validation_client(manager)
+    third = fresh_client._generate_api_v1_response_with_runtime_model(
+        request_id="req-filter-top-k-fresh-client",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": "hello"}],
+        options={"max_tokens": 5, "stream": False},
+        requested_context_tier="8k-fast",
+    )
+
+    assert third["api_v1_response"]["message"]["content"] == "ok"
+    assert manager.runtime.calls[-1]["top_k"] == 20
+    assert not hasattr(manager, "api_v1_generation_kwargs_filtered")
 
 
 def test_api_v1_internal_empty_stop_default_is_filtered_after_runtime_rejection():

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -800,10 +800,10 @@ class ComputeNodeRuntime:
                     diagnostics["api_v1_readiness_completion_smoke_result"] = "passed"
                     diagnostics["api_v1_readiness_completion_smoke_shape"] = "api_v1_assistant_message"
                     supported_generation_kwargs = getattr(
-                        self.model_manager, "api_v1_generation_kwargs_supported", set()
+                        generation_client, "_api_v1_generation_kwargs_supported", set()
                     )
                     filtered_generation_kwargs = getattr(
-                        self.model_manager, "api_v1_generation_kwargs_filtered", set()
+                        generation_client, "_api_v1_generation_kwargs_filtered", set()
                     )
                     diagnostics["api_v1_generation_kwargs_supported"] = sorted(
                         str(name) for name in supported_generation_kwargs

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -799,6 +799,18 @@ class ComputeNodeRuntime:
                 ):
                     diagnostics["api_v1_readiness_completion_smoke_result"] = "passed"
                     diagnostics["api_v1_readiness_completion_smoke_shape"] = "api_v1_assistant_message"
+                    supported_generation_kwargs = getattr(
+                        self.model_manager, "api_v1_generation_kwargs_supported", set()
+                    )
+                    filtered_generation_kwargs = getattr(
+                        self.model_manager, "api_v1_generation_kwargs_filtered", set()
+                    )
+                    diagnostics["api_v1_generation_kwargs_supported"] = sorted(
+                        str(name) for name in supported_generation_kwargs
+                    )
+                    diagnostics["api_v1_generation_kwargs_filtered"] = sorted(
+                        str(name) for name in filtered_generation_kwargs
+                    )
                 else:
                     admitted = False
                     admission_error = {

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1772,7 +1772,7 @@ def _sanitize_error_summary(message):
         return type(message).__name__ + ':kv_cache_allocation'
     if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'eval'))):
         return type(message).__name__ + ':rope_yarn_eval_failure'
-    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument)', str(message or '')):
+    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument|unsupported option|invalid keyword)', str(message or '')):
         return type(message).__name__ + ':unsupported_kwarg'
     return type(message).__name__ + ':redacted'
 
@@ -1784,7 +1784,7 @@ def _classify_generation_exception(exc):
         return 'kv_cache_allocation'
     if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'eval'))):
         return 'rope_yarn_eval_failure'
-    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument)', str(exc or '')):
+    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument|unsupported option|invalid keyword)', str(exc or '')):
         return 'unsupported_generation_kwarg'
     return 'unknown_generation_exception'
 
@@ -1803,17 +1803,37 @@ def _safe_request_error(reason, *, request=None, exc=None, extra=None):
         kwargs = request.get('kwargs')
         if isinstance(kwargs, dict):
             diagnostics['stream'] = bool(kwargs.get('stream'))
+            for safe_scalar in ('max_tokens', 'temperature', 'top_p', 'top_k'):
+                value = kwargs.get(safe_scalar)
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    diagnostics[safe_scalar] = value
     if exc is not None:
         diagnostics['exception_type'] = type(exc).__name__
         diagnostics['sanitized_error_summary'] = _sanitize_error_summary(exc)
         if reason == 'inference_exception':
             diagnostics['generation_exception_category'] = _classify_generation_exception(exc)
             message = str(exc)
-            match = re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument) [\\'"]?([A-Za-z_][A-Za-z0-9_]*)', message)
+            match = None
+            for pattern in (
+                r'(?:unexpected keyword argument|got an unexpected keyword argument) [\\'"]?([A-Za-z_][A-Za-z0-9_]*)',
+                r'unsupported option [\\'"]?([A-Za-z_][A-Za-z0-9_]*)',
+                r'invalid keyword [\\'"]?([A-Za-z_][A-Za-z0-9_]*)',
+            ):
+                match = re.search(pattern, message)
+                if match:
+                    break
             if match:
                 diagnostics['reason'] = 'unsupported_generation_option'
                 diagnostics['code'] = 'compute_node_options_unsupported'
                 diagnostics['rejected_option'] = match.group(1)
+                diagnostics['rejected_generation_kwarg'] = match.group(1)
+                if isinstance(request, dict) and isinstance(request.get('kwargs'), dict):
+                    attempted = sorted(
+                        str(key) for key in request['kwargs']
+                        if isinstance(key, str) and key != 'messages'
+                    )
+                    if attempted:
+                        diagnostics['attempted_generation_kwargs'] = ','.join(attempted[:32])
                 diagnostics['generation_exception_category'] = 'unsupported_generation_kwarg'
     return {
         'status': 'error',

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1764,6 +1764,22 @@ def _jsonable(value):
 def _emit(payload):
     print('TOKEN_PLACE_LLAMA_CPP_JSON:' + json.dumps(_jsonable(payload)), flush=True)
 
+
+def _extract_unsupported_generation_kwarg(message, attempted=None):
+    attempted_set = set(str(key) for key in attempted) if attempted is not None else None
+    for pattern in (
+        r'(?:got an )?unexpected keyword argument [\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',
+        r'unsupported option(?:\\s+[\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]|\\s*:\\s*([A-Za-z_][A-Za-z0-9_]*))',
+        r'invalid keyword(?: argument)? [\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',
+        r'invalid keyword\\s*=\\s*([A-Za-z_][A-Za-z0-9_]*)',
+    ):
+        match = re.search(pattern, str(message or ''))
+        if match:
+            rejected = next((group for group in match.groups() if group), None)
+            if rejected and (attempted_set is None or rejected in attempted_set):
+                return rejected
+    return None
+
 def _sanitize_error_summary(message):
     text = str(message or '').lower()
     if 'metal' in text and any(term in text for term in ('alloc', 'memory', 'out of memory', 'oom')):
@@ -1772,7 +1788,7 @@ def _sanitize_error_summary(message):
         return type(message).__name__ + ':kv_cache_allocation'
     if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'eval'))):
         return type(message).__name__ + ':rope_yarn_eval_failure'
-    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument|unsupported option|invalid keyword)', str(message or '')):
+    if _extract_unsupported_generation_kwarg(str(message or '')) is not None:
         return type(message).__name__ + ':unsupported_kwarg'
     return type(message).__name__ + ':redacted'
 
@@ -1784,7 +1800,7 @@ def _classify_generation_exception(exc):
         return 'kv_cache_allocation'
     if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'eval'))):
         return 'rope_yarn_eval_failure'
-    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument|unsupported option|invalid keyword)', str(exc or '')):
+    if _extract_unsupported_generation_kwarg(str(exc or '')) is not None:
         return 'unsupported_generation_kwarg'
     return 'unknown_generation_exception'
 
@@ -1813,27 +1829,20 @@ def _safe_request_error(reason, *, request=None, exc=None, extra=None):
         if reason == 'inference_exception':
             diagnostics['generation_exception_category'] = _classify_generation_exception(exc)
             message = str(exc)
-            match = None
-            for pattern in (
-                r'(?:unexpected keyword argument|got an unexpected keyword argument) [\\'"]?([A-Za-z_][A-Za-z0-9_]*)',
-                r'unsupported option [\\'"]?([A-Za-z_][A-Za-z0-9_]*)',
-                r'invalid keyword [\\'"]?([A-Za-z_][A-Za-z0-9_]*)',
-            ):
-                match = re.search(pattern, message)
-                if match:
-                    break
-            if match:
+            attempted = None
+            if isinstance(request, dict) and isinstance(request.get('kwargs'), dict):
+                attempted = sorted(
+                    str(key) for key in request['kwargs']
+                    if isinstance(key, str) and key != 'messages'
+                )
+            rejected = _extract_unsupported_generation_kwarg(message, attempted)
+            if rejected:
                 diagnostics['reason'] = 'unsupported_generation_option'
                 diagnostics['code'] = 'compute_node_options_unsupported'
-                diagnostics['rejected_option'] = match.group(1)
-                diagnostics['rejected_generation_kwarg'] = match.group(1)
-                if isinstance(request, dict) and isinstance(request.get('kwargs'), dict):
-                    attempted = sorted(
-                        str(key) for key in request['kwargs']
-                        if isinstance(key, str) and key != 'messages'
-                    )
-                    if attempted:
-                        diagnostics['attempted_generation_kwargs'] = ','.join(attempted[:32])
+                diagnostics['rejected_option'] = rejected
+                diagnostics['rejected_generation_kwarg'] = rejected
+                if attempted:
+                    diagnostics['attempted_generation_kwargs'] = ','.join(attempted[:32])
                 diagnostics['generation_exception_category'] = 'unsupported_generation_kwarg'
     return {
         'status': 'error',

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -44,6 +44,23 @@ def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
     return exc.__class__.__name__ == "LlamaCppInferenceRequestError"
 
 
+_UNSUPPORTED_GENERATION_KWARG_PATTERNS = (
+    re.compile(r"unexpected keyword argument [\'\"]?([A-Za-z_][A-Za-z0-9_]*)"),
+    re.compile(r"got an unexpected keyword argument [\'\"]?([A-Za-z_][A-Za-z0-9_]*)"),
+    re.compile(r"unsupported option [\'\"]?([A-Za-z_][A-Za-z0-9_]*)"),
+    re.compile(r"invalid keyword [\'\"]?([A-Za-z_][A-Za-z0-9_]*)"),
+)
+
+
+def _extract_unsupported_generation_kwarg(value: Any) -> Optional[str]:
+    text = str(value or "")
+    for pattern in _UNSUPPORTED_GENERATION_KWARG_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            return match.group(1)
+    return None
+
+
 def _classify_safe_generation_exception(exc: BaseException) -> str:
     text = f"{type(exc).__name__} {exc}".lower()
     if "metal" in text and any(term in text for term in ("alloc", "memory", "out of memory", "oom")):
@@ -56,7 +73,14 @@ def _classify_safe_generation_exception(exc: BaseException) -> str:
         return "worker_timeout"
     if any(term in text for term in ("worker dead", "broken pipe", "eof", "exited before")):
         return "worker_dead"
-    if "unexpected keyword argument" in text or "got an unexpected keyword argument" in text:
+    if _extract_unsupported_generation_kwarg(exc) or any(
+        marker in text for marker in (
+            "unexpected keyword argument",
+            "got an unexpected keyword argument",
+            "unsupported option",
+            "invalid keyword",
+        )
+    ):
         return "unsupported_generation_kwarg"
     return "unknown_generation_exception"
 
@@ -67,6 +91,8 @@ _SAFE_WORKER_DIAGNOSTIC_KEYS = {
     "generation_exception_category",
     "exception_type",
     "rejected_option",
+    "rejected_generation_kwarg",
+    "attempted_generation_kwargs",
     "method",
     "stream",
     "retryable",
@@ -77,6 +103,10 @@ _SAFE_WORKER_DIAGNOSTIC_KEYS = {
     "context_tier",
     "context_window_tokens",
     "n_ctx",
+    "max_tokens",
+    "temperature",
+    "top_p",
+    "top_k",
     "kv_cache_mode",
     "type_k",
     "type_v",
@@ -148,8 +178,13 @@ def _safe_worker_diagnostic_value(key: str, value: Any) -> Any:
         return bounded if bounded in enum_values else None
     if key == "exception_type":
         return bounded if _SAFE_WORKER_DIAGNOSTIC_CLASS_RE.fullmatch(bounded) else None
-    if key in {"rejected_option", "profile_id", "context_tier", "type_k", "type_v"}:
+    if key in {"rejected_option", "rejected_generation_kwarg", "profile_id", "context_tier", "type_k", "type_v"}:
         return bounded if _SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(bounded) else None
+    if key == "attempted_generation_kwargs":
+        names = [part for part in bounded.split(",") if part]
+        if names and all(_SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(part) for part in names):
+            return ",".join(names[:32])
+        return None
     if key == "sanitized_error_summary":
         return bounded if _SAFE_WORKER_DIAGNOSTIC_REDACTED_SUMMARY_RE.fullmatch(bounded) else None
     if key in {"stderr_tail", "child_stderr_tail"}:
@@ -699,6 +734,9 @@ class RelayClient:
         self.port = port
         self.crypto_manager = crypto_manager
         self.model_manager = model_manager
+        self._api_v1_generation_kwargs_filtered: Set[str] = set()
+        self._api_v1_generation_kwargs_supported: Set[str] = set()
+        self._api_v1_last_rejected_generation_kwargs: List[str] = []
         self.stop_polling = True  # Flag to control polling loop - starts as True so loop won't run until explicitly started
         self._polling_stopped_by_request = False
         self._registration_token: Optional[str] = None
@@ -3088,7 +3126,7 @@ class RelayClient:
     def _api_v1_runtime_completion_kwargs(
         self, safe_options: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Merge API v1 options with model-manager defaults for direct completions."""
+        """Merge API v1 options with filtered model-manager defaults for direct completions."""
 
         config = getattr(self.model_manager, "config", None)
         config_get = getattr(config, "get", None)
@@ -3108,11 +3146,90 @@ class RelayClient:
         profile_defaults = (
             getattr(self.model_manager, "model_profile", {}) or {}
         ).get("generation_defaults") or {}
-        for key in ("temperature", "top_p", "top_k"):
+        for key in ("temperature", "top_p", "top_k", "stop"):
             if key in profile_defaults:
                 completion_kwargs[key] = profile_defaults[key]
+        filtered = set(getattr(self.model_manager, "api_v1_generation_kwargs_filtered", set()) or set())
+        filtered.update(getattr(self, "_api_v1_generation_kwargs_filtered", set()) or set())
+        for key in list(filtered):
+            if key not in safe_options and key not in {"messages", "max_tokens", "stream"}:
+                completion_kwargs.pop(key, None)
         completion_kwargs.update(safe_options)
+        completion_kwargs["stream"] = False
         return completion_kwargs
+
+    @staticmethod
+    def _api_v1_attempted_generation_kwargs(kwargs: Dict[str, Any]) -> List[str]:
+        return sorted(str(key) for key in kwargs if key != "messages")
+
+    def _api_v1_remember_generation_kwargs(
+        self, *, attempted: List[str], rejected: Optional[str] = None
+    ) -> None:
+        filtered = set(getattr(self.model_manager, "api_v1_generation_kwargs_filtered", set()) or set())
+        if rejected:
+            filtered.add(rejected)
+            self._api_v1_generation_kwargs_filtered.add(rejected)
+            self._api_v1_last_rejected_generation_kwargs.append(rejected)
+        supported = set(attempted) - filtered
+        self._api_v1_generation_kwargs_supported.update(supported)
+        setattr(self.model_manager, "api_v1_generation_kwargs_filtered", filtered)
+        setattr(self.model_manager, "api_v1_generation_kwargs_supported", set(self._api_v1_generation_kwargs_supported))
+
+    def _api_v1_create_chat_completion_filtered(
+        self,
+        create_chat_completion: Any,
+        *,
+        messages: List[Dict[str, Any]],
+        safe_options: Dict[str, Any],
+        client_option_names: Set[str],
+        max_removed_kwargs: int = 3,
+    ) -> Tuple[Any, Dict[str, Any]]:
+        """Call the real runtime while removing only rejected internal kwargs."""
+
+        removed: List[str] = []
+        attempted_names: List[str] = []
+        while True:
+            completion_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
+            attempted_names = self._api_v1_attempted_generation_kwargs({"messages": messages, **completion_kwargs})
+            try:
+                result = create_chat_completion(messages=messages, **completion_kwargs)
+                self._api_v1_remember_generation_kwargs(attempted=attempted_names)
+                return result, {
+                    "completion_kwargs": completion_kwargs,
+                    "attempted_generation_kwargs": attempted_names,
+                    "filtered_generation_kwargs": sorted(set(removed) | set(getattr(self, "_api_v1_generation_kwargs_filtered", set()))),
+                    "supported_generation_kwargs": sorted(set(attempted_names) - set(getattr(self.model_manager, "api_v1_generation_kwargs_filtered", set()) or set())),
+                }
+            except Exception as exc:
+                diagnostics = getattr(exc, "diagnostics", {}) if _is_llama_cpp_inference_request_error(exc) else {}
+                safe_worker = _safe_worker_diagnostics(diagnostics)
+                rejected = None
+                if isinstance(safe_worker.get("rejected_generation_kwarg"), str):
+                    rejected = safe_worker["rejected_generation_kwarg"]
+                elif isinstance(safe_worker.get("rejected_option"), str):
+                    rejected = safe_worker["rejected_option"]
+                else:
+                    rejected = _extract_unsupported_generation_kwarg(exc)
+                category = (
+                    safe_worker.get("generation_exception_category")
+                    if isinstance(safe_worker.get("generation_exception_category"), str)
+                    else _classify_safe_generation_exception(exc)
+                )
+                if category != "unsupported_generation_kwarg" or not rejected:
+                    raise
+                if rejected in client_option_names:
+                    raise
+                if rejected in {"messages", "max_tokens", "stream"} or len(removed) >= max_removed_kwargs:
+                    raise
+                removed.append(rejected)
+                self._api_v1_remember_generation_kwargs(attempted=attempted_names, rejected=rejected)
+                log_info(
+                    "api_v1.generation_kwarg_filtered rejected_kwarg={} attempted_kwargs={} filtered_kwargs={}",
+                    rejected,
+                    ",".join(attempted_names),
+                    ",".join(sorted(set(removed))),
+                )
+                continue
 
     def _api_v1_enrich_safe_error(
         self,
@@ -3447,11 +3564,22 @@ class RelayClient:
                     "direct_non_streaming_completion",
                 )
                 started = time.monotonic()
-                completion = create_chat_completion(
+                completion, generation_kwarg_diagnostics = self._api_v1_create_chat_completion_filtered(
+                    create_chat_completion,
                     messages=runtime_messages,
-                    **completion_kwargs,
+                    safe_options=safe_options,
+                    client_option_names=set(safe_options),
                 )
+                completion_kwargs = generation_kwarg_diagnostics.get("completion_kwargs", completion_kwargs)
                 inference_duration = time.monotonic() - started
+                log_info(
+                    "api_v1.generation_kwargs active_tier={} model_id={} supported={} filtered={} attempted={}",
+                    normalize_context_tier(getattr(self.model_manager, "context_tier", DEFAULT_CONTEXT_TIER)),
+                    model_id,
+                    ",".join(generation_kwarg_diagnostics.get("supported_generation_kwargs", [])),
+                    ",".join(generation_kwarg_diagnostics.get("filtered_generation_kwargs", [])),
+                    ",".join(generation_kwarg_diagnostics.get("attempted_generation_kwargs", [])),
+                )
                 log_info(
                     "api_v1.inference_complete active_tier={} prompt_tokens={} output_reservation={} admission_result=admitted inference_duration_seconds={} safe_error_code=none",
                     normalize_context_tier(getattr(self.model_manager, "context_tier", DEFAULT_CONTEXT_TIER)),
@@ -3517,7 +3645,11 @@ class RelayClient:
                 rejected_option = (
                     safe_worker_diagnostics.get("rejected_option")
                     if isinstance(safe_worker_diagnostics.get("rejected_option"), str)
-                    else None
+                    else (
+                        safe_worker_diagnostics.get("rejected_generation_kwarg")
+                        if isinstance(safe_worker_diagnostics.get("rejected_generation_kwarg"), str)
+                        else None
+                    )
                 )
                 error_code = (
                     "compute_node_options_unsupported"
@@ -3580,6 +3712,11 @@ class RelayClient:
             unsupported_generation_kwarg = (
                 exception_category == "unsupported_generation_kwarg"
             )
+            rejected_generation_kwarg = (
+                _extract_unsupported_generation_kwarg(exc)
+                if unsupported_generation_kwarg
+                else None
+            )
             return self._api_v1_response_envelope(
                 request_id,
                 error=self._api_v1_enrich_safe_error(
@@ -3592,6 +3729,9 @@ class RelayClient:
                         "message": "Desktop runtime inference failed",
                         "exception_type": type(exc).__name__,
                         "exception_category": exception_category,
+                        "rejected_generation_kwargs": (
+                            [rejected_generation_kwarg] if rejected_generation_kwarg else None
+                        ),
                     },
                     request_id=request_id,
                     requested_context_tier=requested_context_tier,
@@ -3610,6 +3750,7 @@ class RelayClient:
                         }
                         else "runtime_inference_failed"
                     ),
+                    rejected_option=rejected_generation_kwarg,
                 ),
             )
 

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -736,7 +736,6 @@ class RelayClient:
         self.model_manager = model_manager
         self._api_v1_generation_kwargs_filtered: Set[str] = set()
         self._api_v1_generation_kwargs_supported: Set[str] = set()
-        self._api_v1_last_rejected_generation_kwargs: List[str] = []
         self.stop_polling = True  # Flag to control polling loop - starts as True so loop won't run until explicitly started
         self._polling_stopped_by_request = False
         self._registration_token: Optional[str] = None
@@ -3149,8 +3148,7 @@ class RelayClient:
         for key in ("temperature", "top_p", "top_k", "stop"):
             if key in profile_defaults:
                 completion_kwargs[key] = profile_defaults[key]
-        filtered = set(getattr(self.model_manager, "api_v1_generation_kwargs_filtered", set()) or set())
-        filtered.update(getattr(self, "_api_v1_generation_kwargs_filtered", set()) or set())
+        filtered = set(getattr(self, "_api_v1_generation_kwargs_filtered", set()) or set())
         for key in list(filtered):
             if key not in safe_options and key not in {"messages", "max_tokens", "stream"}:
                 completion_kwargs.pop(key, None)
@@ -3165,15 +3163,10 @@ class RelayClient:
     def _api_v1_remember_generation_kwargs(
         self, *, attempted: List[str], rejected: Optional[str] = None
     ) -> None:
-        filtered = set(getattr(self.model_manager, "api_v1_generation_kwargs_filtered", set()) or set())
         if rejected:
-            filtered.add(rejected)
             self._api_v1_generation_kwargs_filtered.add(rejected)
-            self._api_v1_last_rejected_generation_kwargs.append(rejected)
-        supported = set(attempted) - filtered
+        supported = set(attempted) - self._api_v1_generation_kwargs_filtered
         self._api_v1_generation_kwargs_supported.update(supported)
-        setattr(self.model_manager, "api_v1_generation_kwargs_filtered", filtered)
-        setattr(self.model_manager, "api_v1_generation_kwargs_supported", set(self._api_v1_generation_kwargs_supported))
 
     def _api_v1_create_chat_completion_filtered(
         self,
@@ -3198,7 +3191,7 @@ class RelayClient:
                     "completion_kwargs": completion_kwargs,
                     "attempted_generation_kwargs": attempted_names,
                     "filtered_generation_kwargs": sorted(set(removed) | set(getattr(self, "_api_v1_generation_kwargs_filtered", set()))),
-                    "supported_generation_kwargs": sorted(set(attempted_names) - set(getattr(self.model_manager, "api_v1_generation_kwargs_filtered", set()) or set())),
+                    "supported_generation_kwargs": sorted(set(attempted_names) - set(getattr(self, "_api_v1_generation_kwargs_filtered", set()) or set())),
                 }
             except Exception as exc:
                 diagnostics = getattr(exc, "diagnostics", {}) if _is_llama_cpp_inference_request_error(exc) else {}
@@ -3729,9 +3722,6 @@ class RelayClient:
                         "message": "Desktop runtime inference failed",
                         "exception_type": type(exc).__name__,
                         "exception_category": exception_category,
-                        "rejected_generation_kwargs": (
-                            [rejected_generation_kwarg] if rejected_generation_kwarg else None
-                        ),
                     },
                     request_id=request_id,
                     requested_context_tier=requested_context_tier,

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -45,19 +45,28 @@ def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
 
 
 _UNSUPPORTED_GENERATION_KWARG_PATTERNS = (
-    re.compile(r"unexpected keyword argument [\'\"]?([A-Za-z_][A-Za-z0-9_]*)"),
-    re.compile(r"got an unexpected keyword argument [\'\"]?([A-Za-z_][A-Za-z0-9_]*)"),
-    re.compile(r"unsupported option [\'\"]?([A-Za-z_][A-Za-z0-9_]*)"),
-    re.compile(r"invalid keyword [\'\"]?([A-Za-z_][A-Za-z0-9_]*)"),
+    re.compile(r"(?:got an )?unexpected keyword argument [\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]"),
+    re.compile(r"unsupported option(?:\s+[\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]|\s*:\s*([A-Za-z_][A-Za-z0-9_]*))"),
+    re.compile(r"invalid keyword(?: argument)? [\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]"),
+    re.compile(r"invalid keyword\s*=\s*([A-Za-z_][A-Za-z0-9_]*)"),
 )
 
 
-def _extract_unsupported_generation_kwarg(value: Any) -> Optional[str]:
+def _extract_unsupported_generation_kwarg(
+    value: Any, attempted_generation_kwargs: Optional[Sequence[str]] = None
+) -> Optional[str]:
     text = str(value or "")
+    attempted = (
+        {str(key) for key in attempted_generation_kwargs}
+        if attempted_generation_kwargs is not None
+        else None
+    )
     for pattern in _UNSUPPORTED_GENERATION_KWARG_PATTERNS:
         match = pattern.search(text)
         if match:
-            return match.group(1)
+            rejected = next((group for group in match.groups() if group), None)
+            if rejected and (attempted is None or rejected in attempted):
+                return rejected
     return None
 
 
@@ -73,14 +82,7 @@ def _classify_safe_generation_exception(exc: BaseException) -> str:
         return "worker_timeout"
     if any(term in text for term in ("worker dead", "broken pipe", "eof", "exited before")):
         return "worker_dead"
-    if _extract_unsupported_generation_kwarg(exc) or any(
-        marker in text for marker in (
-            "unexpected keyword argument",
-            "got an unexpected keyword argument",
-            "unsupported option",
-            "invalid keyword",
-        )
-    ):
+    if _extract_unsupported_generation_kwarg(exc):
         return "unsupported_generation_kwarg"
     return "unknown_generation_exception"
 
@@ -734,8 +736,7 @@ class RelayClient:
         self.port = port
         self.crypto_manager = crypto_manager
         self.model_manager = model_manager
-        self._api_v1_generation_kwargs_filtered: Set[str] = set()
-        self._api_v1_generation_kwargs_supported: Set[str] = set()
+        self._api_v1_generation_kwarg_cache: Dict[Tuple[Any, ...], Dict[str, Set[str]]] = {}
         self.stop_polling = True  # Flag to control polling loop - starts as True so loop won't run until explicitly started
         self._polling_stopped_by_request = False
         self._registration_token: Optional[str] = None
@@ -3148,13 +3149,64 @@ class RelayClient:
         for key in ("temperature", "top_p", "top_k", "stop"):
             if key in profile_defaults:
                 completion_kwargs[key] = profile_defaults[key]
-        filtered = set(getattr(self, "_api_v1_generation_kwargs_filtered", set()) or set())
+        filtered = self._api_v1_generation_kwarg_cache_entry()["filtered"]
         for key in list(filtered):
             if key not in safe_options and key not in {"messages", "max_tokens", "stream"}:
                 completion_kwargs.pop(key, None)
         completion_kwargs.update(safe_options)
         completion_kwargs["stream"] = False
         return completion_kwargs
+
+    def _api_v1_generation_kwarg_cache_key(self) -> Tuple[Any, ...]:
+        config = getattr(self.model_manager, "config", None)
+        config_get = getattr(config, "get", None)
+
+        def configured(key: str, default: Any) -> Any:
+            if callable(config_get):
+                return config_get(key, default)
+            return default
+
+        profile = getattr(self.model_manager, "model_profile", {}) or {}
+        generation_defaults = profile.get("generation_defaults") or {}
+        try:
+            generation_signature = json.dumps(
+                {
+                    "config": {
+                        "max_tokens": configured("model.max_tokens", 512),
+                        "temperature": configured("model.temperature", 0.7),
+                        "top_p": configured("model.top_p", 0.9),
+                        "stop": configured("model.stop_tokens", []),
+                    },
+                    "profile_defaults": generation_defaults,
+                },
+                sort_keys=True,
+                default=str,
+            )
+        except TypeError:
+            generation_signature = repr((configured("model.max_tokens", 512), generation_defaults))
+        runtime = getattr(self.model_manager, "runtime", None) or getattr(self.model_manager, "llm", None)
+        return (
+            id(runtime),
+            getattr(self.model_manager, "api_model_id", None),
+            getattr(self.model_manager, "model_id", None),
+            normalize_context_tier(getattr(self.model_manager, "context_tier", DEFAULT_CONTEXT_TIER)),
+            profile.get("id") or profile.get("profile_id") or profile.get("name"),
+            generation_signature,
+        )
+
+    def _api_v1_generation_kwarg_cache_entry(self) -> Dict[str, Set[str]]:
+        return self._api_v1_generation_kwarg_cache.setdefault(
+            self._api_v1_generation_kwarg_cache_key(),
+            {"filtered": set(), "supported": set()},
+        )
+
+    @property
+    def _api_v1_generation_kwargs_filtered(self) -> Set[str]:
+        return self._api_v1_generation_kwarg_cache_entry()["filtered"]
+
+    @property
+    def _api_v1_generation_kwargs_supported(self) -> Set[str]:
+        return self._api_v1_generation_kwarg_cache_entry()["supported"]
 
     @staticmethod
     def _api_v1_attempted_generation_kwargs(kwargs: Dict[str, Any]) -> List[str]:
@@ -3163,10 +3215,11 @@ class RelayClient:
     def _api_v1_remember_generation_kwargs(
         self, *, attempted: List[str], rejected: Optional[str] = None
     ) -> None:
+        cache_entry = self._api_v1_generation_kwarg_cache_entry()
         if rejected:
-            self._api_v1_generation_kwargs_filtered.add(rejected)
-        supported = set(attempted) - self._api_v1_generation_kwargs_filtered
-        self._api_v1_generation_kwargs_supported.update(supported)
+            cache_entry["filtered"].add(rejected)
+        supported = set(attempted) - cache_entry["filtered"]
+        cache_entry["supported"].update(supported)
 
     def _api_v1_create_chat_completion_filtered(
         self,
@@ -3202,7 +3255,9 @@ class RelayClient:
                 elif isinstance(safe_worker.get("rejected_option"), str):
                     rejected = safe_worker["rejected_option"]
                 else:
-                    rejected = _extract_unsupported_generation_kwarg(exc)
+                    rejected = _extract_unsupported_generation_kwarg(exc, attempted_names)
+                if rejected not in set(attempted_names):
+                    rejected = None
                 category = (
                     safe_worker.get("generation_exception_category")
                     if isinstance(safe_worker.get("generation_exception_category"), str)


### PR DESCRIPTION
### Motivation
- Qwen3 64K readiness on packaged desktop runtimes was failing because internally supplied generation kwargs (profile defaults like `top_k` / empty `stop`) were rejected by the real packaged `llama-cpp-python` worker.  The node correctly failed readiness before registration. 
- The parent process must discover which `create_chat_completion` kwargs the real child runtime accepts and avoid passing unsupported internal defaults while still surfacing client-supplied unsupported options as errors. 
- Keep Qwen non-thinking controls and exact context admission intact and add CI/regression coverage to detect packaged-runtime incompatible generation kwargs early.

### Description
- Add real packaged-runtime unsupported-kwarg detection and extraction patterns via `_UNSUPPORTED_GENERATION_KWARG_PATTERNS` and `_extract_unsupported_generation_kwarg` and extend worker diagnostics to include safe identifiers (e.g. `rejected_generation_kwarg`, `attempted_generation_kwargs`) and safe scalar fields (`max_tokens`, `temperature`, `top_p`, `top_k`) in `utils/llm/model_manager.py` and the subprocess bridge.
- Implement a filtering/retry helper `_api_v1_create_chat_completion_filtered` in `utils/networking/relay_client.py` that: probes attempted kwargs, records attempted names, retries once (bounded by a small limit) after removing unsupported internal defaults, caches `api_v1_generation_kwargs_filtered` and `api_v1_generation_kwargs_supported`, and refuses to silently drop client-supplied unsupported options (returns `compute_node_options_unsupported`).
- Update `_api_v1_runtime_completion_kwargs` to consult cached filtered names and ensure required non-streaming shape (`messages`, `max_tokens`, `stream=False`), and route both readiness smoke and real API v1 generation through the same filtered path; log safe diagnostics `api_v1_generation_kwargs_supported` and `api_v1_generation_kwargs_filtered` to `last_compute_diagnostics` only as names/allowed scalars (no prompt/text).
- Improve safe diagnostics mapping so readiness failures caused by rejected generation kwargs record `runtime_completion_smoke_unsupported_generation_kwarg` and include only kwarg names and safe categories; add bounded retry logic and caching per instance to avoid repeated reprobes.
- Add focused tests reproducing the packaged-runtime failure and validating behavior: new/updated tests in `tests/unit/test_relay_client.py` (internal `top_k`/`stop` filtering, bounded retry, client-supplied unsupported option handling, preservation of `/no_think`) and `tests/integration/test_desktop_qwen64k_packaged_runtime.py` (packaged fake-runtime e2e that rejects an internal kwarg once and verifies retry+registration).

### Testing
- Ran focused verification and full unit/integration suites; key commands and outcomes: 
  - `python -m pytest tests/unit/test_relay_client.py -q` — passed.
  - `python -m pytest tests/unit/test_model_manager.py -q` — passed.
  - `python -m pytest tests/unit/test_compute_node_runtime.py -q` — passed.
  - `python -m pytest tests/unit -q --maxfail=1` — full unit suite passed (1918 passed, 1 skipped in the run shown). 
  - `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` — passed.
  - `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q` — passed (packaged fake-runtime e2e/regression exercises unsupported-kwarg rejection and verifies retry/filter/cache behavior).
  - `pre-commit run --all-files` — passed.

All automated checks in CI-local runs above completed successfully and the new tests exercise the packaged-runtime rejection case without logging any prompt/response content or secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49b6a1b180832fbc6449621a5e4ece)