### PR TITLE
Filter unsupported generation kwargs for Qwen3 64K packaged runtime

### DIFF
--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -258,3 +258,29 @@ def test_qwen64k_packaged_fake_runtime_valid_generation_passes_readiness():
     assert diagnostics["api_v1_readiness_result"] == "passed"
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert diagnostics["api_v1_readiness_completion_smoke_path"] == "shared_api_v1_generation"
+
+
+def test_qwen64k_packaged_fake_runtime_filters_unsupported_internal_top_k_before_registration():
+    class RejectTopKOnceRuntime(_Qwen64kFakeRuntime):
+        def __init__(self):
+            self.calls = []
+
+        def create_chat_completion(self, **kwargs):
+            self.calls.append(dict(kwargs))
+            if "top_k" in kwargs:
+                raise TypeError("create_chat_completion() got an unexpected keyword argument 'top_k'")
+            return {"choices": [{"message": {"role": "assistant", "content": "<think></think>\n\nok"}}]}
+
+    fake_runtime = RejectTopKOnceRuntime()
+    runtime, manager = _runtime_for(fake_runtime)
+    manager.model_profile["generation_defaults"] = {"top_k": 40, "temperature": 0.6, "top_p": 0.9}
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    diagnostics = manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
+    assert diagnostics["api_v1_readiness_completion_smoke_path"] == "shared_api_v1_generation"
+    assert len(fake_runtime.calls) == 2
+    assert "top_k" in fake_runtime.calls[0]
+    assert "top_k" not in fake_runtime.calls[1]
+    assert manager.api_v1_generation_kwargs_filtered == ["top_k"]
+    assert "SECRET" not in json.dumps(diagnostics)

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -2029,3 +2029,63 @@ def test_qwen_8k_readiness_still_passes_without_yarn():
 
     assert runtime.ensure_api_v1_runtime_ready() is True
     assert model_manager.last_compute_diagnostics["api_v1_readiness_yarn_rope_enabled"] is False
+
+
+def test_qwen_64k_completion_smoke_filters_internal_top_k_and_registers():
+    class RejectTopKOnceRuntime(_Qwen64kRuntime):
+        def __init__(self):
+            self.calls = []
+
+        def create_chat_completion(self, **kwargs):
+            self.calls.append(dict(kwargs))
+            if "top_k" in kwargs:
+                raise TypeError("create_chat_completion() got an unexpected keyword argument 'top_k'")
+            return {"choices": [{"message": {"role": "assistant", "content": "<think></think>\n\nok"}}]}
+
+    llm_runtime = RejectTopKOnceRuntime()
+    model_manager = _qwen_64k_model_manager(llm_runtime)
+    model_manager.model_profile["generation_defaults"] = {"top_k": 40, "temperature": 0.6, "top_p": 0.9}
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=_ready_relay_client(),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is True
+    assert len(llm_runtime.calls) == 2
+    assert "top_k" in llm_runtime.calls[0]
+    assert "top_k" not in llm_runtime.calls[1]
+    assert model_manager.api_v1_generation_kwargs_filtered == ["top_k"]
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
+    assert diagnostics["api_v1_readiness_error_reason"] is None
+
+
+def test_qwen_64k_completion_smoke_bounded_retry_fails_closed():
+    class RejectManyRuntime(_Qwen64kRuntime):
+        rejected = ["top_k", "stop", "temperature", "top_p"]
+
+        def __init__(self):
+            self.calls = 0
+
+        def create_chat_completion(self, **kwargs):
+            name = self.rejected[min(self.calls, len(self.rejected) - 1)]
+            self.calls += 1
+            raise TypeError(f"create_chat_completion() got an unexpected keyword argument '{name}'")
+
+    llm_runtime = RejectManyRuntime()
+    model_manager = _qwen_64k_model_manager(llm_runtime)
+    model_manager.model_profile["generation_defaults"] = {"top_k": 40, "temperature": 0.6, "top_p": 0.9}
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=_ready_relay_client(),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_unsupported_generation_kwarg"
+    assert llm_runtime.calls == 4
+    assert "SECRET" not in json.dumps(diagnostics)

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -5691,18 +5691,43 @@ def test_api_v1_runtime_rejected_generation_option_drops_unsafe_allowed_values()
     assert "SECRET" not in json.dumps(error)
 
 
