### PR TITLE
Qwen: use minimal plain-completion for render-then-complete and surface precise child-worker diagnostics

### DIFF
--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -201,7 +201,7 @@ def _runtime_for(fake_runtime):
     ("category", "reason"),
     [
         ("kv_cache_allocation", "runtime_completion_smoke_kv_cache_allocation"),
-        ("unsupported_generation_kwarg", "runtime_completion_smoke_unsupported_generation_kwarg"),
+        ("unsupported_generation_kwarg", "runtime_completion_smoke_plain_completion_unexpected_kwarg"),
         ("rope_yarn_eval_failure", "runtime_completion_smoke_rope_yarn_eval_failure"),
         ("worker_timeout", "runtime_completion_smoke_worker_timeout"),
         ("worker_dead", "runtime_completion_smoke_worker_dead"),
@@ -239,7 +239,7 @@ def test_qwen64k_packaged_subprocess_generation_error_preserves_safe_diagnostics
         assert proxy.render_and_tokenize_chat([{'role': 'user', 'content': 'safe'}]) == {'prompt_tokens': 42}
         with pytest.raises(LlamaCppInferenceRequestError) as exc_info:
             proxy.create_chat_completion_from_rendered_prompt([{'role': 'user', 'content': 'SECRET_PROMPT'}], stream=False)
-        assert exc_info.value.diagnostics['method'] == 'create_chat_completion_from_rendered_prompt'
+        assert exc_info.value.diagnostics['method'] == 'create_completion_keyword_prompt'
         assert exc_info.value.diagnostics['generation_exception_category'] == 'kv_cache_allocation'
         assert 'SECRET_PROMPT' not in str(exc_info.value.diagnostics)
 
@@ -263,27 +263,24 @@ def test_qwen64k_packaged_fake_runtime_valid_generation_passes_readiness():
     assert diagnostics["api_v1_readiness_completion_smoke_path"] == "shared_api_v1_generation"
 
 
-def test_qwen64k_packaged_fake_runtime_filters_unsupported_internal_top_k_and_registers():
-    class TopKRejectingRuntime(_Qwen64kFakeRuntime):
+def test_qwen64k_packaged_fake_runtime_readiness_uses_minimal_plain_completion_kwargs():
+    class RecordingRuntime(_Qwen64kFakeRuntime):
         def __init__(self):
             self.calls = []
-            self.rejected = False
 
         def create_chat_completion_from_rendered_prompt(self, messages, **kwargs):
             self.calls.append(dict(kwargs))
-            if "top_k" in kwargs and not self.rejected:
-                self.rejected = True
-                raise TypeError("got an unexpected keyword argument 'top_k'")
+            for forbidden in ("stream", "stop", "temperature", "top_p", "top_k"):
+                if forbidden in kwargs:
+                    raise TypeError(f"got an unexpected keyword argument '{forbidden}'")
             return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
 
-    fake = TopKRejectingRuntime()
+    fake = RecordingRuntime()
     runtime, manager = _runtime_for(fake)
-    manager.model_profile["generation_defaults"] = {"top_k": 20}
+    manager.model_profile["generation_defaults"] = {"top_k": 20, "temperature": 0.1}
 
     assert runtime.ensure_api_v1_runtime_ready() is True
     diagnostics = manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_result"] == "passed"
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
-    assert fake.calls[0]["top_k"] == 20
-    assert "top_k" not in fake.calls[1]
-    assert "top_k" in diagnostics["api_v1_generation_kwargs_filtered"]
+    assert set(fake.calls[0]) == {"max_tokens", "token_place_provider", "token_place_template_policy", "enable_thinking"}

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -126,13 +126,13 @@ def test_completion_smoke_worker_diagnostic_sanitizer_drops_unsafe_shapes():
 @pytest.mark.parametrize(
     ("error", "expected_reason"),
     [
-        ({"internal_reason": "runtime_unsupported_generation_kwarg"}, "runtime_completion_smoke_unsupported_generation_kwarg"),
+        ({"internal_reason": "runtime_unsupported_generation_kwarg"}, "runtime_completion_smoke_plain_completion_unexpected_kwarg"),
         ({"internal_reason": "runtime_rope_yarn_eval_failure"}, "runtime_completion_smoke_rope_yarn_eval_failure"),
         ({"internal_reason": "runtime_metal_memory_allocation"}, "runtime_completion_smoke_metal_memory_allocation"),
         ({"internal_reason": "runtime_kv_cache_allocation"}, "runtime_completion_smoke_kv_cache_allocation"),
         ({"internal_reason": "runtime_worker_timeout"}, "runtime_completion_smoke_worker_timeout"),
         ({"internal_reason": "runtime_worker_dead"}, "runtime_completion_smoke_worker_dead"),
-        ({"code": "compute_node_options_unsupported"}, "runtime_completion_smoke_unsupported_generation_kwarg"),
+        ({"code": "compute_node_options_unsupported"}, "runtime_completion_smoke_plain_completion_unexpected_kwarg"),
     ],
 )
 def test_completion_smoke_reason_from_api_v1_error_maps_runtime_reasons(error, expected_reason):
@@ -146,7 +146,7 @@ def test_completion_smoke_reason_from_api_v1_error_maps_runtime_reasons(error, e
         (RuntimeError("worker dead: broken pipe"), "worker_dead", "runtime_completion_smoke_worker_dead"),
         (RuntimeError("Metal buffer allocation out of memory"), "metal_memory_allocation", "runtime_completion_smoke_metal_memory_allocation"),
         (RuntimeError("KV cache allocation failed"), "kv_cache_allocation", "runtime_completion_smoke_kv_cache_allocation"),
-        (RuntimeError("unexpected keyword argument 'mirostat'"), "unsupported_generation_kwarg", "runtime_completion_smoke_unsupported_generation_kwarg"),
+        (RuntimeError("unexpected keyword argument 'mirostat'"), "unsupported_generation_kwarg", "runtime_completion_smoke_plain_completion_unexpected_kwarg"),
         (RuntimeError("unclassified failure with prompt text"), "unknown_generation_exception", "runtime_completion_smoke_exception"),
     ],
 )
