### PR TITLE
Qwen: use minimal render-then-plain completion in child worker, add fallbacks and safe diagnostics

### DIFF
--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -201,7 +201,7 @@ def _runtime_for(fake_runtime):
     ("category", "reason"),
     [
         ("kv_cache_allocation", "runtime_completion_smoke_kv_cache_allocation"),
-        ("unsupported_generation_kwarg", "runtime_completion_smoke_unsupported_generation_kwarg"),
+        ("unexpected_kwarg", "runtime_completion_smoke_plain_completion_unexpected_kwarg"),
         ("rope_yarn_eval_failure", "runtime_completion_smoke_rope_yarn_eval_failure"),
         ("worker_timeout", "runtime_completion_smoke_worker_timeout"),
         ("worker_dead", "runtime_completion_smoke_worker_dead"),
@@ -263,27 +263,29 @@ def test_qwen64k_packaged_fake_runtime_valid_generation_passes_readiness():
     assert diagnostics["api_v1_readiness_completion_smoke_path"] == "shared_api_v1_generation"
 
 
-def test_qwen64k_packaged_fake_runtime_filters_unsupported_internal_top_k_and_registers():
-    class TopKRejectingRuntime(_Qwen64kFakeRuntime):
+def test_qwen64k_packaged_fake_runtime_readiness_omits_internal_sampling_defaults():
+    class SamplingRejectingRuntime(_Qwen64kFakeRuntime):
         def __init__(self):
             self.calls = []
-            self.rejected = False
 
         def create_chat_completion_from_rendered_prompt(self, messages, **kwargs):
             self.calls.append(dict(kwargs))
-            if "top_k" in kwargs and not self.rejected:
-                self.rejected = True
-                raise TypeError("got an unexpected keyword argument 'top_k'")
+            forbidden = {"top_k", "temperature", "top_p", "stop", "stream"} & set(kwargs)
+            if forbidden:
+                raise TypeError(f"got an unexpected keyword argument '{sorted(forbidden)[0]}'")
             return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
 
-    fake = TopKRejectingRuntime()
+    fake = SamplingRejectingRuntime()
     runtime, manager = _runtime_for(fake)
-    manager.model_profile["generation_defaults"] = {"top_k": 20}
+    manager.model_profile["generation_defaults"] = {"top_k": 20, "temperature": 0.7}
 
     assert runtime.ensure_api_v1_runtime_ready() is True
     diagnostics = manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_result"] == "passed"
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
-    assert fake.calls[0]["top_k"] == 20
-    assert "top_k" not in fake.calls[1]
-    assert "top_k" in diagnostics["api_v1_generation_kwargs_filtered"]
+    assert fake.calls == [{
+        "max_tokens": 64,
+        "token_place_provider": "qwen",
+        "token_place_template_policy": "gguf-jinja",
+        "enable_thinking": False,
+    }]

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -671,7 +671,7 @@ def test_compute_node_runtime_readiness_smoke_completion_passes(monkeypatch):
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert diagnostics["api_v1_readiness_result"] == "passed"
     assert diagnostics["api_v1_readiness_model_profile_id"] == "qwen3-8b-q4-k-m"
-    assert llm_runtime.completion_kwargs["stream"] is False
+    assert "stream" not in llm_runtime.completion_kwargs
     assert llm_runtime.completion_kwargs["max_tokens"] == 64
     assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
 

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -3216,6 +3216,159 @@ def test_llama_worker_render_complete_allows_testing_stories_model_without_metad
     }
 
 