-def test_api_v1_generic_unsupported_generation_kwarg_uses_options_error():
+def test_api_v1_internal_unsupported_generation_kwarg_is_filtered_and_retried():
+    manager = _ApiV1RuntimeManager()
+    manager.runtime.create_chat_completion.side_effect = [
+        TypeError("create_chat_completion() got an unexpected keyword argument 'top_k'"),
+        {"choices": [{"message": {"role": "assistant", "content": "ok"}}]},
+    ]
+    manager.model_profile = {"generation_defaults": {"top_k": 40}}
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-generic-option-retried",
+        model_id="llama-3-8b-instruct",
+        messages=[{"role": "user", "content": "hi"}],
+        options={},
+    )
+
+    assert envelope["api_v1_response"]["message"]["content"] == "ok"
+    assert manager.runtime.create_chat_completion.call_count == 2
+    first = manager.runtime.create_chat_completion.call_args_list[0].kwargs
+    second = manager.runtime.create_chat_completion.call_args_list[1].kwargs
+    assert "top_k" in first
+    assert "top_k" not in second
+    assert manager.api_v1_generation_kwargs_filtered == ["top_k"]
+
+
+def test_api_v1_client_supplied_unsupported_runtime_kwarg_still_fails():
     manager = _ApiV1RuntimeManager()
     manager.runtime.create_chat_completion.side_effect = TypeError(
-        "create_chat_completion() got an unexpected keyword argument 'top_k'"
+        "create_chat_completion() got an unexpected keyword argument 'temperature'"
     )
     client = _api_v1_validation_client(manager)
 
     envelope = client._generate_api_v1_response_with_runtime_model(
-        request_id="req-generic-option-rejected",
+        request_id="req-client-option-rejected",
         model_id="llama-3-8b-instruct",
         messages=[{"role": "user", "content": "hi"}],
-        options={},
+        options={"temperature": 0.2},
     )
 
     error = envelope["api_v1_response"]["error"]

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1772,7 +1772,7 @@ def _sanitize_error_summary(message):
         return type(message).__name__ + ':kv_cache_allocation'
     if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'eval'))):
         return type(message).__name__ + ':rope_yarn_eval_failure'
-    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument)', str(message or '')):
+    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument|unsupported option|invalid keyword)', str(message or '')):
         return type(message).__name__ + ':unsupported_kwarg'
     return type(message).__name__ + ':redacted'
 
@@ -1784,7 +1784,7 @@ def _classify_generation_exception(exc):
         return 'kv_cache_allocation'
     if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'eval'))):
         return 'rope_yarn_eval_failure'
-    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument)', str(exc or '')):
+    if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument|unsupported option|invalid keyword)', str(exc or '')):
         return 'unsupported_generation_kwarg'
     return 'unknown_generation_exception'
 
@@ -1803,18 +1803,37 @@ def _safe_request_error(reason, *, request=None, exc=None, extra=None):
         kwargs = request.get('kwargs')
         if isinstance(kwargs, dict):
             diagnostics['stream'] = bool(kwargs.get('stream'))
+
     if exc is not None:
         diagnostics['exception_type'] = type(exc).__name__
         diagnostics['sanitized_error_summary'] = _sanitize_error_summary(exc)
         if reason == 'inference_exception':
             diagnostics['generation_exception_category'] = _classify_generation_exception(exc)
             message = str(exc)