@@ -207,7 +207,7 @@ def test_classify_completion_smoke_exception_uses_safe_worker_unsupported_reason
     )
 
     assert category == "unsupported_generation_kwarg"
-    assert reason == "runtime_completion_smoke_unsupported_generation_kwarg"
+    assert reason == "runtime_completion_smoke_plain_completion_unexpected_kwarg"
     assert diagnostics["worker_diagnostics"] == {"reason": "unsupported_generation_option"}
 
 
@@ -671,7 +671,7 @@ def test_compute_node_runtime_readiness_smoke_completion_passes(monkeypatch):
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert diagnostics["api_v1_readiness_result"] == "passed"
     assert diagnostics["api_v1_readiness_model_profile_id"] == "qwen3-8b-q4-k-m"
-    assert llm_runtime.completion_kwargs["stream"] is False
+    assert "stream" not in llm_runtime.completion_kwargs
     assert llm_runtime.completion_kwargs["max_tokens"] == 64
     assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
 

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -5953,3 +5953,137 @@ def test_path_redaction_handles_spaces_and_traceback_paths():
     assert '/Users/Alice' not in redacted
     assert 'Application Support' not in redacted
     assert '<path>' in redacted
+
+
+def test_llama_worker_render_complete_minimal_kwargs_omits_stream_stop_temperature(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'minimal fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    attempts = tmp_path / 'attempts.jsonl'
+    (fake_pkg / '__init__.py').write_text(
+        "import json, os\n"
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs): pass\n"
+        "    def create_completion(self, *, prompt, **kwargs):\n"
+        "        with open(os.environ['TOKEN_PLACE_ATTEMPTS_JSONL'], 'a', encoding='utf-8') as handle:\n"
+        "            handle.write(json.dumps(sorted(kwargs)) + '\\\\n')\n"
+        "        for key in ('stream', 'stop', 'temperature'):\n"
+        "            if key in kwargs: raise TypeError(f\"got an unexpected keyword argument '{key}'\")\n"
+        "        return {'choices': [{'text': 'minimal ok'}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'testing')
+    monkeypatch.setenv('TOKEN_PLACE_ATTEMPTS_JSONL', str(attempts))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'mock.gguf'), timeout_seconds=5
+    )
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt(
+            [{'role': 'user', 'content': 'secret prompt text'}],
+            max_tokens=4,
+            stream=False,
+            stop=[],
+            temperature=0.7,
+            token_place_provider='qwen',
+            token_place_template_policy='gguf-jinja',
+            enable_thinking=False,
+        )
+    finally:
+        proxy.close()
+
+    assert result == {'choices': [{'message': {'role': 'assistant', 'content': 'minimal ok'}}]}
+    assert json.loads(attempts.read_text().replace('\\n', '').splitlines()[0]) == ['max_tokens']
+
+
+def test_llama_worker_render_complete_falls_back_from_prompt_keyword_to_positional(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'positional fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs): pass\n"
+        "    def create_completion(self, *args, **kwargs):\n"
+        "        if 'prompt' in kwargs: raise TypeError(\"got an unexpected keyword argument 'prompt'\")\n"
+        "        if len(args) != 1: raise TypeError('missing required positional argument')\n"
+        "        return {'choices': [{'text': 'positional ok'}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'testing')
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'mock.gguf'), timeout_seconds=5
+    )
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt(
+            [{'role': 'user', 'content': 'secret prompt text'}], max_tokens=4,
+            token_place_provider='qwen', token_place_template_policy='gguf-jinja'
+        )
+    finally:
+        proxy.close()
+    assert result['choices'][0]['message']['content'] == 'positional ok'
+
+
+def test_llama_worker_render_complete_falls_back_to_callable_llama(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'callable fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs): pass\n"
+        "    def __call__(self, prompt, **kwargs):\n"
+        "        return {'choices': [{'text': 'callable ok'}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'testing')
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'mock.gguf'), timeout_seconds=5
+    )
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt(
+            [{'role': 'user', 'content': 'secret prompt text'}], max_tokens=4,
+            token_place_provider='qwen', token_place_template_policy='gguf-jinja'
+        )
+    finally:
+        proxy.close()
+    assert result['choices'][0]['message']['content'] == 'callable ok'
+
+
+def test_llama_worker_render_complete_empty_output_safe_diagnostics(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'empty fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs): pass\n"
+        "    def create_completion(self, *, prompt, **kwargs):\n"
+        "        return {'choices': [{'text': ''}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'testing')
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'mock.gguf'), timeout_seconds=5
+    )
+    try:
+        with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as exc_info:
+            proxy.create_chat_completion_from_rendered_prompt(
+                [{'role': 'user', 'content': 'SECRET_PROMPT'}], max_tokens=4,
+                token_place_provider='qwen', token_place_template_policy='gguf-jinja'
+            )
+    finally:
+        proxy.close()
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics['generation_exception_category'] == 'empty_completion_output'
+    assert diagnostics['method'] == 'create_completion_keyword_prompt'
+    assert 'SECRET_PROMPT' not in json.dumps(diagnostics)

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4220,7 +4220,7 @@ def test_api_v1_qwen_generation_uses_render_then_complete_not_chat_completion():
     assert envelope["api_v1_response"]["message"] == {"role": "assistant", "content": "ok"}
     manager.runtime.create_chat_completion.assert_not_called()
     kwargs = manager.runtime.create_chat_completion_from_rendered_prompt.call_args.kwargs