+def test_llama_worker_render_complete_uses_minimal_plain_completion_kwargs(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'minimal fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    metadata = {'general.name': 'Qwen3 test', 'tokenizer.chat_template': 'qwen'}\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def apply_chat_template(self, messages, **kwargs):\n"
+        "        return '<rendered>'\n"
+        "    def create_completion(self, *, prompt, **kwargs):\n"
+        "        assert prompt == '<rendered>'\n"
+        "        assert kwargs == {'max_tokens': 64}\n"
+        "        return {'choices': [{'text': '<think></think>ok<|im_end|>'}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='qwen.gguf', timeout_seconds=5)
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt(
+            [{'role': 'user', 'content': 'secret prompt text'}],
+            max_tokens=64,
+            stream=False,
+            stop=[],
+            temperature=0.7,
+            token_place_provider='qwen',
+            token_place_template_policy='gguf-jinja',
+            enable_thinking=False,
+        )
+    finally:
+        proxy.close()
+
+    assert result == {'choices': [{'message': {'role': 'assistant', 'content': 'ok'}}]}
+
+
+def test_llama_worker_render_complete_falls_back_from_prompt_keyword_to_positional(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'positional fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    metadata = {'general.name': 'Qwen3 test', 'tokenizer.chat_template': 'qwen'}\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def apply_chat_template(self, messages, **kwargs):\n"
+        "        return '<rendered>'\n"
+        "    def create_completion(self, *args, **kwargs):\n"
+        "        if 'prompt' in kwargs:\n"
+        "            raise TypeError(\"got an unexpected keyword argument 'prompt'\")\n"
+        "        assert args == ('<rendered>',)\n"
+        "        assert kwargs == {'max_tokens': 64}\n"
+        "        return {'choices': [{'text': 'positional ok'}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='qwen.gguf', timeout_seconds=5)
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt(
+            [{'role': 'user', 'content': 'secret prompt text'}],
+            max_tokens=64,
+            token_place_provider='qwen',
+            token_place_template_policy='gguf-jinja',
+            enable_thinking=False,
+        )
+    finally:
+        proxy.close()
+
+    assert result['choices'][0]['message']['content'] == 'positional ok'
+
+
+def test_llama_worker_render_complete_uses_callable_llama_without_create_completion(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'callable fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    metadata = {'general.name': 'Qwen3 test', 'tokenizer.chat_template': 'qwen'}\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def apply_chat_template(self, messages, **kwargs):\n"
+        "        return '<rendered>'\n"
+        "    def __call__(self, prompt, **kwargs):\n"
+        "        assert prompt == '<rendered>'\n"
+        "        assert kwargs == {'max_tokens': 64}\n"
+        "        return {'choices': [{'text': 'callable ok'}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='qwen.gguf', timeout_seconds=5)
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt(
+            [{'role': 'user', 'content': 'secret prompt text'}],
+            max_tokens=64,
+            token_place_provider='qwen',
+            token_place_template_policy='gguf-jinja',
+            enable_thinking=False,
+        )
+    finally:
+        proxy.close()
+
+    assert result['choices'][0]['message']['content'] == 'callable ok'
+
+
+def test_llama_worker_render_complete_empty_output_has_safe_plain_completion_diagnostics(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'empty fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    metadata = {'general.name': 'Qwen3 test', 'tokenizer.chat_template': 'qwen'}\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def apply_chat_template(self, messages, **kwargs):\n"
+        "        return '<rendered SECRET_RENDERED>'\n"
+        "    def create_completion(self, *, prompt, **kwargs):\n"
+        "        return {'choices': [{'text': '   '}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='qwen.gguf', timeout_seconds=5)
+    try:
+        with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as exc_info:
+            proxy.create_chat_completion_from_rendered_prompt(
+                [{'role': 'user', 'content': 'SECRET_PROMPT'}],
+                max_tokens=64,
+                token_place_provider='qwen',
+                token_place_template_policy='gguf-jinja',
+                enable_thinking=False,
+            )
+    finally:
+        proxy.close()
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics['generation_exception_category'] == 'empty_completion_output'
+    assert diagnostics['plain_completion_method'] == 'create_completion_keyword_prompt'
+    assert diagnostics['attempted_generation_kwargs'] == 'max_tokens,prompt'
+    assert diagnostics['result_shape'] == 'choices_text'
+    assert 'SECRET_PROMPT' not in json.dumps(diagnostics)
+    assert 'SECRET_RENDERED' not in json.dumps(diagnostics)
+
 def test_llama_worker_render_complete_denies_testing_fallback_outside_testing_env(tmp_path, monkeypatch):
     from utils.llm import model_manager as model_manager_module
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4220,8 +4220,10 @@ def test_api_v1_qwen_generation_uses_render_then_complete_not_chat_completion():
     assert envelope["api_v1_response"]["message"] == {"role": "assistant", "content": "ok"}
     manager.runtime.create_chat_completion.assert_not_called()
     kwargs = manager.runtime.create_chat_completion_from_rendered_prompt.call_args.kwargs
-    assert kwargs["stream"] is False
     assert kwargs["max_tokens"] == 64
+    assert "stream" not in kwargs
+    assert "temperature" not in kwargs
+    assert "stop" not in kwargs
     assert kwargs["enable_thinking"] is False
     assert "messages" not in kwargs
     messages = manager.runtime.create_chat_completion_from_rendered_prompt.call_args.args[0]
@@ -4258,7 +4260,7 @@ def test_api_v1_qwen_missing_render_complete_bridge_fails_closed_without_chat_fa
     assert error["internal_reason"] == "qwen_render_complete_bridge_unavailable"
     manager.runtime.create_chat_completion.assert_not_called()
 
-def test_api_v1_qwen_render_then_complete_preserves_seed_option():
+def test_api_v1_qwen_render_then_complete_rejects_unproven_seed_option():
     manager = _ApiV1RuntimeManager()
     manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
     manager.runtime.create_chat_completion_from_rendered_prompt = MagicMock(return_value={
@@ -4273,9 +4275,10 @@ def test_api_v1_qwen_render_then_complete_preserves_seed_option():
         options={"max_tokens": 64, "seed": 7},
     )
 
-    assert envelope["api_v1_response"]["message"]["content"] == "ok"
-    kwargs = manager.runtime.create_chat_completion_from_rendered_prompt.call_args.kwargs
-    assert kwargs["seed"] == 7
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_options_unsupported"
+    assert error["rejected_option"] == "seed"
+    manager.runtime.create_chat_completion_from_rendered_prompt.assert_not_called()
 
 
 def test_api_v1_qwen_render_then_complete_retries_rejected_option_once():
@@ -4318,19 +4321,9 @@ def test_api_v1_qwen_render_then_complete_retries_rejected_top_k_without_resendi
 
     manager = _ApiV1RuntimeManager()
     client = _api_v1_validation_client(manager)
-    render_complete = MagicMock(side_effect=[
-        LlamaCppInferenceRequestError(
-            "unexpected keyword argument 'top_k'",
-            diagnostics={
-                "code": "compute_node_options_unsupported",
-                "reason": "unsupported_generation_option",
-                "rejected_option": "top_k",
-                "generation_exception_category": "unsupported_generation_kwarg",
-                "method": "create_chat_completion_from_rendered_prompt",
-            },
-        ),
-        {"choices": [{"message": {"role": "assistant", "content": "ok"}}]},
-    ])
+    render_complete = MagicMock(return_value={
+        "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+    })
 
     completion, diagnostics = client._api_v1_create_completion_from_rendered_prompt_filtered(
         render_complete,
@@ -4342,10 +4335,8 @@ def test_api_v1_qwen_render_then_complete_retries_rejected_top_k_without_resendi
 
     assert completion["choices"][0]["message"]["content"] == "ok"
     calls = render_complete.call_args_list
-    assert calls[0].kwargs["top_k"] == 20
-    assert "top_k" not in calls[1].kwargs
-    assert "top_k" in diagnostics["filtered_generation_kwargs"]
-    assert "top_k" in client._api_v1_generation_kwargs_filtered
+    assert calls[0].kwargs == {"max_tokens": 64, "token_place_provider": "qwen", "enable_thinking": False}
+    assert "top_k" not in diagnostics["attempted_generation_kwargs"]
 
 
 def test_api_v1_qwen_render_then_complete_empty_think_wrapper_is_cleaned():
@@ -5799,7 +5790,7 @@ def test_api_v1_runtime_rejected_generation_option_is_safe_options_error():
     error = envelope["api_v1_response"]["error"]
     assert error["code"] == "compute_node_options_unsupported"
     assert error["request_id"] == "req-option-rejected"
-    assert error["internal_reason"] == "unsupported_generation_option"
+    assert error["internal_reason"] in {"unsupported_generation_option", "runtime_plain_completion_unexpected_kwarg"}
     assert error["rejected_option"] == "top_k"
     assert error["active_context_tier"] == "8k-fast"
     assert error["requested_context_tier"] == "8k-fast"
@@ -5948,9 +5939,8 @@ def test_api_v1_cached_internal_filter_does_not_drop_later_explicit_client_optio
 
     error = second["api_v1_response"]["error"]
     assert error["code"] == "compute_node_options_unsupported"
-    assert error["internal_reason"] == "unsupported_generation_option"
+    assert error["internal_reason"] == "runtime_plain_completion_unexpected_kwarg"
     assert error["rejected_option"] == "temperature"
-    assert manager.runtime.calls[-1]["temperature"] == 0.3
 
 
 def test_api_v1_invalid_output_reason_clears_before_unavailable_completion_callable():
@@ -6034,10 +6024,9 @@ def test_api_v1_internal_top_k_default_is_filtered_and_cached_per_client_after_r
 
     assert first["api_v1_response"]["message"]["content"] == "ok"
     assert second["api_v1_response"]["message"]["content"] == "ok"
-    assert manager.runtime.calls[0]["top_k"] == 20
+    assert "top_k" not in manager.runtime.calls[0]
     assert "top_k" not in manager.runtime.calls[1]
-    assert "top_k" not in manager.runtime.calls[-1]
-    assert "top_k" in client._api_v1_generation_kwargs_filtered
+    assert not getattr(client, "_api_v1_generation_kwargs_filtered", set())
 
     fresh_client = _api_v1_validation_client(manager)
     third = fresh_client._generate_api_v1_response_with_runtime_model(
@@ -6049,7 +6038,7 @@ def test_api_v1_internal_top_k_default_is_filtered_and_cached_per_client_after_r
     )
 
     assert third["api_v1_response"]["message"]["content"] == "ok"
-    assert manager.runtime.calls[-1]["top_k"] == 20
+    assert "top_k" not in manager.runtime.calls[-1]
     assert not hasattr(manager, "api_v1_generation_kwargs_filtered")
 
 
@@ -6067,8 +6056,7 @@ def test_api_v1_internal_empty_stop_default_is_filtered_after_runtime_rejection(
     )
 
     assert envelope["api_v1_response"]["message"]["content"] == "ok"
-    assert manager.runtime.calls[0]["stop"] == []
-    assert "stop" not in manager.runtime.calls[1]
+    assert "stop" not in manager.runtime.calls[0]
 
 
 def test_api_v1_client_supplied_runtime_unsupported_option_is_not_silently_dropped():
@@ -6100,10 +6088,9 @@ def test_api_v1_generation_kwarg_filtering_stops_after_bounded_internal_retries(
         requested_context_tier="8k-fast",
     )
 
-    error = envelope["api_v1_response"]["error"]
-    assert error["code"] in {"compute_node_options_unsupported", "compute_node_internal_error"}
-    assert error["rejected_option"] == "stop"
-    assert len(manager.runtime.calls) == 4
+    assert envelope["api_v1_response"]["message"]["content"] == "ok"
+    assert len(manager.runtime.calls) == 1
+    assert not ({"top_k", "temperature", "top_p", "stop"} & set(manager.runtime.calls[0]))
 
 
 def test_api_v1_qwen_no_think_survives_generation_kwarg_filtering():

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -51,6 +51,15 @@ _COMPLETION_SMOKE_REASON_BY_CATEGORY = {
     "kv_cache_allocation": "runtime_completion_smoke_kv_cache_allocation",
     "rope_yarn_eval_failure": "runtime_completion_smoke_rope_yarn_eval_failure",
     "unsupported_generation_kwarg": "runtime_completion_smoke_unsupported_generation_kwarg",
+    "unexpected_kwarg": "runtime_completion_smoke_plain_completion_unexpected_kwarg",
+    "unsupported_prompt_kwarg": "runtime_completion_smoke_plain_completion_method_shape",
+    "unsupported_stream_kwarg": "runtime_completion_smoke_plain_completion_unexpected_kwarg",
+    "unsupported_stop_kwarg": "runtime_completion_smoke_plain_completion_unexpected_kwarg",
+    "method_shape": "runtime_completion_smoke_plain_completion_method_shape",
+    "malformed_completion_output": "runtime_completion_smoke_plain_completion_malformed_output",
+    "empty_completion_output": "runtime_completion_smoke_plain_completion_empty_output",
+    "thinking_output_leaked": "runtime_completion_smoke_plain_completion_thinking_leaked",
+    "worker_exception": "runtime_completion_smoke_plain_completion_worker_exception",
     "worker_timeout": "runtime_completion_smoke_worker_timeout",
     "worker_dead": "runtime_completion_smoke_worker_dead",
 }
@@ -77,6 +86,11 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_KEYS = {
     "stderr_tail",
     "child_stderr_tail",
     "sanitized_error_summary",
+    "rejected_generation_kwarg",
+    "attempted_generation_kwargs",
+    "plain_completion_method",
+    "attempted_plain_completion_methods",
+    "result_shape",
 }
 
 
@@ -92,6 +106,14 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "runtime_chat_template_renderer_unavailable",
         "runtime_template_tokenizer_bridge_unavailable",
         "malformed_completion_output",
+        "empty_completion_output",
+        "unexpected_kwarg",
+        "unsupported_prompt_kwarg",
+        "unsupported_stream_kwarg",
+        "unsupported_stop_kwarg",
+        "method_shape",
+        "worker_exception",
+        "thinking_output_leaked",
     },
     "generation_exception_category": {
         "metal_memory_allocation",
@@ -102,6 +124,14 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "worker_dead",
         "unknown_generation_exception",
         "malformed_completion_output",
+        "empty_completion_output",
+        "unexpected_kwarg",
+        "unsupported_prompt_kwarg",
+        "unsupported_stream_kwarg",
+        "unsupported_stop_kwarg",
+        "method_shape",
+        "worker_exception",
+        "thinking_output_leaked",
     },
     "method": {
         "apply_chat_template",
@@ -148,7 +178,7 @@ def _safe_completion_smoke_worker_diagnostic_value(key: str, value: Any) -> Any:
         return bounded if bounded in enum_values else None
     if key == "exception_type":
         return bounded if _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_CLASS_RE.fullmatch(bounded) else None
-    if key in {"rejected_option", "profile_id", "context_tier", "type_k", "type_v"}:
+    if key in {"rejected_option", "rejected_generation_kwarg", "profile_id", "context_tier", "type_k", "type_v", "plain_completion_method", "attempted_plain_completion_methods", "attempted_generation_kwargs", "result_shape"}:
         return bounded if _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(bounded) else None
     if key == "sanitized_error_summary":
         return (
@@ -216,6 +246,18 @@ def _completion_smoke_reason_from_api_v1_error(error: Dict[str, Any]) -> str:
         return "runtime_completion_smoke_thinking_leaked"
     if internal_reason == "qwen_empty_after_think_wrapper_strip":
         return "runtime_completion_smoke_empty_after_think_strip"
+    if internal_reason in {"runtime_plain_completion_unexpected_kwarg"}:
+        return "runtime_completion_smoke_plain_completion_unexpected_kwarg"
+    if internal_reason in {"runtime_plain_completion_method_shape"}:
+        return "runtime_completion_smoke_plain_completion_method_shape"
+    if internal_reason in {"runtime_plain_completion_malformed_output"}:
+        return "runtime_completion_smoke_plain_completion_malformed_output"
+    if internal_reason in {"runtime_plain_completion_empty_output"}:
+        return "runtime_completion_smoke_plain_completion_empty_output"
+    if internal_reason in {"runtime_plain_completion_thinking_leaked"}:
+        return "runtime_completion_smoke_plain_completion_thinking_leaked"
+    if internal_reason in {"runtime_plain_completion_worker_exception"}:
+        return "runtime_completion_smoke_plain_completion_worker_exception"
     if internal_reason in {
         "unsupported_generation_option",
         "runtime_rejected_generation_options",

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1783,10 +1783,12 @@ def _emit(payload):
 def _extract_unsupported_generation_kwarg(message, attempted=None):
     attempted_set = set(str(key) for key in attempted) if attempted is not None else None
     for pattern in (
-        r'(?:got an )?unexpected keyword argument [\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',
-        r'unsupported option(?:\\s+[\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]|\\s*:\\s*([A-Za-z_][A-Za-z0-9_]*))',
-        r'invalid keyword(?: argument)? [\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',
+        r"(?:got an )?unexpected keyword argument ['\\"]([A-Za-z_][A-Za-z0-9_]*)['\\"]",
+        r"unexpected keyword argument\\s*:?\\s*['\\"]?([A-Za-z_][A-Za-z0-9_]*)['\\"]?",
+        r"unsupported option(?:\\s+['\\"]([A-Za-z_][A-Za-z0-9_]*)['\\"]|\\s*:\\s*([A-Za-z_][A-Za-z0-9_]*))",
+        r"invalid keyword(?: argument)?(?:\\s*:\\s*|\\s+)['\\"]?([A-Za-z_][A-Za-z0-9_]*)['\\"]?",
         r'invalid keyword\\s*=\\s*([A-Za-z_][A-Za-z0-9_]*)',
+        r"got multiple values for keyword argument ['\\"]([A-Za-z_][A-Za-z0-9_]*)['\\"]",
     ):
         match = re.search(pattern, str(message or ''))
         if match:
@@ -1794,6 +1796,71 @@ def _extract_unsupported_generation_kwarg(message, attempted=None):
             if rejected and (attempted_set is None or rejected in attempted_set):
                 return rejected
     return None
+
+def _plain_completion_exception_category(exc, attempted=None):
+    rejected = _extract_unsupported_generation_kwarg(str(exc or ''), attempted)
+    if rejected == 'prompt':
+        return 'unsupported_prompt_kwarg', rejected
+    if rejected == 'stream':
+        return 'unsupported_stream_kwarg', rejected
+    if rejected == 'stop':
+        return 'unsupported_stop_kwarg', rejected
+    if rejected:
+        return 'unexpected_kwarg', rejected
+    text = str(exc or '').lower()
+    if ('positional argument' in text and ('takes' in text or 'missing' in text)) or 'multiple values for keyword argument' in text:
+        return 'method_shape', None
+    return 'worker_exception', None
+
+def _plain_completion_result_shape(result):
+    if isinstance(result, dict):
+        choices = result.get('choices')
+        if isinstance(choices, list) and choices:
+            first = choices[0]
+            if isinstance(first, dict):
+                if isinstance(first.get('text'), str):
+                    return 'choices_text'
+                message = first.get('message')
+                if isinstance(message, dict) and isinstance(message.get('content'), str):
+                    return 'choices_message_content'
+            return 'choices_malformed'
+        return 'dict_without_choices'
+    if isinstance(result, str):
+        return 'direct_string'
+    return type(result).__name__
+
+def _normalize_plain_completion_result(result):
+    text = None
+    if isinstance(result, str):
+        text = result
+    elif isinstance(result, dict):
+        choices = result.get('choices')
+        if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+            choice = choices[0]
+            if isinstance(choice.get('text'), str):
+                text = choice.get('text')
+            else:
+                message = choice.get('message')
+                if isinstance(message, dict) and isinstance(message.get('content'), str):
+                    text = message.get('content')
+    if not isinstance(text, str):
+        return None, 'malformed_completion_output'
+    cleaned = text.lstrip()
+    while True:
+        match = re.match(r'^<\s*think\s*>\s*<\s*/\s*think\s*>', cleaned, re.IGNORECASE)
+        if not match:
+            break
+        cleaned = cleaned[match.end():].lstrip()
+    cleaned = cleaned.strip()
+    if not cleaned:
+        return None, 'empty_completion_output'
+    if re.search(r'<\s*/?\s*think\b', cleaned, re.IGNORECASE):
+        return None, 'thinking_output_leaked'
+    if cleaned.endswith('<|im_end|>'):
+        cleaned = cleaned[:-len('<|im_end|>')].rstrip()
+    if not cleaned:
+        return None, 'empty_completion_output'
+    return {'choices': [{'message': {'role': 'assistant', 'content': cleaned}}]}, None
 
 def _sanitize_error_summary(message):
     text = str(message or '').lower()
@@ -2266,37 +2333,106 @@ for line in sys.stdin:
                 else:
                     _emit(_safe_request_error(reason, request=request, exc=exc))
                     continue
-            completion_kwargs = {
-                key: kwargs[key]
-                for key in (
-                    'max_tokens', 'temperature', 'top_p', 'top_k', 'min_p', 'stop',
-                    'presence_penalty', 'frequency_penalty', 'repeat_penalty', 'seed', 'stream'
-                )
-                if key in kwargs
-            }
-            completion_kwargs['stream'] = False
-            stop = completion_kwargs.get('stop')
-            if stop is None:
-                stop_values = ['<|im_end|>']
-            elif isinstance(stop, list):
-                stop_values = list(stop)
-                if '<|im_end|>' not in stop_values:
-                    stop_values.append('<|im_end|>')
-            else:
-                stop_values = [stop, '<|im_end|>'] if stop != '<|im_end|>' else [stop]
-            completion_kwargs['stop'] = stop_values
-            result = llama.create_completion(prompt=rendered_prompt, **completion_kwargs)
-            if not isinstance(result, dict):
-                _emit(_safe_request_error('malformed_completion_output', request=request, extra=render_diagnostics))
+            completion_kwargs = {'max_tokens': kwargs.get('max_tokens', 64)}
+            attempted = []
+            completed = False
+            last_exception = None
+            last_extra = None
+            completion_fn = getattr(llama, 'create_completion', None)
+            if callable(completion_fn):
+                for attempt_method, call in (
+                    ('create_completion_keyword_prompt', lambda: completion_fn(prompt=rendered_prompt, **completion_kwargs)),
+                    ('create_completion_positional_prompt', lambda: completion_fn(rendered_prompt, **completion_kwargs)),
+                ):
+                    attempted_names = ['max_tokens'] + (['prompt'] if attempt_method.endswith('keyword_prompt') else [])
+                    try:
+                        result = call()
+                        normalized, invalid_reason = _normalize_plain_completion_result(result)
+                        extra = dict(render_diagnostics)
+                        extra.update({
+                            'plain_completion_method': attempt_method,
+                            'attempted_plain_completion_methods': ','.join(attempted + [attempt_method]),
+                            'attempted_generation_kwargs': ','.join(attempted_names),
+                            'result_shape': _plain_completion_result_shape(result),
+                        })
+                        if invalid_reason is not None:
+                            category = 'empty_completion_output' if invalid_reason == 'empty_completion_output' else 'malformed_completion_output'
+                            if invalid_reason == 'thinking_output_leaked':
+                                category = 'thinking_output_leaked'
+                            extra['generation_exception_category'] = category
+                            _emit(_safe_request_error(invalid_reason, request=request, extra=extra))
+                            completed = True
+                            break
+                        _emit({'status': 'ok', 'result': normalized})
+                        completed = True
+                        break
+                    except Exception as exc:
+                        attempted.append(attempt_method)
+                        category, rejected = _plain_completion_exception_category(exc, attempted_names)
+                        extra = dict(render_diagnostics)
+                        extra.update({
+                            'plain_completion_method': attempt_method,
+                            'attempted_plain_completion_methods': ','.join(attempted),
+                            'attempted_generation_kwargs': ','.join(attempted_names),
+                            'generation_exception_category': category,
+                        })
+                        if rejected:
+                            extra['rejected_generation_kwarg'] = rejected
+                            extra['rejected_option'] = rejected
+                        if category == 'unsupported_prompt_kwarg' and attempt_method == 'create_completion_keyword_prompt':
+                            continue
+                        last_exception = exc
+                        last_extra = extra
+                        # Try callable fallback only after create_completion shapes are exhausted.
+                        break
+                else:
+                    pass
+                if completed:
+                    continue
+            call_attempt = 'llama_call_positional_prompt'
+            if callable(llama):
+                try:
+                    result = llama(rendered_prompt, **completion_kwargs)
+                    normalized, invalid_reason = _normalize_plain_completion_result(result)
+                    extra = dict(render_diagnostics)
+                    extra.update({
+                        'plain_completion_method': call_attempt,
+                        'attempted_plain_completion_methods': ','.join(attempted + [call_attempt]),
+                        'attempted_generation_kwargs': 'max_tokens',
+                        'result_shape': _plain_completion_result_shape(result),
+                    })
+                    if invalid_reason is not None:
+                        category = 'empty_completion_output' if invalid_reason == 'empty_completion_output' else 'malformed_completion_output'
+                        if invalid_reason == 'thinking_output_leaked':
+                            category = 'thinking_output_leaked'
+                        extra['generation_exception_category'] = category
+                        _emit(_safe_request_error(invalid_reason, request=request, extra=extra))
+                        continue
+                    _emit({'status': 'ok', 'result': normalized})
+                    continue
+                except Exception as exc:
+                    attempted.append(call_attempt)
+                    category, rejected = _plain_completion_exception_category(exc, ['max_tokens'])
+                    extra = dict(render_diagnostics)
+                    extra.update({
+                        'plain_completion_method': call_attempt,
+                        'attempted_plain_completion_methods': ','.join(attempted),
+                        'attempted_generation_kwargs': 'max_tokens',
+                        'generation_exception_category': category,
+                    })
+                    if rejected:
+                        extra['rejected_generation_kwarg'] = rejected
+                        extra['rejected_option'] = rejected
+                    _emit(_safe_request_error('inference_exception', request=request, exc=exc, extra=extra))
+                    continue
+            if last_exception is not None:
+                _emit(_safe_request_error('inference_exception', request=request, exc=last_exception, extra=last_extra or {}))
                 continue
-            choices = result.get('choices')
-            text = None
-            if isinstance(choices, list) and choices and isinstance(choices[0], dict):
-                text = choices[0].get('text')
-            if not isinstance(text, str):
-                _emit(_safe_request_error('malformed_completion_output', request=request, extra=render_diagnostics))
-                continue
-            _emit({'status': 'ok', 'result': {'choices': [{'message': {'role': 'assistant', 'content': text}}]}})
+            _emit(_safe_request_error('inference_exception', request=request, extra={
+                'generation_exception_category': 'worker_exception',
+                'attempted_plain_completion_methods': ','.join(attempted),
+                'attempted_generation_kwargs': 'max_tokens',
+            }))
             continue
         result = llama.create_chat_completion(*request.get('args', []), **kwargs)
         if kwargs.get('stream'):

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -46,9 +46,11 @@ def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
 
 _UNSUPPORTED_GENERATION_KWARG_PATTERNS = (
     re.compile(r"(?:got an )?unexpected keyword argument [\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]"),
+    re.compile(r"unexpected keyword argument\s*:?\s*[\'\"]?([A-Za-z_][A-Za-z0-9_]*)[\'\"]?"),
     re.compile(r"unsupported option(?:\s+[\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]|\s*:\s*([A-Za-z_][A-Za-z0-9_]*))"),
-    re.compile(r"invalid keyword(?: argument)? [\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]"),
+    re.compile(r"invalid keyword(?: argument)?(?:\s*:\s*|\s+)[\'\"]?([A-Za-z_][A-Za-z0-9_]*)[\'\"]?"),
     re.compile(r"invalid keyword\s*=\s*([A-Za-z_][A-Za-z0-9_]*)"),
+    re.compile(r"got multiple values for keyword argument [\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]"),
 )
 
 
@@ -95,6 +97,9 @@ _SAFE_WORKER_DIAGNOSTIC_KEYS = {
     "rejected_option",
     "rejected_generation_kwarg",
     "attempted_generation_kwargs",
+    "plain_completion_method",
+    "attempted_plain_completion_methods",
+    "result_shape",
     "method",
     "stream",
     "retryable",
@@ -130,6 +135,8 @@ _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "runtime_chat_template_renderer_unavailable",
         "runtime_template_tokenizer_bridge_unavailable",
         "malformed_completion_output",
+        "empty_completion_output",
+        "thinking_output_leaked",
     },
     "generation_exception_category": {
         "metal_memory_allocation",
@@ -140,6 +147,14 @@ _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "worker_dead",
         "unknown_generation_exception",
         "malformed_completion_output",
+        "empty_completion_output",
+        "unexpected_kwarg",
+        "unsupported_prompt_kwarg",
+        "unsupported_stream_kwarg",
+        "unsupported_stop_kwarg",
+        "method_shape",
+        "worker_exception",
+        "thinking_output_leaked",
     },
     "method": {
         "apply_chat_template",
@@ -184,7 +199,7 @@ def _safe_worker_diagnostic_value(key: str, value: Any) -> Any:
         return bounded if bounded in enum_values else None
     if key == "exception_type":
         return bounded if _SAFE_WORKER_DIAGNOSTIC_CLASS_RE.fullmatch(bounded) else None
-    if key in {"rejected_option", "rejected_generation_kwarg", "profile_id", "context_tier", "type_k", "type_v"}:
+    if key in {"rejected_option", "rejected_generation_kwarg", "profile_id", "context_tier", "type_k", "type_v", "plain_completion_method", "attempted_plain_completion_methods", "attempted_generation_kwargs", "result_shape"}:
         return bounded if _SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(bounded) else None
     if key == "attempted_generation_kwargs":
         names = [part for part in bounded.split(",") if part]
@@ -3308,23 +3323,26 @@ class RelayClient:
         removed: List[str] = []
         attempted_names: List[str] = []
         while True:
-            completion_kwargs = {
-                key: value
-                for key, value in self._api_v1_runtime_completion_kwargs(safe_options).items()
-                if key in allowed_plain_kwargs
-            }
             removed_set = set(removed) | (set(getattr(self, "_api_v1_generation_kwargs_filtered", set())) - set(client_option_names))
-            completion_kwargs = {
-                key: value for key, value in completion_kwargs.items() if key not in removed_set
-            }
-            if "stream" not in removed_set:
-                completion_kwargs["stream"] = False
-            if model_profile.get("provider") and "token_place_provider" not in removed_set:
-                completion_kwargs["token_place_provider"] = model_profile.get("provider")
-            if model_profile.get("chat_template_policy") and "token_place_template_policy" not in removed_set:
-                completion_kwargs["token_place_template_policy"] = model_profile.get("chat_template_policy")
-            if self._api_v1_qwen_non_thinking_required(model_profile) and "enable_thinking" not in removed_set:
-                completion_kwargs["enable_thinking"] = False
+            if self._api_v1_qwen_non_thinking_required(model_profile):
+                completion_kwargs = {"max_tokens": int(safe_options.get("max_tokens") or 64)}
+                if model_profile.get("provider") and "token_place_provider" not in removed_set:
+                    completion_kwargs["token_place_provider"] = model_profile.get("provider")
+                if model_profile.get("chat_template_policy") and "token_place_template_policy" not in removed_set:
+                    completion_kwargs["token_place_template_policy"] = model_profile.get("chat_template_policy")
+                if "enable_thinking" not in removed_set:
+                    completion_kwargs["enable_thinking"] = False
+            else:
+                completion_kwargs = {
+                    key: value
+                    for key, value in self._api_v1_runtime_completion_kwargs(safe_options).items()
+                    if key in allowed_plain_kwargs
+                }
+                completion_kwargs = {
+                    key: value for key, value in completion_kwargs.items() if key not in removed_set
+                }
+                if "stream" not in removed_set:
+                    completion_kwargs["stream"] = False
             attempted_names = sorted(str(key) for key in completion_kwargs)
             try:
                 result = create_completion_from_rendered_prompt(messages, **completion_kwargs)
@@ -3736,6 +3754,26 @@ class RelayClient:
                 )
                 started = time.monotonic()
                 if callable(qwen_render_complete):
+                    unsupported_client_options = sorted(
+                        name for name in set(safe_options)
+                        if name not in {"max_tokens", "stream"}
+                    )
+                    if unsupported_client_options:
+                        return self._api_v1_response_envelope(
+                            request_id,
+                            error=self._api_v1_enrich_safe_error(
+                                {
+                                    "code": "compute_node_options_unsupported",
+                                    "message": "Desktop runtime rejected unsupported generation options",
+                                },
+                                request_id=request_id,
+                                requested_context_tier=requested_context_tier,
+                                prompt_tokens=prompt_tokens,
+                                requested_output_tokens=requested_output_tokens,
+                                internal_reason="runtime_plain_completion_unexpected_kwarg",
+                                rejected_option=unsupported_client_options[0],
+                            ),
+                        )
                     completion, generation_kwarg_diagnostics = self._api_v1_create_completion_from_rendered_prompt_filtered(
                         qwen_render_complete,
                         messages=runtime_messages,
@@ -3814,8 +3852,26 @@ class RelayClient:
                     "worker_dead",
                 }:
                     internal_reason = f"runtime_{category}"
-                elif category == "unsupported_generation_kwarg":
-                    internal_reason = "unsupported_generation_option"
+                elif category in {"unsupported_generation_kwarg", "unexpected_kwarg", "unsupported_stream_kwarg", "unsupported_stop_kwarg"}:
+                    internal_reason = (
+                        "runtime_plain_completion_unexpected_kwarg"
+                        if generation_branch == "qwen_render_then_plain_completion"
+                        else "unsupported_generation_option"
+                    )
+                elif category in {"unsupported_prompt_kwarg", "method_shape"}:
+                    internal_reason = (
+                        "runtime_plain_completion_method_shape"
+                        if generation_branch == "qwen_render_then_plain_completion"
+                        else "unsupported_generation_option"
+                    )
+                elif category == "malformed_completion_output":
+                    internal_reason = "runtime_plain_completion_malformed_output"
+                elif category == "empty_completion_output":
+                    internal_reason = "runtime_plain_completion_empty_output"
+                elif category == "thinking_output_leaked":
+                    internal_reason = "runtime_plain_completion_thinking_leaked"
+                elif category == "worker_exception":
+                    internal_reason = "runtime_plain_completion_worker_exception"
                 else:
                     internal_reason = (
                         safe_worker_diagnostics.get("reason")
@@ -3835,7 +3891,7 @@ class RelayClient:
                     "compute_node_options_unsupported"
                     if (
                         safe_worker_diagnostics.get("code") == "compute_node_options_unsupported"
-                        or internal_reason == "unsupported_generation_option"
+                        or internal_reason in {"unsupported_generation_option", "runtime_plain_completion_unexpected_kwarg"}
                     )
                     else "compute_node_internal_error"
                 )


### PR DESCRIPTION
### Motivation
- Qwen 64K readiness was failing because the child-worker plain-completion call still sent unsupported generation kwargs and returned only a generic `unsupported_generation_kwarg` readiness failure. 
- The goal is to make the render-then-complete readiness smoke use the smallest known-good plain completion invocation, add bounded child-side fallback shapes, and surface precise safe diagnostics so next issues are actionable. 

### Description
- Make worker plain-completion minimal and robust: the subprocess worker now calls plain completion with only `max_tokens` (default 64) and tries bounded fallbacks inside the child: `create_completion(prompt=...)`, then `create_completion(positional)`, then `llama(rendered_prompt, ...)` when callable, and never returns or logs rendered prompt text. (file: `utils/llm/model_manager.py` — worker code section and helpers added: `_plain_completion_exception_category`, `_plain_completion_result_shape`, `_normalize_plain_completion_result`, and updated worker logic.)
- Add safe, allowlisted child diagnostics for plain completion attempts: `plain_completion_method`, `attempted_plain_completion_methods`, `attempted_generation_kwargs`, `result_shape`, `rejected_generation_kwarg`, plus robust parsing for rejected kwarg strings. (files: `utils/llm/model_manager.py`, `utils/networking/relay_client.py`, `utils/compute_node_runtime.py`.)
- Have parent-side Qwen readiness use truly minimal completion kwargs when non-thinking is required, omit internal sampling defaults (no `temperature`, `top_k`, `stop`, `stream` by default), and fail early if a client-supplied option is unsupported; map child failure categories to precise readiness internal reasons (e.g. `runtime_plain_completion_unexpected_kwarg`, `runtime_plain_completion_method_shape`, `runtime_plain_completion_malformed_output`, etc.). (file: `utils/networking/relay_client.py` and `utils/compute_node_runtime.py`.)
- Normalize plain-completion shapes to a canonical API v1 assistant message `{ role: "assistant", content: cleaned_text }`, reject empty/malformed/think-containing outputs, strip empty `<think></think>` wrappers and trailing `<|im_end|>`. (file: `utils/llm/model_manager.py` worker helpers and normalization usage.)
- Add and update focused regression/unit/integration tests that reproduce the previous packaged-subprocess failure and assert minimal-kwargs behavior, fallback shapes, safe diagnostics, and readiness mapping for Qwen 64K. (files: `tests/unit/test_model_manager.py`, `tests/unit/test_relay_client.py`, `tests/unit/test_compute_node_runtime.py`, `tests/integration/test_desktop_qwen64k_packaged_runtime.py`.)

### Testing
- Ran unit and integration suites that cover the changed paths: `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/unit/test_relay_client.py -q`, `python -m pytest tests/unit/test_compute_node_runtime.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, and `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q`; all invoked test runs completed with the updated assertions passing on CI run shown in the rollout. 
- Ran repository hooks and checks with `pre-commit run --all-files` and `git diff --check`, which passed in the verification run. 
- Result: the Qwen render-then-complete readiness path uses a truly minimal plain completion call and returns precise safe diagnostics from child-worker failures, and the regression tests that would have caught the original packaged desktop 64K failure now pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4acf4b9cd8832f90d0084616eefcff)