-            match = re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument) [\\'"]?([A-Za-z_][A-Za-z0-9_]*)', message)
-            if match:
-                diagnostics['reason'] = 'unsupported_generation_option'
-                diagnostics['code'] = 'compute_node_options_unsupported'
-                diagnostics['rejected_option'] = match.group(1)
-                diagnostics['generation_exception_category'] = 'unsupported_generation_kwarg'
+            patterns = (
+                r'(?:got an )?unexpected keyword argument [\\'"]?([A-Za-z_][A-Za-z0-9_]*)',
+                r'unsupported option [\\'"]?([A-Za-z_][A-Za-z0-9_]*)',
+                r'invalid keyword [\\'"]?([A-Za-z_][A-Za-z0-9_]*)',
+            )
+            for pattern in patterns:
+                match = re.search(pattern, message, flags=re.IGNORECASE)
+                if match:
+                    diagnostics['reason'] = 'unsupported_generation_option'
+                    diagnostics['code'] = 'compute_node_options_unsupported'
+                    diagnostics['rejected_option'] = match.group(1)
+                    diagnostics['rejected_generation_kwarg'] = match.group(1)
+                    if isinstance(request, dict) and isinstance(request.get('kwargs'), dict):
+                        attempted_generation_kwargs = ','.join(
+                            sorted(
+                                str(key)
+                                for key in request.get('kwargs')
+                                if isinstance(key, str) and key != 'messages'
+                            )
+                        )
+                        if attempted_generation_kwargs:
+                            diagnostics['attempted_generation_kwargs'] = attempted_generation_kwargs
+                    diagnostics['generation_exception_category'] = 'unsupported_generation_kwarg'
+                    break
     return {
         'status': 'error',
         'request_error': True,

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -56,7 +56,7 @@ def _classify_safe_generation_exception(exc: BaseException) -> str:
         return "worker_timeout"
     if any(term in text for term in ("worker dead", "broken pipe", "eof", "exited before")):
         return "worker_dead"
-    if "unexpected keyword argument" in text or "got an unexpected keyword argument" in text:
+    if re.search(r"(?:unexpected keyword argument|got an unexpected keyword argument|unsupported option|invalid keyword)", text):
         return "unsupported_generation_kwarg"
     return "unknown_generation_exception"
 
@@ -67,6 +67,8 @@ _SAFE_WORKER_DIAGNOSTIC_KEYS = {
     "generation_exception_category",
     "exception_type",
     "rejected_option",
+    "rejected_generation_kwarg",
+    "attempted_generation_kwargs",
     "method",
     "stream",
     "retryable",
@@ -148,8 +150,11 @@ def _safe_worker_diagnostic_value(key: str, value: Any) -> Any:
         return bounded if bounded in enum_values else None
     if key == "exception_type":
         return bounded if _SAFE_WORKER_DIAGNOSTIC_CLASS_RE.fullmatch(bounded) else None
-    if key in {"rejected_option", "profile_id", "context_tier", "type_k", "type_v"}:
+    if key in {"rejected_option", "rejected_generation_kwarg", "profile_id", "context_tier", "type_k", "type_v"}:
         return bounded if _SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(bounded) else None
+    if key == "attempted_generation_kwargs":
+        names = [name for name in bounded.split(",") if _SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(name)]
+        return ",".join(names[:32]) if names else None
     if key == "sanitized_error_summary":
         return bounded if _SAFE_WORKER_DIAGNOSTIC_REDACTED_SUMMARY_RE.fullmatch(bounded) else None
     if key in {"stderr_tail", "child_stderr_tail"}:
@@ -3112,7 +3117,79 @@ class RelayClient:
             if key in profile_defaults:
                 completion_kwargs[key] = profile_defaults[key]
         completion_kwargs.update(safe_options)
-        return completion_kwargs
+        return self._api_v1_filter_cached_internal_generation_kwargs(
+            completion_kwargs, client_option_names=set(safe_options)
+        )
+
+    @staticmethod
+    def _api_v1_rejected_generation_kwarg_from_error(error: BaseException) -> Optional[str]:
+        text = str(error or "")
+        patterns = (
+            r"(?:got an )?unexpected keyword argument [\'\"]?([A-Za-z_][A-Za-z0-9_]*)",
+            r"unsupported option [\'\"]?([A-Za-z_][A-Za-z0-9_]*)",
+            r"invalid keyword [\'\"]?([A-Za-z_][A-Za-z0-9_]*)",
+        )
+        for pattern in patterns:
+            match = re.search(pattern, text, flags=re.IGNORECASE)
+            if match:
+                return match.group(1)
+        return None
+
+    def _api_v1_filter_cached_internal_generation_kwargs(
+        self, completion_kwargs: Dict[str, Any], *, client_option_names: Set[str]
+    ) -> Dict[str, Any]:
+        required = {"max_tokens", "stream"}
+        unsupported = getattr(self.model_manager, "_api_v1_unsupported_internal_generation_kwargs", set())
+        if not isinstance(unsupported, set):
+            unsupported = set(unsupported or [])
+        filtered = {
+            key: value for key, value in completion_kwargs.items()
+            if key in required or key in client_option_names or key not in unsupported
+        }
+        if filtered.get("stop") == [] and "stop" not in client_option_names and "stop" in unsupported:
+            filtered.pop("stop", None)
+        return filtered
+
+    def _api_v1_record_generation_kwarg_filter_result(
+        self, attempted: Dict[str, Any], rejected: Sequence[str]
+    ) -> None:
+        rejected_set = {name for name in rejected if isinstance(name, str)}
+        manager_set = getattr(self.model_manager, "_api_v1_unsupported_internal_generation_kwargs", set())
+        if not isinstance(manager_set, set):
+            manager_set = set(manager_set or [])
+        manager_set.update(rejected_set)
+        setattr(self.model_manager, "_api_v1_unsupported_internal_generation_kwargs", manager_set)
+        setattr(self.model_manager, "api_v1_generation_kwargs_supported", sorted(set(attempted) - manager_set))
+        setattr(self.model_manager, "api_v1_generation_kwargs_filtered", sorted(manager_set))
+
+    def _api_v1_create_chat_completion_filtered(
+        self, create_chat_completion: Any, *, messages: List[Dict[str, Any]],
+        completion_kwargs: Dict[str, Any], client_option_names: Set[str], max_removed_kwargs: int = 3
+    ) -> Tuple[Any, Dict[str, Any], List[str]]:
+        rejected: List[str] = []
+        current = self._api_v1_filter_cached_internal_generation_kwargs(
+            dict(completion_kwargs), client_option_names=client_option_names
+        )
+        while True:
+            try:
+                completion = create_chat_completion(messages=messages, **current)
+                self._api_v1_record_generation_kwarg_filter_result(current, rejected)
+                return completion, current, rejected
+            except Exception as exc:
+                rejected_kwarg = self._api_v1_rejected_generation_kwarg_from_error(exc)
+                if (
+                    not rejected_kwarg
+                    or rejected_kwarg in client_option_names
+                    or rejected_kwarg in {"messages", "max_tokens", "stream"}
+                    or rejected_kwarg not in current
+                    or len(rejected) >= max_removed_kwargs
+                ):
+                    setattr(exc, "token_place_rejected_generation_kwargs", list(rejected) + ([rejected_kwarg] if rejected_kwarg else []))
+                    setattr(exc, "token_place_attempted_generation_kwargs", sorted(current))
+                    raise
+                rejected.append(rejected_kwarg)
+                current.pop(rejected_kwarg, None)
+                self._api_v1_record_generation_kwarg_filter_result(current, rejected)
 
     def _api_v1_enrich_safe_error(
         self,
@@ -3447,17 +3524,23 @@ class RelayClient:
                     "direct_non_streaming_completion",
                 )
                 started = time.monotonic()
-                completion = create_chat_completion(
-                    messages=runtime_messages,
-                    **completion_kwargs,
+                completion, completion_kwargs, rejected_generation_kwargs = (
+                    self._api_v1_create_chat_completion_filtered(
+                        create_chat_completion,
+                        messages=runtime_messages,
+                        completion_kwargs=completion_kwargs,
+                        client_option_names=set(safe_options),
+                    )
                 )
                 inference_duration = time.monotonic() - started
                 log_info(
-                    "api_v1.inference_complete active_tier={} prompt_tokens={} output_reservation={} admission_result=admitted inference_duration_seconds={} safe_error_code=none",
+                    "api_v1.inference_complete active_tier={} prompt_tokens={} output_reservation={} admission_result=admitted inference_duration_seconds={} safe_error_code=none generation_kwargs_supported={} generation_kwargs_filtered={}",
                     normalize_context_tier(getattr(self.model_manager, "context_tier", DEFAULT_CONTEXT_TIER)),
                     prompt_tokens if prompt_tokens is not None else "unknown",
                     completion_kwargs["max_tokens"],
                     round(inference_duration, 3),
+                    sorted(completion_kwargs),
+                    rejected_generation_kwargs,
                 )
                 assistant_message = self._assistant_message_from_runtime_completion(
                     completion
@@ -3592,6 +3675,8 @@ class RelayClient:
                         "message": "Desktop runtime inference failed",
                         "exception_type": type(exc).__name__,
                         "exception_category": exception_category,
+                    "rejected_generation_kwargs": getattr(exc, "token_place_rejected_generation_kwargs", None),
+                    "attempted_generation_kwargs": getattr(exc, "token_place_attempted_generation_kwargs", None),
                     },
                     request_id=request_id,
                     requested_context_tier=requested_context_tier,


### PR DESCRIPTION
### Motivation
- Packaged desktop llama-cpp runtimes (Qwen3 64K) can reject internally supplied generation kwargs (e.g. `top_k`) during readiness smoke and block registration.  The runtime support must be discovered and internal defaults filtered at call time so internal defaults cannot make a node unusable.
- Diagnostics must expose only safe metadata (rejected kwarg names, attempted kwarg names, exception category/type) without logging prompts, assistant text, or any secret material.

### Description
- Add detection and safe extraction of rejected generation kwarg names from common runtime error messages and worker diagnostics by matching patterns like `unexpected keyword argument`, `unsupported option`, or `invalid keyword` in `utils/llm/model_manager.py` and `utils/networking/relay_client.py`.
- Implement a shared runtime-aware filtering/retry helper in `RelayClient` that: filters internal defaults against a per-manager cached unsupported set, retries once (bounded by a small limit) when the runtime signals a rejected internal kwarg, caches filtered names on success, and preserves client-supplied unsupported option failures (`compute_node_options_unsupported`).
- Preserve Qwen non-thinking controls and output normalization paths by routing readiness smoke and real API v1 generation through the same filtered completion helper (`_api_v1_create_chat_completion_filtered`) so behavior cannot diverge.
- Extend worker/child diagnostics allowlist and sanitizer to accept and return safe fields: `rejected_generation_kwarg`, `attempted_generation_kwargs`, `api_v1_generation_kwargs_supported`, and `api_v1_generation_kwargs_filtered`, while ensuring no prompt/response content is included.
- Add unit and integration tests that reproduce the packaged-runtime failure and validate the fix: tests cover filtering an unsupported internal `top_k`, bounded retry fail-closed behavior, caching filtered kwargs, and packaged fake-runtime e2e for Qwen 64K.

### Testing
- Ran focused unit and integration suites: `python -m pytest tests/unit/test_relay_client.py -q`, `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/unit/test_compute_node_runtime.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, and `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`; all passed.
- Ran the new packaged-runtime regression: `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q`; all tests in that file passed.
- Ran full unit sweep `python -m pytest tests/unit -q -x` and project `pre-commit run --all-files`; the test suites and pre-commit checks passed with no sensitive content leaked in logs.
- Changes touched `utils/networking/relay_client.py`, `utils/llm/model_manager.py`, and added/updated tests under `tests/unit/` and `tests/integration/` to cover the failure modes and regression scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49b6ab0be0832f97890549007b0690)