-    assert kwargs["stream"] is False
+    assert "stream" not in kwargs
     assert kwargs["max_tokens"] == 64
     assert kwargs["enable_thinking"] is False
     assert "messages" not in kwargs
@@ -6013,45 +6013,20 @@ class _RejectingAdmissionManager(_AdmissionManager):
         self.api_model_id = "qwen3-8b-instruct"
 
 
-def test_api_v1_internal_top_k_default_is_filtered_and_cached_per_client_after_runtime_rejection():
+def test_api_v1_internal_top_k_default_is_not_sent_to_qwen_plain_completion():
     manager = _RejectingAdmissionManager(["top_k"], window=256)
     client = _api_v1_validation_client(manager)
 
-    first = client._generate_api_v1_response_with_runtime_model(
+    envelope = client._generate_api_v1_response_with_runtime_model(
         request_id="req-filter-top-k",
         model_id="qwen3-8b-instruct",
         messages=[{"role": "user", "content": "hello"}],
         options={"max_tokens": 5, "stream": False},
         requested_context_tier="8k-fast",
     )
-    second = client._generate_api_v1_response_with_runtime_model(
-        request_id="req-filter-top-k-cached",
-        model_id="qwen3-8b-instruct",
-        messages=[{"role": "user", "content": "hello"}],
-        options={"max_tokens": 5, "stream": False},
-        requested_context_tier="8k-fast",
-    )
 
-    assert first["api_v1_response"]["message"]["content"] == "ok"
-    assert second["api_v1_response"]["message"]["content"] == "ok"
-    assert manager.runtime.calls[0]["top_k"] == 20
-    assert "top_k" not in manager.runtime.calls[1]
-    assert "top_k" not in manager.runtime.calls[-1]
-    assert "top_k" in client._api_v1_generation_kwargs_filtered
-
-    fresh_client = _api_v1_validation_client(manager)
-    third = fresh_client._generate_api_v1_response_with_runtime_model(
-        request_id="req-filter-top-k-fresh-client",
-        model_id="qwen3-8b-instruct",
-        messages=[{"role": "user", "content": "hello"}],
-        options={"max_tokens": 5, "stream": False},
-        requested_context_tier="8k-fast",
-    )
-
-    assert third["api_v1_response"]["message"]["content"] == "ok"
-    assert manager.runtime.calls[-1]["top_k"] == 20
-    assert not hasattr(manager, "api_v1_generation_kwargs_filtered")
-
+    assert envelope["api_v1_response"]["message"]["content"] == "ok"
+    assert "top_k" not in manager.runtime.calls[0]
 
 def test_api_v1_internal_empty_stop_default_is_filtered_after_runtime_rejection():
     manager = _RejectingAdmissionManager(["stop"], window=256)
@@ -6067,8 +6042,7 @@ def test_api_v1_internal_empty_stop_default_is_filtered_after_runtime_rejection(
     )
 
     assert envelope["api_v1_response"]["message"]["content"] == "ok"
-    assert manager.runtime.calls[0]["stop"] == []
-    assert "stop" not in manager.runtime.calls[1]
+    assert "stop" not in manager.runtime.calls[0]
 
 
 def test_api_v1_client_supplied_runtime_unsupported_option_is_not_silently_dropped():
@@ -6100,10 +6074,9 @@ def test_api_v1_generation_kwarg_filtering_stops_after_bounded_internal_retries(
         requested_context_tier="8k-fast",
     )
 
-    error = envelope["api_v1_response"]["error"]
-    assert error["code"] in {"compute_node_options_unsupported", "compute_node_internal_error"}
-    assert error["rejected_option"] == "stop"
-    assert len(manager.runtime.calls) == 4
+    assert envelope["api_v1_response"]["message"]["content"] == "ok"
+    assert len(manager.runtime.calls) == 1
+    assert {key for key in manager.runtime.calls[0] if key != "messages"} == {"max_tokens", "token_place_provider", "enable_thinking"}
 
 
 def test_api_v1_qwen_no_think_survives_generation_kwarg_filtering():

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -50,7 +50,15 @@ _COMPLETION_SMOKE_REASON_BY_CATEGORY = {
     "metal_memory_allocation": "runtime_completion_smoke_metal_memory_allocation",
     "kv_cache_allocation": "runtime_completion_smoke_kv_cache_allocation",
     "rope_yarn_eval_failure": "runtime_completion_smoke_rope_yarn_eval_failure",
-    "unsupported_generation_kwarg": "runtime_completion_smoke_unsupported_generation_kwarg",
+    "unsupported_generation_kwarg": "runtime_completion_smoke_plain_completion_unexpected_kwarg",
+    "unexpected_kwarg": "runtime_completion_smoke_plain_completion_unexpected_kwarg",
+    "unsupported_prompt_kwarg": "runtime_completion_smoke_plain_completion_method_shape",
+    "unsupported_stream_kwarg": "runtime_completion_smoke_plain_completion_unexpected_kwarg",
+    "unsupported_stop_kwarg": "runtime_completion_smoke_plain_completion_unexpected_kwarg",
+    "method_shape": "runtime_completion_smoke_plain_completion_method_shape",
+    "malformed_completion_output": "runtime_completion_smoke_plain_completion_malformed_output",
+    "empty_completion_output": "runtime_completion_smoke_plain_completion_empty_output",
+    "worker_exception": "runtime_completion_smoke_plain_completion_worker_exception",
     "worker_timeout": "runtime_completion_smoke_worker_timeout",
     "worker_dead": "runtime_completion_smoke_worker_dead",
 }
@@ -61,6 +69,11 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_KEYS = {
     "generation_exception_category",
     "exception_type",
     "rejected_option",
+    "rejected_generation_kwarg",
+    "attempted_generation_kwargs",
+    "attempted_methods",
+    "attempted_kwarg_names",
+    "result_shape",
     "method",
     "stream",
     "retryable",
@@ -92,6 +105,13 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "runtime_chat_template_renderer_unavailable",
         "runtime_template_tokenizer_bridge_unavailable",
         "malformed_completion_output",
+        "empty_completion_output",
+        "unexpected_kwarg",
+        "unsupported_prompt_kwarg",
+        "unsupported_stream_kwarg",
+        "unsupported_stop_kwarg",
+        "method_shape",
+        "worker_exception",
     },
     "generation_exception_category": {
         "metal_memory_allocation",
@@ -102,6 +122,13 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "worker_dead",
         "unknown_generation_exception",
         "malformed_completion_output",
+        "empty_completion_output",
+        "unexpected_kwarg",
+        "unsupported_prompt_kwarg",
+        "unsupported_stream_kwarg",
+        "unsupported_stop_kwarg",
+        "method_shape",
+        "worker_exception",
     },
     "method": {
         "apply_chat_template",
@@ -110,6 +137,9 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "render_and_tokenize_chat",
         "create_chat_completion_from_rendered_prompt",
         "create_completion_from_rendered_prompt",
+        "create_completion_keyword_prompt",
+        "create_completion_positional_prompt",
+        "llama_call_positional_prompt",
         "tokenize",
     },
     "kv_cache_mode": {"f16", "q8_0", "q4_0", "auto", "unknown"},
@@ -146,6 +176,11 @@ def _safe_completion_smoke_worker_diagnostic_value(key: str, value: Any) -> Any:
     enum_values = _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_ENUM_VALUES.get(key)
     if enum_values is not None:
         return bounded if bounded in enum_values else None
+    if key in {"attempted_generation_kwargs", "attempted_methods", "attempted_kwarg_names"}:
+        parts = [part for part in bounded.split(",") if part]
+        return bounded if parts and all(_SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(part) for part in parts) else None
+    if key == "result_shape":
+        return bounded if _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(bounded) else None
     if key == "exception_type":
         return bounded if _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_CLASS_RE.fullmatch(bounded) else None
     if key in {"rejected_option", "profile_id", "context_tier", "type_k", "type_v"}:
@@ -221,7 +256,7 @@ def _completion_smoke_reason_from_api_v1_error(error: Dict[str, Any]) -> str:
         "runtime_rejected_generation_options",
         "runtime_unsupported_generation_kwarg",
     }:
-        return "runtime_completion_smoke_unsupported_generation_kwarg"
+        return "runtime_completion_smoke_plain_completion_unexpected_kwarg"
     if internal_reason in {"rope_yarn_eval_failure", "runtime_rope_yarn_eval_failure"}:
         return "runtime_completion_smoke_rope_yarn_eval_failure"
     if internal_reason in {"metal_memory_allocation", "runtime_metal_memory_allocation"}:
@@ -235,7 +270,7 @@ def _completion_smoke_reason_from_api_v1_error(error: Dict[str, Any]) -> str:
     if error.get("code") == "compute_node_invalid_model_output":
         return "runtime_completion_smoke_invalid_model_output"
     if error.get("code") == "compute_node_options_unsupported":
-        return "runtime_completion_smoke_unsupported_generation_kwarg"
+        return "runtime_completion_smoke_plain_completion_unexpected_kwarg"
     return "runtime_completion_smoke_exception"
 
 

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1786,7 +1786,9 @@ def _extract_unsupported_generation_kwarg(message, attempted=None):
         r'(?:got an )?unexpected keyword argument [\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',
         r'unsupported option(?:\\s+[\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]|\\s*:\\s*([A-Za-z_][A-Za-z0-9_]*))',
         r'invalid keyword(?: argument)? [\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',
+        r'invalid keyword argument\\s*:\\s*([A-Za-z_][A-Za-z0-9_]*)',
         r'invalid keyword\\s*=\\s*([A-Za-z_][A-Za-z0-9_]*)',
+        r'got multiple values for keyword argument [\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',
     ):
         match = re.search(pattern, str(message or ''))
         if match:
@@ -1830,9 +1832,9 @@ def _safe_request_error(reason, *, request=None, exc=None, extra=None):
     if isinstance(request, dict):
         method = request.get('method')
         if method in {'create_chat_completion', 'create_chat_completion_from_rendered_prompt'}:
-            diagnostics['method'] = method
+            diagnostics.setdefault('method', method)
         elif method is not None:
-            diagnostics['method'] = 'unsupported'
+            diagnostics.setdefault('method', 'unsupported')
         kwargs = request.get('kwargs')
         if isinstance(kwargs, dict):
             diagnostics['stream'] = bool(kwargs.get('stream'))
@@ -1844,7 +1846,7 @@ def _safe_request_error(reason, *, request=None, exc=None, extra=None):
         diagnostics['exception_type'] = type(exc).__name__
         diagnostics['sanitized_error_summary'] = _sanitize_error_summary(exc)
         if reason == 'inference_exception':
-            diagnostics['generation_exception_category'] = _classify_generation_exception(exc)
+            diagnostics.setdefault('generation_exception_category', _classify_generation_exception(exc))
             message = str(exc)
             attempted = None
             if isinstance(request, dict) and isinstance(request.get('kwargs'), dict):
@@ -2266,35 +2268,122 @@ for line in sys.stdin:
                 else:
                     _emit(_safe_request_error(reason, request=request, exc=exc))
                     continue
-            completion_kwargs = {
-                key: kwargs[key]
-                for key in (
-                    'max_tokens', 'temperature', 'top_p', 'top_k', 'min_p', 'stop',
-                    'presence_penalty', 'frequency_penalty', 'repeat_penalty', 'seed', 'stream'
-                )
-                if key in kwargs
-            }
-            completion_kwargs['stream'] = False
-            stop = completion_kwargs.get('stop')
-            if stop is None:
-                stop_values = ['<|im_end|>']
-            elif isinstance(stop, list):
-                stop_values = list(stop)
-                if '<|im_end|>' not in stop_values:
-                    stop_values.append('<|im_end|>')
-            else:
-                stop_values = [stop, '<|im_end|>'] if stop != '<|im_end|>' else [stop]
-            completion_kwargs['stop'] = stop_values
-            result = llama.create_completion(prompt=rendered_prompt, **completion_kwargs)
-            if not isinstance(result, dict):
-                _emit(_safe_request_error('malformed_completion_output', request=request, extra=render_diagnostics))
+            plain_kwargs = {'max_tokens': kwargs.get('max_tokens', 64)}
+            attempted = []
+            def _shape(value):
+                if isinstance(value, dict):
+                    choices = value.get('choices')
+                    if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+                        first = choices[0]
+                        if isinstance(first.get('text'), str):
+                            return 'choices_text'
+                        message = first.get('message')
+                        if isinstance(message, dict) and isinstance(message.get('content'), str):
+                            return 'choices_message_content'
+                    return 'dict'
+                if isinstance(value, str):
+                    return 'string'
+                return type(value).__name__
+            def _normalize_plain(value):
+                if isinstance(value, str):
+                    return value
+                if not isinstance(value, dict):
+                    raise RuntimeError('malformed_completion_output')
+                choices = value.get('choices')
+                if not (isinstance(choices, list) and choices and isinstance(choices[0], dict)):
+                    raise RuntimeError('malformed_completion_output')
+                first = choices[0]
+                if isinstance(first.get('text'), str):
+                    return first.get('text')
+                message = first.get('message')
+                if isinstance(message, dict) and isinstance(message.get('content'), str):
+                    return message.get('content')
+                raise RuntimeError('malformed_completion_output')
+            def _attempt_error(method_name, exc, kwarg_names):
+                rejected = _extract_unsupported_generation_kwarg(str(exc), kwarg_names)
+                text_lower = str(exc).lower()
+                category = 'worker_exception'
+                if 'kv' in text_lower and any(term in text_lower for term in ('alloc', 'cache', 'memory', 'out of memory', 'oom')):
+                    category = 'kv_cache_allocation'
+                elif 'metal' in text_lower and any(term in text_lower for term in ('alloc', 'memory', 'out of memory', 'oom')):
+                    category = 'metal_memory_allocation'
+                elif 'yarn' in text_lower or ('rope' in text_lower and any(term in text_lower for term in ('scal', 'freq', 'eval'))):
+                    category = 'rope_yarn_eval_failure'
+                elif rejected == 'prompt':
+                    category = 'unsupported_prompt_kwarg'
+                elif rejected == 'stream':
+                    category = 'unsupported_stream_kwarg'
+                elif rejected == 'stop':
+                    category = 'unsupported_stop_kwarg'
+                elif rejected:
+                    category = 'unexpected_kwarg'
+                elif 'positional argument' in str(exc).lower() or 'required positional argument' in str(exc).lower():
+                    category = 'method_shape'
+                attempted.append({
+                    'method': method_name,
+                    'exception_type': type(exc).__name__,
+                    'exception_category': category,
+                    'rejected_kwarg': rejected,
+                    'attempted_kwarg_names': ','.join(sorted(kwarg_names)),
+                })
+                return category, rejected
+            result = None
+            result_shape = None
+            method_used = None
+            create_completion = getattr(llama, 'create_completion', None)
+            if callable(create_completion):
+                try:
+                    method_used = 'create_completion_keyword_prompt'
+                    result = create_completion(prompt=rendered_prompt, **plain_kwargs)
+                    result_shape = _shape(result)
+                except Exception as exc:
+                    category, rejected = _attempt_error('create_completion_keyword_prompt', exc, ['prompt'] + list(plain_kwargs))
+                    if category != 'unsupported_prompt_kwarg':
+                        extra = dict(render_diagnostics or {})
+                        extra.update({'method': 'create_completion_keyword_prompt', 'generation_exception_category': category, 'rejected_generation_kwarg': rejected, 'attempted_generation_kwargs': 'max_tokens,prompt', 'result_shape': result_shape})
+                        _emit(_safe_request_error('inference_exception', request=request, exc=exc, extra=extra))
+                        continue
+                    result = None
+                if result is None:
+                    try:
+                        method_used = 'create_completion_positional_prompt'
+                        result = create_completion(rendered_prompt, **plain_kwargs)
+                        result_shape = _shape(result)
+                    except Exception as exc:
+                        category, rejected = _attempt_error('create_completion_positional_prompt', exc, list(plain_kwargs))
+                        extra = dict(render_diagnostics or {})
+                        extra.update({'method': 'create_completion_positional_prompt', 'generation_exception_category': category, 'rejected_generation_kwarg': rejected, 'attempted_generation_kwargs': 'max_tokens', 'result_shape': result_shape})
+                        if category not in {'method_shape', 'worker_exception'}:
+                            _emit(_safe_request_error('inference_exception', request=request, exc=exc, extra=extra))
+                            continue
+                        result = None
+            if result is None and callable(llama):
+                try:
+                    method_used = 'llama_call_positional_prompt'
+                    result = llama(rendered_prompt, **plain_kwargs)
+                    result_shape = _shape(result)
+                except Exception as exc:
+                    category, rejected = _attempt_error('llama_call_positional_prompt', exc, list(plain_kwargs))
+                    extra = dict(render_diagnostics or {})
+                    extra.update({'method': 'llama_call_positional_prompt', 'generation_exception_category': category, 'rejected_generation_kwarg': rejected, 'attempted_generation_kwargs': 'max_tokens', 'result_shape': result_shape})
+                    _emit(_safe_request_error('inference_exception', request=request, exc=exc, extra=extra))
+                    continue
+            if result is None:
+                extra = dict(render_diagnostics or {})
+                extra.update({'method': 'llama_call_positional_prompt', 'generation_exception_category': 'worker_exception', 'attempted_generation_kwargs': 'max_tokens'})
+                _emit(_safe_request_error('inference_exception', request=request, extra=extra))
                 continue
-            choices = result.get('choices')
-            text = None
-            if isinstance(choices, list) and choices and isinstance(choices[0], dict):
-                text = choices[0].get('text')
-            if not isinstance(text, str):
-                _emit(_safe_request_error('malformed_completion_output', request=request, extra=render_diagnostics))
+            try:
+                text = _normalize_plain(result)
+            except Exception as exc:
+                extra = dict(render_diagnostics or {})
+                extra.update({'method': method_used, 'generation_exception_category': 'malformed_completion_output', 'result_shape': _shape(result), 'attempted_generation_kwargs': 'max_tokens'})
+                _emit(_safe_request_error('malformed_completion_output', request=request, exc=exc, extra=extra))
+                continue
+            if not text.strip():
+                extra = dict(render_diagnostics or {})
+                extra.update({'method': method_used, 'generation_exception_category': 'empty_completion_output', 'result_shape': _shape(result), 'attempted_generation_kwargs': 'max_tokens'})
+                _emit(_safe_request_error('empty_completion_output', request=request, extra=extra))
                 continue
             _emit({'status': 'ok', 'result': {'choices': [{'message': {'role': 'assistant', 'content': text}}]}})
             continue

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -48,7 +48,9 @@ _UNSUPPORTED_GENERATION_KWARG_PATTERNS = (
     re.compile(r"(?:got an )?unexpected keyword argument [\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]"),
     re.compile(r"unsupported option(?:\s+[\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]|\s*:\s*([A-Za-z_][A-Za-z0-9_]*))"),
     re.compile(r"invalid keyword(?: argument)? [\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]"),
+    re.compile(r"invalid keyword argument\s*:\s*([A-Za-z_][A-Za-z0-9_]*)"),
     re.compile(r"invalid keyword\s*=\s*([A-Za-z_][A-Za-z0-9_]*)"),
+    re.compile(r"got multiple values for keyword argument [\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]"),
 )
 
 
@@ -95,6 +97,9 @@ _SAFE_WORKER_DIAGNOSTIC_KEYS = {
     "rejected_option",
     "rejected_generation_kwarg",
     "attempted_generation_kwargs",
+    "attempted_methods",
+    "attempted_kwarg_names",
+    "result_shape",
     "method",
     "stream",
     "retryable",
@@ -130,6 +135,13 @@ _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "runtime_chat_template_renderer_unavailable",
         "runtime_template_tokenizer_bridge_unavailable",
         "malformed_completion_output",
+        "empty_completion_output",
+        "unexpected_kwarg",
+        "unsupported_prompt_kwarg",
+        "unsupported_stream_kwarg",
+        "unsupported_stop_kwarg",
+        "method_shape",
+        "worker_exception",
     },
     "generation_exception_category": {
         "metal_memory_allocation",
@@ -140,6 +152,13 @@ _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "worker_dead",
         "unknown_generation_exception",
         "malformed_completion_output",
+        "empty_completion_output",
+        "unexpected_kwarg",
+        "unsupported_prompt_kwarg",
+        "unsupported_stream_kwarg",
+        "unsupported_stop_kwarg",
+        "method_shape",
+        "worker_exception",
     },
     "method": {
         "apply_chat_template",
@@ -147,6 +166,9 @@ _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "create_chat_completion_with_recovery",
         "create_chat_completion_from_rendered_prompt",
         "create_completion_from_rendered_prompt",
+        "create_completion_keyword_prompt",
+        "create_completion_positional_prompt",
+        "llama_call_positional_prompt",
         "render_and_tokenize_chat",
         "tokenize",
     },
@@ -182,6 +204,11 @@ def _safe_worker_diagnostic_value(key: str, value: Any) -> Any:
     enum_values = _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES.get(key)
     if enum_values is not None:
         return bounded if bounded in enum_values else None
+    if key in {"attempted_generation_kwargs", "attempted_methods", "attempted_kwarg_names"}:
+        parts = [part for part in bounded.split(",") if part]
+        return bounded if parts and all(_SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(part) for part in parts) else None
+    if key == "result_shape":
+        return bounded if _SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(bounded) else None
     if key == "exception_type":
         return bounded if _SAFE_WORKER_DIAGNOSTIC_CLASS_RE.fullmatch(bounded) else None
     if key in {"rejected_option", "rejected_generation_kwarg", "profile_id", "context_tier", "type_k", "type_v"}:
@@ -3308,17 +3335,15 @@ class RelayClient:
         removed: List[str] = []
         attempted_names: List[str] = []
         while True:
-            completion_kwargs = {
-                key: value
-                for key, value in self._api_v1_runtime_completion_kwargs(safe_options).items()
-                if key in allowed_plain_kwargs
-            }
+            runtime_defaults = self._api_v1_runtime_completion_kwargs(safe_options)
+            completion_kwargs = {"max_tokens": runtime_defaults.get("max_tokens", 64)}
+            for key, value in safe_options.items():
+                if key in allowed_plain_kwargs and key != "stream":
+                    completion_kwargs[key] = value
             removed_set = set(removed) | (set(getattr(self, "_api_v1_generation_kwargs_filtered", set())) - set(client_option_names))
             completion_kwargs = {
                 key: value for key, value in completion_kwargs.items() if key not in removed_set
             }
-            if "stream" not in removed_set:
-                completion_kwargs["stream"] = False
             if model_profile.get("provider") and "token_place_provider" not in removed_set:
                 completion_kwargs["token_place_provider"] = model_profile.get("provider")
             if model_profile.get("chat_template_policy") and "token_place_template_policy" not in removed_set:


### PR DESCRIPTION
### Motivation
- Qwen 64K readiness was failing because the packaged render-then-complete path sent too many plain-completion kwargs and returned a generic unsupported-kwarg readiness error instead of a precise failure; the goal is to make the child-worker plain completion call minimal and return actionable, safe diagnostics when it still fails.

### Description
- In the packaged llama.cpp subprocess worker (embedded runtime code in `utils/llm/model_manager.py`) the render-then-complete branch now issues a truly minimal plain completion call using only the prompt and `max_tokens` and normalizes supported plain-completion result shapes to `{role: "assistant", content: text}` while rejecting empty/malformed/think outputs. 
- Added bounded fallback method shapes inside the child worker to try `create_completion(prompt=...)`, then `create_completion(rendered_prompt, ...)`, then `llama(rendered_prompt, ...)`, and capture safe per-attempt diagnostics without ever returning or logging rendered prompt text. 
- Improved parsing of rejected-kwarg/method-shape exceptions (extra regexes and robust extraction) and expanded the allowlist of safe diagnostic keys and enumerated diagnostic values in `utils/networking/relay_client.py` and `utils/compute_node_runtime.py`. 
- Parent-side Qwen readiness path (`utils/networking/relay_client.py`) now builds plain-completion kwargs minimally (defaults `max_tokens` only, avoids sending `stream`, `stop`, `temperature`, sampling fields unless explicitly supported) and preserves the render-then-complete branch; readiness failure reasons were extended to precise plain-completion categories in `utils/compute_node_runtime.py`. 
- Added and updated focused tests that reproduce the original failure and validate the new minimal-call behavior, fallbacks, normalization, and safe diagnostics: new/updated tests under `tests/unit/test_model_manager.py`, `tests/unit/test_relay_client.py`, `tests/unit/test_compute_node_runtime.py`, and `tests/integration/test_desktop_qwen64k_packaged_runtime.py`.

### Testing
- Installed focused verification deps with `pip install -r config/requirements_codex_verification.txt` and ran full/focused test suites; all exercised tests passed: `python -m pytest tests/unit/test_model_manager.py -q` (passed), `python -m pytest tests/unit/test_relay_client.py -q` (passed), `python -m pytest tests/unit/test_compute_node_runtime.py -q` (passed), `python -m pytest tests/unit/test_context_profiles.py -q` (passed), `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (passed), and `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q` (passed). 
- Verified focused new regressions and helper cases (minimal kwargs, prompt-keyword fallback, callable fallback, empty-output diagnostics) via targeted runs, all passed; compiled `utils/llm/model_manager.py` with `python -m py_compile` and ran `pre-commit run --all-files` with no failures. 
- Files changed (high level): `utils/llm/model_manager.py`, `utils/networking/relay_client.py`, `utils/compute_node_runtime.py`, and test updates under `tests/unit/` and `tests/integration/` to cover the new behavior and regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4acf5ad084832f880cf2a961046d22)