### PR TITLE
Fix Qwen plain completion readiness

### DIFF
--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -239,8 +239,9 @@ def test_qwen64k_packaged_subprocess_generation_error_preserves_safe_diagnostics
         assert proxy.render_and_tokenize_chat([{'role': 'user', 'content': 'safe'}]) == {'prompt_tokens': 42}
         with pytest.raises(LlamaCppInferenceRequestError) as exc_info:
             proxy.create_chat_completion_from_rendered_prompt([{'role': 'user', 'content': 'SECRET_PROMPT'}], stream=False)
-        assert exc_info.value.diagnostics['method'] == 'create_chat_completion_from_rendered_prompt'
+        assert exc_info.value.diagnostics['method'] == 'create_completion_keyword_prompt'
         assert exc_info.value.diagnostics['generation_exception_category'] == 'kv_cache_allocation'
+        assert exc_info.value.diagnostics['attempted_plain_completion_methods'] == 'create_completion_keyword_prompt'
         assert 'SECRET_PROMPT' not in str(exc_info.value.diagnostics)
 
         runtime, manager = _runtime_for(proxy)
@@ -284,6 +285,5 @@ def test_qwen64k_packaged_fake_runtime_filters_unsupported_internal_top_k_and_re
     diagnostics = manager.last_compute_diagnostics
     assert diagnostics["api_v1_readiness_result"] == "passed"
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
-    assert fake.calls[0]["top_k"] == 20
-    assert "top_k" not in fake.calls[1]
-    assert "top_k" in diagnostics["api_v1_generation_kwargs_filtered"]
+    assert "top_k" not in fake.calls[0]
+    assert diagnostics.get("api_v1_generation_kwargs_filtered", []) == []

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -133,6 +133,19 @@ def test_completion_smoke_worker_diagnostic_sanitizer_drops_unsafe_shapes():
         ({"internal_reason": "runtime_worker_timeout"}, "runtime_completion_smoke_worker_timeout"),
         ({"internal_reason": "runtime_worker_dead"}, "runtime_completion_smoke_worker_dead"),
         ({"code": "compute_node_options_unsupported"}, "runtime_completion_smoke_unsupported_generation_kwarg"),
+        # Top-level generation_exception_category checks.
+        ({"generation_exception_category": "empty_completion_output"}, "runtime_completion_smoke_plain_completion_empty_output"),
+        ({"generation_exception_category": "thinking_leaked"}, "runtime_completion_smoke_plain_completion_thinking_leaked"),
+        ({"generation_exception_category": "malformed_completion_output"}, "runtime_completion_smoke_plain_completion_malformed_output"),
+        ({"generation_exception_category": "method_shape"}, "runtime_completion_smoke_plain_completion_method_shape"),
+        ({"generation_exception_category": "unsupported_prompt_kwarg"}, "runtime_completion_smoke_plain_completion_method_shape"),
+        # Relay path: generation_exception_category nested inside worker_diagnostics.
+        ({"worker_diagnostics": {"generation_exception_category": "method_shape"}}, "runtime_completion_smoke_plain_completion_method_shape"),
+        ({"worker_diagnostics": {"generation_exception_category": "unsupported_prompt_kwarg"}}, "runtime_completion_smoke_plain_completion_method_shape"),
+        ({"worker_diagnostics": {"generation_exception_category": "empty_completion_output"}}, "runtime_completion_smoke_plain_completion_empty_output"),
+        ({"worker_diagnostics": {"generation_exception_category": "thinking_leaked"}}, "runtime_completion_smoke_plain_completion_thinking_leaked"),
+        # Top-level takes precedence over nested.
+        ({"generation_exception_category": "empty_completion_output", "worker_diagnostics": {"generation_exception_category": "thinking_leaked"}}, "runtime_completion_smoke_plain_completion_empty_output"),
     ],
 )
 def test_completion_smoke_reason_from_api_v1_error_maps_runtime_reasons(error, expected_reason):

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -146,7 +146,7 @@ def test_completion_smoke_reason_from_api_v1_error_maps_runtime_reasons(error, e
         (RuntimeError("worker dead: broken pipe"), "worker_dead", "runtime_completion_smoke_worker_dead"),
         (RuntimeError("Metal buffer allocation out of memory"), "metal_memory_allocation", "runtime_completion_smoke_metal_memory_allocation"),
         (RuntimeError("KV cache allocation failed"), "kv_cache_allocation", "runtime_completion_smoke_kv_cache_allocation"),
-        (RuntimeError("unexpected keyword argument 'mirostat'"), "unsupported_generation_kwarg", "runtime_completion_smoke_unsupported_generation_kwarg"),
+        (RuntimeError("unexpected keyword argument 'mirostat'"), "unsupported_generation_kwarg", "runtime_completion_smoke_plain_completion_unexpected_kwarg"),
         (RuntimeError("unclassified failure with prompt text"), "unknown_generation_exception", "runtime_completion_smoke_exception"),
     ],
 )
@@ -207,7 +207,7 @@ def test_classify_completion_smoke_exception_uses_safe_worker_unsupported_reason
     )
 
     assert category == "unsupported_generation_kwarg"
-    assert reason == "runtime_completion_smoke_unsupported_generation_kwarg"
+    assert reason == "runtime_completion_smoke_plain_completion_unexpected_kwarg"
     assert diagnostics["worker_diagnostics"] == {"reason": "unsupported_generation_option"}
 
 
@@ -671,8 +671,9 @@ def test_compute_node_runtime_readiness_smoke_completion_passes(monkeypatch):
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert diagnostics["api_v1_readiness_result"] == "passed"
     assert diagnostics["api_v1_readiness_model_profile_id"] == "qwen3-8b-q4-k-m"
-    assert llm_runtime.completion_kwargs["stream"] is False
     assert llm_runtime.completion_kwargs["max_tokens"] == 64
+    assert "stream" not in llm_runtime.completion_kwargs
+    assert "stop" not in llm_runtime.completion_kwargs
     assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
 
 

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -144,6 +144,7 @@ def test_completion_smoke_worker_diagnostic_sanitizer_drops_unsafe_shapes():
         ({"worker_diagnostics": {"generation_exception_category": "unsupported_prompt_kwarg"}}, "runtime_completion_smoke_plain_completion_method_shape"),
         ({"worker_diagnostics": {"generation_exception_category": "empty_completion_output"}}, "runtime_completion_smoke_plain_completion_empty_output"),
         ({"worker_diagnostics": {"generation_exception_category": "thinking_leaked"}}, "runtime_completion_smoke_plain_completion_thinking_leaked"),
+        ({"worker_diagnostics": {"generation_exception_category": "malformed_completion_output"}}, "runtime_completion_smoke_plain_completion_malformed_output"),
         # Top-level takes precedence over nested.
         ({"generation_exception_category": "empty_completion_output", "worker_diagnostics": {"generation_exception_category": "thinking_leaked"}}, "runtime_completion_smoke_plain_completion_empty_output"),
     ],

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -897,6 +897,55 @@ def test_compute_node_runtime_readiness_smoke_completion_rejects_missing_content
     assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_invalid_model_output"
 
 
+def test_compute_node_runtime_promotes_nested_worker_diagnostics_to_flat_readiness_fields(monkeypatch):
+    class NestedWorkerDiagnosticRelayClient:
+        def _api_v1_authoritative_context_admission(self, **_kwargs):
+            return True, None, 2
+
+        def _generate_api_v1_response_with_runtime_model(self, **_kwargs):
+            return {
+                "api_v1_response": {
+                    "error": {
+                        "code": "compute_node_internal_error",
+                        "worker_diagnostics": {
+                            "rejected_generation_kwarg": "stream",
+                            "attempted_generation_kwargs": "max_tokens,stream",
+                            "attempted_plain_completion_methods": "create_completion_keyword_prompt",
+                            "result_shape": "dict_malformed",
+                        },
+                    }
+                }
+            }
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", "1")
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "local", "thinking_mode": "n/a"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "local-model"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = _ReadyRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=NestedWorkerDiagnosticRelayClient(),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_worker_diagnostics"] == {
+        "rejected_generation_kwarg": "stream",
+        "attempted_generation_kwargs": "max_tokens,stream",
+        "attempted_plain_completion_methods": "create_completion_keyword_prompt",
+        "result_shape": "dict_malformed",
+    }
+    assert diagnostics["api_v1_readiness_completion_smoke_rejected_generation_kwarg"] == "stream"
+    assert diagnostics["api_v1_readiness_completion_smoke_attempted_generation_kwargs"] == "max_tokens,stream"
+    assert diagnostics["api_v1_readiness_completion_smoke_attempted_plain_completion_methods"] == "create_completion_keyword_prompt"
+    assert diagnostics["api_v1_readiness_completion_smoke_result_shape"] == "dict_malformed"
+
 def test_compute_node_runtime_qwen_readiness_smoke_completion_is_required_without_env(monkeypatch):
     class ThinkRuntime:
         def render_and_tokenize_chat(self, *_args, **_kwargs):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -5793,11 +5793,20 @@ def test_subprocess_worker_plain_completion_helpers_cover_safe_shapes():
     assert extract_rejected("unsupported option: mirostat", ['mirostat']) == 'mirostat'
     assert extract_rejected("invalid keyword=temperature", ['temperature']) == 'temperature'
     assert extract_rejected("unexpected keyword argument 'prompt'", ['max_tokens']) is None
+    assert (
+        extract_rejected(
+            "got some positional-only arguments passed as keyword arguments: 'prompt'",
+            ['max_tokens', 'prompt'],
+        )
+        == 'prompt'
+    )
     assert classify_shape(TypeError("got an unexpected keyword argument 'prompt'")) == 'unsupported_prompt_kwarg'
+    assert classify_shape(
+        TypeError("got some positional-only arguments passed as keyword arguments: 'prompt'")
+    ) == 'unsupported_prompt_kwarg'
     assert classify_shape(TypeError("got an unexpected keyword argument 'stream'")) == 'unsupported_stream_kwarg'
     assert classify_shape(TypeError("got an unexpected keyword argument 'stop'")) == 'unsupported_stop_kwarg'
     assert classify_shape(TypeError("got an unexpected keyword argument 'temperature'")) == 'unexpected_kwarg'
-    assert classify_shape(TypeError("got some positional-only arguments passed as keyword arguments: 'prompt'")) == 'method_shape'
     assert classify_shape(RuntimeError("KV cache allocation failed")) == 'worker_exception'
 
 
@@ -6313,6 +6322,43 @@ def test_llama_worker_render_complete_falls_back_to_positional_prompt(tmp_path, 
     assert result == {'choices': [{'message': {'role': 'assistant', 'content': 'positional ok'}}]}
 
 
+def test_llama_worker_render_complete_falls_back_for_positional_only_prompt(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'positional only fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def create_completion(self, prompt, /, max_tokens=None):\n"
+        "        if len(prompt) <= 0 or max_tokens != 4:\n"
+        "            raise TypeError('bad method shape')\n"
+        "        return {'choices': [{'text': 'positional only ok'}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'testing')
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'mock.gguf'),
+        timeout_seconds=5,
+    )
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt(
+            [{'role': 'user', 'content': 'secret prompt text'}],
+            max_tokens=4,
+            token_place_provider='qwen',
+            token_place_template_policy='gguf-jinja',
+            enable_thinking=False,
+        )
+    finally:
+        proxy.close()
+
+    assert result == {'choices': [{'message': {'role': 'assistant', 'content': 'positional only ok'}}]}
+
+
 def test_llama_worker_render_complete_falls_back_to_callable_llama(tmp_path, monkeypatch):
     from utils.llm import model_manager as model_manager_module
 
@@ -6348,6 +6394,48 @@ def test_llama_worker_render_complete_falls_back_to_callable_llama(tmp_path, mon
         proxy.close()
 
     assert result == {'choices': [{'message': {'role': 'assistant', 'content': 'callable ok'}}]}
+
+
+def test_llama_worker_render_complete_runtime_failure_does_not_fall_back_to_callable(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'runtime failure fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def create_completion(self, *, prompt, **kwargs):\n"
+        "        raise RuntimeError('KV cache allocation failed during completion')\n"
+        "    def __call__(self, prompt, **kwargs):\n"
+        "        return {'choices': [{'text': 'callable should not run'}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'testing')
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'mock.gguf'),
+        timeout_seconds=5,
+    )
+    try:
+        with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as exc_info:
+            proxy.create_chat_completion_from_rendered_prompt(
+                [{'role': 'user', 'content': 'secret prompt text'}],
+                max_tokens=4,
+                token_place_provider='qwen',
+                token_place_template_policy='gguf-jinja',
+                enable_thinking=False,
+            )
+    finally:
+        proxy.close()
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics['generation_exception_category'] == 'kv_cache_allocation'
+    assert diagnostics['method'] == 'create_completion_keyword_prompt'
+    assert diagnostics['attempted_plain_completion_methods'] == 'create_completion_keyword_prompt'
+    assert diagnostics['sanitized_error_summary'] == 'RuntimeError:kv_cache_allocation'
 
 
 def test_llama_worker_render_complete_empty_and_thinking_fail_safely(tmp_path, monkeypatch):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -5940,6 +5940,91 @@ def test_subprocess_proxy_removes_temp_worker_script_when_popen_fails(monkeypatc
     assert created_tmpfiles
     assert not os.path.exists(created_tmpfiles[0])
 
+
+def test_subprocess_proxy_stream_marks_closed_on_eof(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    proxy = object.__new__(model_manager_module._SubprocessLlamaProxy)
+    proxy._closed = False
+    proxy._lock = model_manager_module.Lock()
+    proxy._process = object()
+
+    sent_payloads = []
+
+    def fake_send(payload, *, check_health=True):
+        sent_payloads.append(payload)
+
+    monkeypatch.setattr(proxy, "_send", fake_send)
+    monkeypatch.setattr(
+        model_manager_module,
+        "_read_llama_subprocess_message",
+        lambda *args, **kwargs: (_ for _ in ()).throw(model_manager_module.LlamaCppWorkerEOFError("eof")),
+    )
+
+    with pytest.raises(model_manager_module.LlamaCppWorkerEOFError):
+        next(proxy._stream_chat_completion([{"role": "user", "content": "hi"}]))
+
+    assert proxy._closed is True
+    assert sent_payloads[0]["method"] == "create_chat_completion"
+
+
+def test_subprocess_proxy_ignores_unlink_failure_when_popen_fails(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    unlink_calls = []
+    real_mkstemp = model_manager_module.tempfile.mkstemp
+
+    def tracking_mkstemp(*args, **kwargs):
+        return real_mkstemp(*args, **kwargs)
+
+    def failing_unlink(path):
+        unlink_calls.append(path)
+        raise PermissionError("busy temp worker")
+
+    monkeypatch.setattr(model_manager_module.tempfile, "mkstemp", tracking_mkstemp)
+    monkeypatch.setattr(model_manager_module.os, "unlink", failing_unlink)
+    monkeypatch.setattr(
+        model_manager_module.subprocess,
+        "Popen",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("spawn failed")),
+    )
+
+    with pytest.raises(OSError, match="spawn failed"):
+        model_manager_module._SubprocessLlamaProxy(model_path="model.gguf")
+
+    assert unlink_calls
+
+
+def test_subprocess_proxy_close_ignores_temp_worker_unlink_failure(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    class FakeStdin:
+        def close(self):
+            pass
+
+    class FakeProcess:
+        stdin = FakeStdin()
+
+        def poll(self):
+            return 0
+
+    unlink_calls = []
+
+    def failing_unlink(path):
+        unlink_calls.append(path)
+        raise PermissionError("busy temp worker")
+
+    proxy = object.__new__(model_manager_module._SubprocessLlamaProxy)
+    proxy._closed = False
+    proxy._process = FakeProcess()
+    proxy._worker_tmpfile = "/tmp/token-place-worker.py"
+    monkeypatch.setattr(model_manager_module.os, "unlink", failing_unlink)
+
+    proxy.close()
+
+    assert unlink_calls == ["/tmp/token-place-worker.py"]
+    assert proxy._worker_tmpfile is None
+
 def test_qwen_64k_context_create_failure_retries_q8_profile(tmp_path):
     from utils.context_profiles import apply_context_profile
 

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -5801,6 +5801,145 @@ def test_subprocess_worker_plain_completion_helpers_cover_safe_shapes():
     assert classify_shape(RuntimeError("KV cache allocation failed")) == 'worker_exception'
 
 
+
+def test_subprocess_proxy_uses_temp_worker_script_and_cleans_up(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    popen_calls = []
+
+    class FakeStdin:
+        def __init__(self):
+            self.writes = []
+            self.closed = False
+
+        def write(self, value):
+            self.writes.append(value)
+
+        def flush(self):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    class FakeProcess:
+        def __init__(self, command, **kwargs):
+            self.command = command
+            self.kwargs = kwargs
+            self.stdin = FakeStdin()
+            self.stdout = None
+            self.stderr = []
+            self.terminated = False
+            self.waited = False
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+
+        def wait(self, timeout=None):
+            self.waited = True
+            return 0
+
+    def fake_popen(command, **kwargs):
+        process = FakeProcess(command, **kwargs)
+        popen_calls.append(process)
+        return process
+
+    monkeypatch.setattr(model_manager_module.subprocess, 'Popen', fake_popen)
+    monkeypatch.setattr(model_manager_module._SubprocessLlamaProxy, '_start_stderr_tail_reader', lambda self: None)
+    monkeypatch.setattr(
+        model_manager_module,
+        '_read_llama_subprocess_message',
+        lambda *args, **kwargs: {'status': 'ok'},
+    )
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='model.gguf')
+    tmpfile = proxy._worker_tmpfile
+
+    assert tmpfile
+    assert os.path.exists(tmpfile)
+    assert popen_calls[0].command == [sys.executable, '-u', tmpfile]
+    assert popen_calls[0]._token_place_command == [sys.executable, '<runtime-worker-script>']
+    assert '"method": "__init__"' in popen_calls[0].stdin.writes[0]
+
+    proxy.close()
+
+    assert popen_calls[0].stdin.closed is True
+    assert popen_calls[0].terminated is True
+    assert popen_calls[0].waited is True
+    assert not os.path.exists(tmpfile)
+    assert proxy._worker_tmpfile is None
+
+
+def test_subprocess_proxy_falls_back_to_inline_code_when_tempfile_unavailable(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    popen_commands = []
+
+    class FakeStdin:
+        def write(self, value):
+            pass
+
+        def flush(self):
+            pass
+
+        def close(self):
+            pass
+
+    class FakeProcess:
+        stdin = FakeStdin()
+        stdout = None
+        stderr = []
+
+        def poll(self):
+            return 0
+
+    def fake_popen(command, **kwargs):
+        process = FakeProcess()
+        popen_commands.append(command)
+        return process
+
+    monkeypatch.setattr(model_manager_module.tempfile, 'mkstemp', lambda *args, **kwargs: (_ for _ in ()).throw(OSError('no tmp')))
+    monkeypatch.setattr(model_manager_module.subprocess, 'Popen', fake_popen)
+    monkeypatch.setattr(model_manager_module._SubprocessLlamaProxy, '_start_stderr_tail_reader', lambda self: None)
+    monkeypatch.setattr(
+        model_manager_module,
+        '_read_llama_subprocess_message',
+        lambda *args, **kwargs: {'status': 'ok'},
+    )
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='model.gguf')
+
+    assert proxy._worker_tmpfile is None
+    assert popen_commands[0][:3] == [sys.executable, '-u', '-c']
+    assert proxy._process._token_place_command == [sys.executable, '<runtime-worker-code>']
+
+
+def test_subprocess_proxy_removes_temp_worker_script_when_popen_fails(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    created_tmpfiles = []
+    real_mkstemp = model_manager_module.tempfile.mkstemp
+
+    def tracking_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        created_tmpfiles.append(path)
+        return fd, path
+
+    monkeypatch.setattr(model_manager_module.tempfile, 'mkstemp', tracking_mkstemp)
+    monkeypatch.setattr(
+        model_manager_module.subprocess,
+        'Popen',
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError('spawn failed')),
+    )
+
+    with pytest.raises(OSError, match='spawn failed'):
+        model_manager_module._SubprocessLlamaProxy(model_path='model.gguf')
+
+    assert created_tmpfiles
+    assert not os.path.exists(created_tmpfiles[0])
+
 def test_qwen_64k_context_create_failure_retries_q8_profile(tmp_path):
     from utils.context_profiles import apply_context_profile
 

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -5953,3 +5953,164 @@ def test_path_redaction_handles_spaces_and_traceback_paths():
     assert '/Users/Alice' not in redacted
     assert 'Application Support' not in redacted
     assert '<path>' in redacted
+
+
+def test_llama_worker_render_complete_minimal_kwargs_omit_sampling_and_stop(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'minimal fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def create_completion(self, *, prompt, **kwargs):\n"
+        "        forbidden = {'stream', 'stop', 'temperature', 'top_p', 'top_k', 'min_p', 'seed'} & set(kwargs)\n"
+        "        if forbidden:\n"
+        "            raise TypeError(f\"got an unexpected keyword argument '{sorted(forbidden)[0]}'\")\n"
+        "        if set(kwargs) != {'max_tokens'}:\n"
+        "            raise TypeError('unexpected keyword argument: extra')\n"
+        "        return {'choices': [{'text': 'minimal ok<|im_end|>'}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'testing')
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'mock.gguf'),
+        timeout_seconds=5,
+    )
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt(
+            [{'role': 'user', 'content': 'secret prompt text'}],
+            max_tokens=4,
+            temperature=0.5,
+            stop=[],
+            stream=False,
+            token_place_provider='qwen',
+            token_place_template_policy='gguf-jinja',
+            enable_thinking=False,
+        )
+    finally:
+        proxy.close()
+
+    assert result == {'choices': [{'message': {'role': 'assistant', 'content': 'minimal ok'}}]}
+
+
+def test_llama_worker_render_complete_falls_back_to_positional_prompt(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'positional fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def create_completion(self, *args, **kwargs):\n"
+        "        if 'prompt' in kwargs:\n"
+        "            raise TypeError(\"got an unexpected keyword argument 'prompt'\")\n"
+        "        if len(args) != 1 or set(kwargs) != {'max_tokens'}:\n"
+        "            raise TypeError('bad method shape')\n"
+        "        return {'choices': [{'text': 'positional ok'}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'testing')
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'mock.gguf'),
+        timeout_seconds=5,
+    )
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt(
+            [{'role': 'user', 'content': 'secret prompt text'}],
+            max_tokens=4,
+            token_place_provider='qwen',
+            token_place_template_policy='gguf-jinja',
+            enable_thinking=False,
+        )
+    finally:
+        proxy.close()
+
+    assert result == {'choices': [{'message': {'role': 'assistant', 'content': 'positional ok'}}]}
+
+
+def test_llama_worker_render_complete_falls_back_to_callable_llama(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'callable fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def __call__(self, prompt, **kwargs):\n"
+        "        if set(kwargs) != {'max_tokens'}:\n"
+        "            raise TypeError('bad callable kwargs')\n"
+        "        return {'choices': [{'message': {'content': 'callable ok'}}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'testing')
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'mock.gguf'),
+        timeout_seconds=5,
+    )
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt(
+            [{'role': 'user', 'content': 'secret prompt text'}],
+            max_tokens=4,
+            token_place_provider='qwen',
+            token_place_template_policy='gguf-jinja',
+            enable_thinking=False,
+        )
+    finally:
+        proxy.close()
+
+    assert result == {'choices': [{'message': {'role': 'assistant', 'content': 'callable ok'}}]}
+
+
+def test_llama_worker_render_complete_empty_and_thinking_fail_safely(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'unsafe output fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def create_completion(self, *, prompt, **kwargs):\n"
+        "        if 'empty' in prompt:\n"
+        "            return {'choices': [{'text': ''}]}\n"
+        "        return {'choices': [{'text': '<think>secret reasoning</think> visible'}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'testing')
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'mock.gguf'),
+        timeout_seconds=5,
+    )
+    try:
+        with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as empty_exc:
+            proxy.create_chat_completion_from_rendered_prompt(
+                [{'role': 'user', 'content': 'empty'}], max_tokens=4,
+                token_place_provider='qwen', token_place_template_policy='gguf-jinja', enable_thinking=False,
+            )
+        with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as think_exc:
+            proxy.create_chat_completion_from_rendered_prompt(
+                [{'role': 'user', 'content': 'think'}], max_tokens=4,
+                token_place_provider='qwen', token_place_template_policy='gguf-jinja', enable_thinking=False,
+            )
+    finally:
+        proxy.close()
+
+    assert empty_exc.value.diagnostics['generation_exception_category'] == 'empty_completion_output'
+    assert think_exc.value.diagnostics['generation_exception_category'] == 'thinking_leaked'
+    assert 'secret reasoning' not in json.dumps(think_exc.value.diagnostics)

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -5749,6 +5749,58 @@ def test_subprocess_worker_error_summary_keeps_safe_category_hint():
 
     assert summary == 'RuntimeError:metal_memory_allocation'
 
+
+def test_subprocess_worker_plain_completion_helpers_cover_safe_shapes():
+    from utils.llm import model_manager as model_manager_module
+
+    namespace = {}
+    worker_code = model_manager_module._LLAMA_CPP_RUNTIME_WORKER_CODE
+    exec(worker_code.split('def _metadata_value', 1)[0], namespace)
+
+    normalize = namespace['_normalize_plain_completion_result']
+    result_shape = namespace['_completion_result_shape']
+    classify_shape = namespace['_plain_completion_method_shape_category']
+    extract_rejected = namespace['_extract_unsupported_generation_kwarg']
+
+    normalized, invalid_reason = normalize({'choices': [{'text': ' ok <|im_end|>'}]})
+    assert invalid_reason is None
+    assert normalized == {'choices': [{'message': {'role': 'assistant', 'content': 'ok'}}]}
+    normalized, invalid_reason = normalize({'choices': [{'message': {'content': 'message ok'}}]})
+    assert invalid_reason is None
+    assert normalized['choices'][0]['message']['content'] == 'message ok'
+    normalized, invalid_reason = normalize('direct ok')
+    assert invalid_reason is None
+    assert normalized['choices'][0]['message']['content'] == 'direct ok'
+    normalized, invalid_reason = normalize('<think></think> wrapper ok')
+    assert invalid_reason is None
+    assert normalized['choices'][0]['message']['content'] == 'wrapper ok'
+
+    assert normalize({'choices': []}) == (None, 'malformed_completion_output')
+    assert normalize({'choices': [{'text': '<think>secret</think> visible'}]}) == (
+        None,
+        'thinking_leaked',
+    )
+    assert normalize('<think>unterminated') == (None, 'thinking_leaked')
+    assert normalize('visible </think>') == (None, 'thinking_leaked')
+    assert normalize('<think></think><|im_end|>') == (None, 'empty_completion_output')
+
+    assert result_shape('text') == 'direct_string'
+    assert result_shape({'choices': [{'text': 'text'}]}) == 'choices_text'
+    assert result_shape({'choices': [{'message': {'content': 'text'}}]}) == 'choices_message'
+    assert result_shape({'choices': []}) == 'dict_malformed'
+    assert result_shape(['not', 'supported']) == 'list'
+
+    assert extract_rejected("unsupported option: mirostat", ['mirostat']) == 'mirostat'
+    assert extract_rejected("invalid keyword=temperature", ['temperature']) == 'temperature'
+    assert extract_rejected("unexpected keyword argument 'prompt'", ['max_tokens']) is None
+    assert classify_shape(TypeError("got an unexpected keyword argument 'prompt'")) == 'unsupported_prompt_kwarg'
+    assert classify_shape(TypeError("got an unexpected keyword argument 'stream'")) == 'unsupported_stream_kwarg'
+    assert classify_shape(TypeError("got an unexpected keyword argument 'stop'")) == 'unsupported_stop_kwarg'
+    assert classify_shape(TypeError("got an unexpected keyword argument 'temperature'")) == 'unexpected_kwarg'
+    assert classify_shape(TypeError("got some positional-only arguments passed as keyword arguments: 'prompt'")) == 'method_shape'
+    assert classify_shape(RuntimeError("KV cache allocation failed")) == 'worker_exception'
+
+
 def test_qwen_64k_context_create_failure_retries_q8_profile(tmp_path):
     from utils.context_profiles import apply_context_profile
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4220,10 +4220,11 @@ def test_api_v1_qwen_generation_uses_render_then_complete_not_chat_completion():
     assert envelope["api_v1_response"]["message"] == {"role": "assistant", "content": "ok"}
     manager.runtime.create_chat_completion.assert_not_called()
     kwargs = manager.runtime.create_chat_completion_from_rendered_prompt.call_args.kwargs
-    assert kwargs["stream"] is False
-    assert kwargs["max_tokens"] == 64
-    assert kwargs["enable_thinking"] is False
-    assert "messages" not in kwargs
+    assert kwargs == {
+        "max_tokens": 64,
+        "token_place_provider": "qwen",
+        "enable_thinking": False,
+    }
     messages = manager.runtime.create_chat_completion_from_rendered_prompt.call_args.args[0]
     assert messages[-1]["content"].startswith("/no_think\n")
 
@@ -4258,7 +4259,7 @@ def test_api_v1_qwen_missing_render_complete_bridge_fails_closed_without_chat_fa
     assert error["internal_reason"] == "qwen_render_complete_bridge_unavailable"
     manager.runtime.create_chat_completion.assert_not_called()
 
-def test_api_v1_qwen_render_then_complete_preserves_seed_option():
+def test_api_v1_qwen_render_then_complete_rejects_unproven_seed_option():
     manager = _ApiV1RuntimeManager()
     manager.model_profile = {"provider": "qwen", "thinking_mode": "disabled"}
     manager.runtime.create_chat_completion_from_rendered_prompt = MagicMock(return_value={
@@ -4273,9 +4274,10 @@ def test_api_v1_qwen_render_then_complete_preserves_seed_option():
         options={"max_tokens": 64, "seed": 7},
     )
 
-    assert envelope["api_v1_response"]["message"]["content"] == "ok"
-    kwargs = manager.runtime.create_chat_completion_from_rendered_prompt.call_args.kwargs
-    assert kwargs["seed"] == 7
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_options_unsupported"
+    assert error["rejected_option"] == "seed"
+    manager.runtime.create_chat_completion_from_rendered_prompt.assert_not_called()
 
 
 def test_api_v1_qwen_render_then_complete_retries_rejected_option_once():
@@ -4313,24 +4315,12 @@ def test_api_v1_qwen_render_then_complete_retries_rejected_option_once():
 
 
 
-def test_api_v1_qwen_render_then_complete_retries_rejected_top_k_without_resending():
-    from utils.llm.model_manager import LlamaCppInferenceRequestError
-
+def test_api_v1_qwen_render_then_complete_does_not_send_unproven_top_k():
     manager = _ApiV1RuntimeManager()
     client = _api_v1_validation_client(manager)
-    render_complete = MagicMock(side_effect=[
-        LlamaCppInferenceRequestError(
-            "unexpected keyword argument 'top_k'",
-            diagnostics={
-                "code": "compute_node_options_unsupported",
-                "reason": "unsupported_generation_option",
-                "rejected_option": "top_k",
-                "generation_exception_category": "unsupported_generation_kwarg",
-                "method": "create_chat_completion_from_rendered_prompt",
-            },
-        ),
-        {"choices": [{"message": {"role": "assistant", "content": "ok"}}]},
-    ])
+    render_complete = MagicMock(return_value={
+        "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+    })
 
     completion, diagnostics = client._api_v1_create_completion_from_rendered_prompt_filtered(
         render_complete,
@@ -4341,11 +4331,13 @@ def test_api_v1_qwen_render_then_complete_retries_rejected_top_k_without_resendi
     )
 
     assert completion["choices"][0]["message"]["content"] == "ok"
-    calls = render_complete.call_args_list
-    assert calls[0].kwargs["top_k"] == 20
-    assert "top_k" not in calls[1].kwargs
-    assert "top_k" in diagnostics["filtered_generation_kwargs"]
-    assert "top_k" in client._api_v1_generation_kwargs_filtered
+    render_complete.assert_called_once()
+    assert render_complete.call_args.kwargs == {
+        "max_tokens": 64,
+        "token_place_provider": "qwen",
+        "enable_thinking": False,
+    }
+    assert diagnostics["attempted_generation_kwargs"] == ["enable_thinking", "max_tokens", "token_place_provider"]
 
 
 def test_api_v1_qwen_render_then_complete_empty_think_wrapper_is_cleaned():
@@ -5950,7 +5942,7 @@ def test_api_v1_cached_internal_filter_does_not_drop_later_explicit_client_optio
     assert error["code"] == "compute_node_options_unsupported"
     assert error["internal_reason"] == "unsupported_generation_option"
     assert error["rejected_option"] == "temperature"
-    assert manager.runtime.calls[-1]["temperature"] == 0.3
+    assert all("temperature" not in call for call in manager.runtime.calls)
 
 
 def test_api_v1_invalid_output_reason_clears_before_unavailable_completion_callable():
@@ -6034,10 +6026,8 @@ def test_api_v1_internal_top_k_default_is_filtered_and_cached_per_client_after_r
 
     assert first["api_v1_response"]["message"]["content"] == "ok"
     assert second["api_v1_response"]["message"]["content"] == "ok"
-    assert manager.runtime.calls[0]["top_k"] == 20
-    assert "top_k" not in manager.runtime.calls[1]
-    assert "top_k" not in manager.runtime.calls[-1]
-    assert "top_k" in client._api_v1_generation_kwargs_filtered
+    assert all("top_k" not in call for call in manager.runtime.calls)
+    assert not client._api_v1_generation_kwargs_filtered
 
     fresh_client = _api_v1_validation_client(manager)
     third = fresh_client._generate_api_v1_response_with_runtime_model(
@@ -6049,7 +6039,7 @@ def test_api_v1_internal_top_k_default_is_filtered_and_cached_per_client_after_r
     )
 
     assert third["api_v1_response"]["message"]["content"] == "ok"
-    assert manager.runtime.calls[-1]["top_k"] == 20
+    assert "top_k" not in manager.runtime.calls[-1]
     assert not hasattr(manager, "api_v1_generation_kwargs_filtered")
 
 
@@ -6067,8 +6057,7 @@ def test_api_v1_internal_empty_stop_default_is_filtered_after_runtime_rejection(
     )
 
     assert envelope["api_v1_response"]["message"]["content"] == "ok"
-    assert manager.runtime.calls[0]["stop"] == []
-    assert "stop" not in manager.runtime.calls[1]
+    assert all("stop" not in call for call in manager.runtime.calls)
 
 
 def test_api_v1_client_supplied_runtime_unsupported_option_is_not_silently_dropped():
@@ -6100,10 +6089,9 @@ def test_api_v1_generation_kwarg_filtering_stops_after_bounded_internal_retries(
         requested_context_tier="8k-fast",
     )
 
-    error = envelope["api_v1_response"]["error"]
-    assert error["code"] in {"compute_node_options_unsupported", "compute_node_internal_error"}
-    assert error["rejected_option"] == "stop"
-    assert len(manager.runtime.calls) == 4
+    assert envelope["api_v1_response"]["message"]["content"] == "ok"
+    assert len(manager.runtime.calls) == 1
+    assert all(key not in manager.runtime.calls[0] for key in {"top_k", "temperature", "top_p", "stop"})
 
 
 def test_api_v1_qwen_no_think_survives_generation_kwarg_filtering():

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -268,10 +268,11 @@ def _completion_smoke_reason_from_api_v1_error(error: Dict[str, Any]) -> str:
     # Map plain-completion diagnostic categories surfaced by the subprocess worker.
     # Check both the top-level error dict and nested worker_diagnostics, since the
     # relay path carries child-worker details inside worker_diagnostics.
-    nested = error.get("worker_diagnostics") or {}
-    generation_exception_category = error.get("generation_exception_category") or (
-        nested.get("generation_exception_category") if isinstance(nested, dict) else None
-    )
+    generation_exception_category = error.get("generation_exception_category")
+    if not generation_exception_category:
+        worker_diag = error.get("worker_diagnostics")
+        if isinstance(worker_diag, dict):
+            generation_exception_category = worker_diag.get("generation_exception_category")
     if generation_exception_category and generation_exception_category in _COMPLETION_SMOKE_REASON_BY_CATEGORY:
         return _COMPLETION_SMOKE_REASON_BY_CATEGORY[generation_exception_category]
     if error.get("code") == "compute_node_invalid_model_output":

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -265,14 +265,15 @@ def _completion_smoke_reason_from_api_v1_error(error: Dict[str, Any]) -> str:
         return "runtime_completion_smoke_worker_timeout"
     if internal_reason in {"worker_dead", "runtime_worker_dead"}:
         return "runtime_completion_smoke_worker_dead"
-    # Map new plain-completion diagnostic categories surfaced by the subprocess worker.
-    generation_exception_category = error.get("generation_exception_category")
-    if generation_exception_category == "empty_completion_output":
-        return "runtime_completion_smoke_plain_completion_empty_output"
-    if generation_exception_category == "thinking_leaked":
-        return "runtime_completion_smoke_plain_completion_thinking_leaked"
-    if generation_exception_category == "malformed_completion_output":
-        return "runtime_completion_smoke_plain_completion_malformed_output"
+    # Map plain-completion diagnostic categories surfaced by the subprocess worker.
+    # Check both the top-level error dict and nested worker_diagnostics, since the
+    # relay path carries child-worker details inside worker_diagnostics.
+    nested = error.get("worker_diagnostics") or {}
+    generation_exception_category = error.get("generation_exception_category") or (
+        nested.get("generation_exception_category") if isinstance(nested, dict) else None
+    )
+    if generation_exception_category and generation_exception_category in _COMPLETION_SMOKE_REASON_BY_CATEGORY:
+        return _COMPLETION_SMOKE_REASON_BY_CATEGORY[generation_exception_category]
     if error.get("code") == "compute_node_invalid_model_output":
         return "runtime_completion_smoke_invalid_model_output"
     if error.get("code") == "compute_node_options_unsupported":

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -824,22 +824,26 @@ class ComputeNodeRuntime:
                     if isinstance(exception_type, str):
                         diagnostics["api_v1_readiness_completion_smoke_exception_type"] = exception_type
                     worker_diagnostics = smoke_error.get("worker_diagnostics")
+                    safe_worker_diagnostics: Dict[str, Any] = {}
                     if isinstance(worker_diagnostics, dict):
+                        safe_worker_diagnostics = _safe_completion_smoke_worker_diagnostics(worker_diagnostics)
                         diagnostics["api_v1_readiness_completion_smoke_worker_diagnostics"] = (
-                            _safe_completion_smoke_worker_diagnostics(worker_diagnostics)
+                            safe_worker_diagnostics
                         )
                     for key in (
                         "runtime_healthy",
                         "recovery_attempted",
                         "recovery_succeeded",
                         "rejected_option",
-    "rejected_generation_kwarg",
-    "attempted_generation_kwargs",
-    "attempted_plain_completion_methods",
-    "result_shape",
+                        "rejected_generation_kwarg",
+                        "attempted_generation_kwargs",
+                        "attempted_plain_completion_methods",
+                        "result_shape",
                     ):
                         if key in smoke_error:
                             diagnostics[f"api_v1_readiness_completion_smoke_{key}"] = smoke_error[key]
+                        elif key in safe_worker_diagnostics:
+                            diagnostics[f"api_v1_readiness_completion_smoke_{key}"] = safe_worker_diagnostics[key]
                 elif (
                     smoke_message is not None
                     and smoke_message.get("role") == "assistant"

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -265,6 +265,14 @@ def _completion_smoke_reason_from_api_v1_error(error: Dict[str, Any]) -> str:
         return "runtime_completion_smoke_worker_timeout"
     if internal_reason in {"worker_dead", "runtime_worker_dead"}:
         return "runtime_completion_smoke_worker_dead"
+    # Map new plain-completion diagnostic categories surfaced by the subprocess worker.
+    generation_exception_category = error.get("generation_exception_category")
+    if generation_exception_category == "empty_completion_output":
+        return "runtime_completion_smoke_plain_completion_empty_output"
+    if generation_exception_category == "thinking_leaked":
+        return "runtime_completion_smoke_plain_completion_thinking_leaked"
+    if generation_exception_category == "malformed_completion_output":
+        return "runtime_completion_smoke_plain_completion_malformed_output"
     if error.get("code") == "compute_node_invalid_model_output":
         return "runtime_completion_smoke_invalid_model_output"
     if error.get("code") == "compute_node_options_unsupported":

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -50,7 +50,16 @@ _COMPLETION_SMOKE_REASON_BY_CATEGORY = {
     "metal_memory_allocation": "runtime_completion_smoke_metal_memory_allocation",
     "kv_cache_allocation": "runtime_completion_smoke_kv_cache_allocation",
     "rope_yarn_eval_failure": "runtime_completion_smoke_rope_yarn_eval_failure",
-    "unsupported_generation_kwarg": "runtime_completion_smoke_unsupported_generation_kwarg",
+    "unsupported_generation_kwarg": "runtime_completion_smoke_plain_completion_unexpected_kwarg",
+    "unexpected_kwarg": "runtime_completion_smoke_plain_completion_unexpected_kwarg",
+    "unsupported_prompt_kwarg": "runtime_completion_smoke_plain_completion_method_shape",
+    "unsupported_stream_kwarg": "runtime_completion_smoke_plain_completion_unexpected_kwarg",
+    "unsupported_stop_kwarg": "runtime_completion_smoke_plain_completion_unexpected_kwarg",
+    "method_shape": "runtime_completion_smoke_plain_completion_method_shape",
+    "malformed_completion_output": "runtime_completion_smoke_plain_completion_malformed_output",
+    "empty_completion_output": "runtime_completion_smoke_plain_completion_empty_output",
+    "thinking_leaked": "runtime_completion_smoke_plain_completion_thinking_leaked",
+    "worker_exception": "runtime_completion_smoke_plain_completion_worker_exception",
     "worker_timeout": "runtime_completion_smoke_worker_timeout",
     "worker_dead": "runtime_completion_smoke_worker_dead",
 }
@@ -61,6 +70,10 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_KEYS = {
     "generation_exception_category",
     "exception_type",
     "rejected_option",
+    "rejected_generation_kwarg",
+    "attempted_generation_kwargs",
+    "attempted_plain_completion_methods",
+    "result_shape",
     "method",
     "stream",
     "retryable",
@@ -92,16 +105,28 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "runtime_chat_template_renderer_unavailable",
         "runtime_template_tokenizer_bridge_unavailable",
         "malformed_completion_output",
+        "empty_completion_output",
+        "thinking_leaked",
     },
     "generation_exception_category": {
         "metal_memory_allocation",
         "kv_cache_allocation",
         "rope_yarn_eval_failure",
         "unsupported_generation_kwarg",
+        "unexpected_kwarg",
+        "unsupported_prompt_kwarg",
+        "unsupported_stream_kwarg",
+        "unsupported_stop_kwarg",
+        "method_shape",
+        "worker_exception",
+        "empty_completion_output",
+        "thinking_leaked",
         "worker_timeout",
         "worker_dead",
         "unknown_generation_exception",
         "malformed_completion_output",
+        "empty_completion_output",
+        "thinking_leaked",
     },
     "method": {
         "apply_chat_template",
@@ -110,6 +135,9 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "render_and_tokenize_chat",
         "create_chat_completion_from_rendered_prompt",
         "create_completion_from_rendered_prompt",
+        "create_completion_keyword_prompt",
+        "create_completion_positional_prompt",
+        "llama_call_positional_prompt",
         "tokenize",
     },
     "kv_cache_mode": {"f16", "q8_0", "q4_0", "auto", "unknown"},
@@ -148,8 +176,13 @@ def _safe_completion_smoke_worker_diagnostic_value(key: str, value: Any) -> Any:
         return bounded if bounded in enum_values else None
     if key == "exception_type":
         return bounded if _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_CLASS_RE.fullmatch(bounded) else None
-    if key in {"rejected_option", "profile_id", "context_tier", "type_k", "type_v"}:
+    if key in {"rejected_option", "rejected_generation_kwarg", "profile_id", "context_tier", "type_k", "type_v", "result_shape"}:
         return bounded if _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(bounded) else None
+    if key in {"attempted_generation_kwargs", "attempted_plain_completion_methods"}:
+        names = [part for part in bounded.split(",") if part]
+        if names and all(_SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(part) for part in names):
+            return ",".join(names[:32])
+        return None
     if key == "sanitized_error_summary":
         return (
             bounded
@@ -792,6 +825,10 @@ class ComputeNodeRuntime:
                         "recovery_attempted",
                         "recovery_succeeded",
                         "rejected_option",
+    "rejected_generation_kwarg",
+    "attempted_generation_kwargs",
+    "attempted_plain_completion_methods",
+    "result_shape",
                     ):
                         if key in smoke_error:
                             diagnostics[f"api_v1_readiness_completion_smoke_{key}"] = smoke_error[key]

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -12,6 +12,7 @@ import importlib
 import importlib.metadata
 import inspect
 import subprocess
+import tempfile
 import queue
 import signal
 import threading
@@ -1498,20 +1499,41 @@ class _SubprocessLlamaProxy:
         self._timeout_seconds = timeout_seconds if timeout_seconds is not None else _runtime_stage_timeout_seconds()
         self._lock = Lock()
         self._closed = False
-        command = [sys.executable, '-u', '-c', _llama_cpp_runtime_worker_code(_LLAMA_CPP_RUNTIME_WORKER_CODE)]
+        self._worker_tmpfile: Optional[str] = None
+        code = _llama_cpp_runtime_worker_code(_LLAMA_CPP_RUNTIME_WORKER_CODE)
+        # Write worker code to a temp file to avoid Windows command-line length
+        # limit (CreateProcess caps at 32767 chars; the code is ~36KB).
+        try:
+            fd, tmppath = tempfile.mkstemp(suffix='.py', prefix='_token_place_worker_')
+            with os.fdopen(fd, 'w', encoding='utf-8') as f:
+                f.write(code)
+            self._worker_tmpfile = tmppath
+            command = [sys.executable, '-u', tmppath]
+        except Exception:
+            self._worker_tmpfile = None
+            command = [sys.executable, '-u', '-c', code]
         env = _llama_cpp_runtime_worker_env()
         cwd = _llama_cpp_probe_subprocess_cwd()
-        self._process = subprocess.Popen(
-            command,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            env=env,
-            cwd=cwd,
-            bufsize=1,
-        )
-        self._process._token_place_command = [command[0], command[1], '<runtime-worker-code>']  # type: ignore[attr-defined]
+        try:
+            self._process = subprocess.Popen(
+                command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+                cwd=cwd,
+                bufsize=1,
+            )
+        except OSError:
+            if self._worker_tmpfile:
+                try:
+                    os.unlink(self._worker_tmpfile)
+                except Exception:
+                    pass
+                self._worker_tmpfile = None
+            raise
+        self._process._token_place_command = [command[0], '<runtime-worker-script>' if self._worker_tmpfile else '<runtime-worker-code>']  # type: ignore[attr-defined]
         self._process._token_place_cwd = cwd  # type: ignore[attr-defined]
         self._process._token_place_import_root = env.get('TOKEN_PLACE_PYTHON_IMPORT_ROOT', '')  # type: ignore[attr-defined]
         self._process._token_place_module_path_hint = module_path_hint or ''  # type: ignore[attr-defined]
@@ -1701,6 +1723,13 @@ class _SubprocessLlamaProxy:
                     self._process.kill()
                 except Exception:
                     pass
+        tmpfile = getattr(self, '_worker_tmpfile', None)
+        if tmpfile:
+            try:
+                os.unlink(tmpfile)
+            except Exception:
+                pass
+            self._worker_tmpfile = None
 
     def __del__(self) -> None:
         try:

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1862,7 +1862,7 @@ def _plain_completion_method_shape_category(exc):
         return 'unsupported_stream_kwarg'
     if rejected == 'stop':
         return 'unsupported_stop_kwarg'
-    if 'positional argument' in text or 'were given' in text or 'missing required positional argument' in text:
+    if 'positional argument' in text or 'positional-only argument' in text or 'were given' in text or 'missing required positional argument' in text:
         return 'method_shape'
     if rejected is not None:
         return 'unexpected_kwarg'

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1819,6 +1819,73 @@ def _classify_generation_exception(exc):
         return 'unsupported_generation_kwarg'
     return 'unknown_generation_exception'
 
+def _plain_completion_method_shape_category(exc):
+    text = str(exc or '').lower()
+    rejected = _extract_unsupported_generation_kwarg(text)
+    if rejected == 'prompt':
+        return 'unsupported_prompt_kwarg'
+    if rejected == 'stream':
+        return 'unsupported_stream_kwarg'
+    if rejected == 'stop':
+        return 'unsupported_stop_kwarg'
+    if 'positional argument' in text or 'were given' in text or 'missing required positional argument' in text:
+        return 'method_shape'
+    if rejected is not None:
+        return 'unexpected_kwarg'
+    return 'worker_exception'
+
+def _completion_result_shape(result):
+    if isinstance(result, str):
+        return 'direct_string'
+    if isinstance(result, dict):
+        choices = result.get('choices')
+        if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+            choice = choices[0]
+            if isinstance(choice.get('text'), str):
+                return 'choices_text'
+            message = choice.get('message')
+            if isinstance(message, dict):
+                return 'choices_message'
+        return 'dict_malformed'
+    return type(result).__name__
+
+def _normalize_plain_completion_result(result):
+    text = None
+    if isinstance(result, str):
+        text = result
+    elif isinstance(result, dict):
+        choices = result.get('choices')
+        if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+            choice = choices[0]
+            message = choice.get('message')
+            if isinstance(choice.get('text'), str):
+                text = choice.get('text')
+            elif isinstance(message, dict):
+                content = message.get('content')
+                if isinstance(content, str):
+                    text = content
+    if not isinstance(text, str):
+        return None, 'malformed_completion_output'
+    cleaned = text.strip()
+    lower_cleaned = cleaned.lower()
+    if lower_cleaned.startswith('<think>'):
+        end = lower_cleaned.find('</think>')
+        if end >= 0:
+            think_body = cleaned[len('<think>'):end].strip()
+            if think_body:
+                return None, 'thinking_leaked'
+            cleaned = cleaned[end + len('</think>'):].lstrip()
+            lower_cleaned = cleaned.lower()
+        else:
+            return None, 'thinking_leaked'
+    if '<think>' in lower_cleaned or '</think>' in lower_cleaned:
+        return None, 'thinking_leaked'
+    if cleaned.endswith('<|im_end|>'):
+        cleaned = cleaned[:-len('<|im_end|>')].rstrip()
+    if not cleaned:
+        return None, 'empty_completion_output'
+    return {'choices': [{'message': {'role': 'assistant', 'content': cleaned}}]}, None
+
 def _safe_request_error(reason, *, request=None, exc=None, extra=None):
     diagnostics = {'reason': reason}
     if reason == 'malformed_completion_output':
@@ -1829,10 +1896,11 @@ def _safe_request_error(reason, *, request=None, exc=None, extra=None):
                 diagnostics[key] = value
     if isinstance(request, dict):
         method = request.get('method')
-        if method in {'create_chat_completion', 'create_chat_completion_from_rendered_prompt'}:
-            diagnostics['method'] = method
-        elif method is not None:
-            diagnostics['method'] = 'unsupported'
+        if 'method' not in diagnostics:
+            if method in {'create_chat_completion', 'create_chat_completion_from_rendered_prompt'}:
+                diagnostics['method'] = method
+            elif method is not None:
+                diagnostics['method'] = 'unsupported'
         kwargs = request.get('kwargs')
         if isinstance(kwargs, dict):
             diagnostics['stream'] = bool(kwargs.get('stream'))
@@ -2266,37 +2334,71 @@ for line in sys.stdin:
                 else:
                     _emit(_safe_request_error(reason, request=request, exc=exc))
                     continue
-            completion_kwargs = {
-                key: kwargs[key]
-                for key in (
-                    'max_tokens', 'temperature', 'top_p', 'top_k', 'min_p', 'stop',
-                    'presence_penalty', 'frequency_penalty', 'repeat_penalty', 'seed', 'stream'
-                )
-                if key in kwargs
-            }
-            completion_kwargs['stream'] = False
-            stop = completion_kwargs.get('stop')
-            if stop is None:
-                stop_values = ['<|im_end|>']
-            elif isinstance(stop, list):
-                stop_values = list(stop)
-                if '<|im_end|>' not in stop_values:
-                    stop_values.append('<|im_end|>')
-            else:
-                stop_values = [stop, '<|im_end|>'] if stop != '<|im_end|>' else [stop]
-            completion_kwargs['stop'] = stop_values
-            result = llama.create_completion(prompt=rendered_prompt, **completion_kwargs)
-            if not isinstance(result, dict):
-                _emit(_safe_request_error('malformed_completion_output', request=request, extra=render_diagnostics))
+            max_tokens = kwargs.get('max_tokens', 64)
+            if not isinstance(max_tokens, int) or isinstance(max_tokens, bool) or max_tokens <= 0:
+                max_tokens = 64
+            attempts = []
+            result = None
+            completion_error = None
+            create_completion = getattr(llama, 'create_completion', None)
+            if callable(create_completion):
+                attempt_method = 'create_completion_keyword_prompt'
+                attempted_kwargs = ['max_tokens', 'prompt']
+                try:
+                    result = create_completion(prompt=rendered_prompt, max_tokens=max_tokens)
+                    completion_error = None
+                    attempts.append({'method': attempt_method, 'attempted_kwarg_names': ','.join(attempted_kwargs), 'result_shape': _completion_result_shape(result)})
+                except Exception as exc:
+                    category = _plain_completion_method_shape_category(exc)
+                    rejected = _extract_unsupported_generation_kwarg(str(exc), attempted_kwargs)
+                    attempts.append({'method': attempt_method, 'attempted_kwarg_names': ','.join(attempted_kwargs), 'exception_type': type(exc).__name__, 'generation_exception_category': category, 'rejected_generation_kwarg': rejected or ''})
+                    completion_error = exc
+                    if category == 'unsupported_prompt_kwarg' or rejected == 'prompt':
+                        attempt_method = 'create_completion_positional_prompt'
+                        attempted_kwargs = ['max_tokens']
+                        try:
+                            result = create_completion(rendered_prompt, max_tokens=max_tokens)
+                            completion_error = None
+                            attempts.append({'method': attempt_method, 'attempted_kwarg_names': ','.join(attempted_kwargs), 'result_shape': _completion_result_shape(result)})
+                        except Exception as positional_exc:
+                            category = _plain_completion_method_shape_category(positional_exc)
+                            rejected = _extract_unsupported_generation_kwarg(str(positional_exc), attempted_kwargs)
+                            attempts.append({'method': attempt_method, 'attempted_kwarg_names': ','.join(attempted_kwargs), 'exception_type': type(positional_exc).__name__, 'generation_exception_category': category, 'rejected_generation_kwarg': rejected or ''})
+                            completion_error = positional_exc
+            if result is None and completion_error is not None and not (attempts and attempts[-1].get('method') == 'create_completion_keyword_prompt'):
+                pass
+            if result is None and callable(llama):
+                try:
+                    result = llama(rendered_prompt, max_tokens=max_tokens)
+                    completion_error = None
+                    attempts.append({'method': 'llama_call_positional_prompt', 'attempted_kwarg_names': 'max_tokens', 'result_shape': _completion_result_shape(result)})
+                except Exception as exc:
+                    attempts.append({'method': 'llama_call_positional_prompt', 'attempted_kwarg_names': 'max_tokens', 'exception_type': type(exc).__name__, 'generation_exception_category': _plain_completion_method_shape_category(exc), 'rejected_generation_kwarg': _extract_unsupported_generation_kwarg(str(exc), ['max_tokens']) or ''})
+                    completion_error = exc
+            if result is None:
+                extra = dict(render_diagnostics)
+                extra.update({
+                    'method': attempts[-1].get('method') if attempts else 'create_completion_from_rendered_prompt',
+                    'attempted_plain_completion_methods': ','.join(item.get('method', '') for item in attempts if item.get('method')),
+                    'attempted_generation_kwargs': ','.join(sorted(set(','.join(item.get('attempted_kwarg_names', '') for item in attempts).split(',')) - {''})),
+                    'generation_exception_category': attempts[-1].get('generation_exception_category', 'worker_exception') if attempts else 'worker_exception',
+                    'rejected_generation_kwarg': attempts[-1].get('rejected_generation_kwarg', '') if attempts else '',
+                })
+                _emit(_safe_request_error('inference_exception', request=request, exc=completion_error, extra=extra))
                 continue
-            choices = result.get('choices')
-            text = None
-            if isinstance(choices, list) and choices and isinstance(choices[0], dict):
-                text = choices[0].get('text')
-            if not isinstance(text, str):
-                _emit(_safe_request_error('malformed_completion_output', request=request, extra=render_diagnostics))
+            normalized, invalid_reason = _normalize_plain_completion_result(result)
+            if invalid_reason is not None:
+                extra = dict(render_diagnostics)
+                extra.update({
+                    'method': attempts[-1].get('method') if attempts else 'create_completion_from_rendered_prompt',
+                    'attempted_plain_completion_methods': ','.join(item.get('method', '') for item in attempts if item.get('method')),
+                    'attempted_generation_kwargs': ','.join(sorted(set(','.join(item.get('attempted_kwarg_names', '') for item in attempts).split(',')) - {''})),
+                    'generation_exception_category': invalid_reason,
+                    'result_shape': _completion_result_shape(result),
+                })
+                _emit(_safe_request_error(invalid_reason, request=request, extra=extra))
                 continue
-            _emit({'status': 'ok', 'result': {'choices': [{'message': {'role': 'assistant', 'content': text}}]}})
+            _emit({'status': 'ok', 'result': normalized})
             continue
         result = llama.create_chat_completion(*request.get('args', []), **kwargs)
         if kwargs.get('stream'):

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -2365,9 +2365,10 @@ for line in sys.stdin:
                             rejected = _extract_unsupported_generation_kwarg(str(positional_exc), attempted_kwargs)
                             attempts.append({'method': attempt_method, 'attempted_kwarg_names': ','.join(attempted_kwargs), 'exception_type': type(positional_exc).__name__, 'generation_exception_category': category, 'rejected_generation_kwarg': rejected or ''})
                             completion_error = positional_exc
-            if result is None and completion_error is not None and not (attempts and attempts[-1].get('method') == 'create_completion_keyword_prompt'):
-                pass
-            if result is None and callable(llama):
+            if result is None and callable(llama) and (
+                not attempts
+                or attempts[-1].get('generation_exception_category') != 'worker_exception'
+            ):
                 try:
                     result = llama(rendered_prompt, max_tokens=max_tokens)
                     completion_error = None

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1509,7 +1509,10 @@ class _SubprocessLlamaProxy:
                 f.write(code)
             self._worker_tmpfile = tmppath
             command = [sys.executable, '-u', tmppath]
-        except Exception:
+        except OSError:
+            # Temp file creation failed (e.g. disk full, permissions); fall back
+            # to the -c form which may exceed Windows' 32767-char limit but is
+            # better than not launching at all.
             self._worker_tmpfile = None
             command = [sys.executable, '-u', '-c', code]
         env = _llama_cpp_runtime_worker_env()
@@ -1526,6 +1529,8 @@ class _SubprocessLlamaProxy:
                 bufsize=1,
             )
         except OSError:
+            # Popen failed; clean up the temp file if one was created (when
+            # self._worker_tmpfile is None we were already using the -c fallback).
             if self._worker_tmpfile:
                 try:
                     os.unlink(self._worker_tmpfile)

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1817,6 +1817,8 @@ def _emit(payload):
 def _extract_unsupported_generation_kwarg(message, attempted=None):
     attempted_set = set(str(key) for key in attempted) if attempted is not None else None
     for pattern in (
+        r'positional-only (?:arguments?|keyword arguments?).*keyword arguments?:\\s*[\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',
+        r'positional-only (?:arguments?|keyword arguments?).*[\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',
         r'(?:got an )?unexpected keyword argument [\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',
         r'unsupported option(?:\\s+[\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]|\\s*:\\s*([A-Za-z_][A-Za-z0-9_]*))',
         r'invalid keyword(?: argument)? [\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -46,9 +46,11 @@ def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
 
 _UNSUPPORTED_GENERATION_KWARG_PATTERNS = (
     re.compile(r"(?:got an )?unexpected keyword argument [\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]"),
+    re.compile(r"unexpected keyword argument\s*:\s*([A-Za-z_][A-Za-z0-9_]*)"),
     re.compile(r"unsupported option(?:\s+[\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]|\s*:\s*([A-Za-z_][A-Za-z0-9_]*))"),
-    re.compile(r"invalid keyword(?: argument)? [\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]"),
+    re.compile(r"invalid keyword(?: argument)?(?:\s+[\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]|\s*:\s*([A-Za-z_][A-Za-z0-9_]*))"),
     re.compile(r"invalid keyword\s*=\s*([A-Za-z_][A-Za-z0-9_]*)"),
+    re.compile(r"got multiple values for keyword argument [\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]"),
 )
 
 
@@ -95,6 +97,8 @@ _SAFE_WORKER_DIAGNOSTIC_KEYS = {
     "rejected_option",
     "rejected_generation_kwarg",
     "attempted_generation_kwargs",
+    "attempted_plain_completion_methods",
+    "result_shape",
     "method",
     "stream",
     "retryable",
@@ -130,16 +134,31 @@ _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "runtime_chat_template_renderer_unavailable",
         "runtime_template_tokenizer_bridge_unavailable",
         "malformed_completion_output",
+        "empty_completion_output",
+        "thinking_leaked",
     },
     "generation_exception_category": {
         "metal_memory_allocation",
         "kv_cache_allocation",
         "rope_yarn_eval_failure",
         "unsupported_generation_kwarg",
+        "unexpected_kwarg",
+        "unsupported_prompt_kwarg",
+        "unsupported_stream_kwarg",
+        "unsupported_stop_kwarg",
+        "method_shape",
+        "worker_exception",
+        "malformed_completion_output",
+        "empty_completion_output",
+        "thinking_leaked",
+        "empty_completion_output",
+        "thinking_leaked",
         "worker_timeout",
         "worker_dead",
         "unknown_generation_exception",
         "malformed_completion_output",
+        "empty_completion_output",
+        "thinking_leaked",
     },
     "method": {
         "apply_chat_template",
@@ -147,6 +166,9 @@ _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "create_chat_completion_with_recovery",
         "create_chat_completion_from_rendered_prompt",
         "create_completion_from_rendered_prompt",
+        "create_completion_keyword_prompt",
+        "create_completion_positional_prompt",
+        "llama_call_positional_prompt",
         "render_and_tokenize_chat",
         "tokenize",
     },
@@ -184,9 +206,9 @@ def _safe_worker_diagnostic_value(key: str, value: Any) -> Any:
         return bounded if bounded in enum_values else None
     if key == "exception_type":
         return bounded if _SAFE_WORKER_DIAGNOSTIC_CLASS_RE.fullmatch(bounded) else None
-    if key in {"rejected_option", "rejected_generation_kwarg", "profile_id", "context_tier", "type_k", "type_v"}:
+    if key in {"rejected_option", "rejected_generation_kwarg", "profile_id", "context_tier", "type_k", "type_v", "result_shape"}:
         return bounded if _SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(bounded) else None
-    if key == "attempted_generation_kwargs":
+    if key in {"attempted_generation_kwargs", "attempted_plain_completion_methods"}:
         names = [part for part in bounded.split(",") if part]
         if names and all(_SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE.fullmatch(part) for part in names):
             return ",".join(names[:32])
@@ -3308,17 +3330,14 @@ class RelayClient:
         removed: List[str] = []
         attempted_names: List[str] = []
         while True:
-            completion_kwargs = {
-                key: value
-                for key, value in self._api_v1_runtime_completion_kwargs(safe_options).items()
-                if key in allowed_plain_kwargs
-            }
+            runtime_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
+            completion_kwargs = {"max_tokens": int(runtime_kwargs.get("max_tokens", 64) or 64)}
             removed_set = set(removed) | (set(getattr(self, "_api_v1_generation_kwargs_filtered", set())) - set(client_option_names))
             completion_kwargs = {
                 key: value for key, value in completion_kwargs.items() if key not in removed_set
             }
-            if "stream" not in removed_set:
-                completion_kwargs["stream"] = False
+            # Plain completion defaults to non-streaming in the subprocess worker.
+            # Keep this call minimal: prompt plus max_tokens, with only render metadata below.
             if model_profile.get("provider") and "token_place_provider" not in removed_set:
                 completion_kwargs["token_place_provider"] = model_profile.get("provider")
             if model_profile.get("chat_template_policy") and "token_place_template_policy" not in removed_set:
@@ -3471,6 +3490,9 @@ class RelayClient:
             if message is None:
                 self._last_api_v1_invalid_model_output_reason = "unsupported_completion_shape"
             return message
+
+        if isinstance(completion, str) and completion.strip():
+            return {"role": "assistant", "content": completion}
 
         # API v1 relay inference is explicitly non-streaming; runtimes must return
         # a complete chat completion object for this path.
@@ -3736,6 +3758,31 @@ class RelayClient:
                 )
                 started = time.monotonic()
                 if callable(qwen_render_complete):
+                    unsupported_plain_options = sorted(
+                        key for key in set(safe_options) - {"max_tokens", "stream"}
+                    )
+                    if unsupported_plain_options:
+                        rejected_option = unsupported_plain_options[0]
+                        return self._api_v1_response_envelope(
+                            request_id,
+                            error=self._api_v1_enrich_safe_error(
+                                {
+                                    "code": "compute_node_options_unsupported",
+                                    "message": (
+                                        "Requested option is unsupported by the Qwen plain completion runtime: "
+                                        f"{rejected_option}"
+                                    ),
+                                    "exception_category": "unsupported_generation_kwarg",
+                                },
+                                request_id=request_id,
+                                requested_context_tier=requested_context_tier,
+                                prompt_tokens=prompt_tokens,
+                                requested_output_tokens=requested_output_tokens,
+                                internal_reason="unsupported_generation_option",
+                                rejected_option=rejected_option,
+                                retryable=False,
+                            ),
+                        )
                     completion, generation_kwarg_diagnostics = self._api_v1_create_completion_from_rendered_prompt_filtered(
                         qwen_render_complete,
                         messages=runtime_messages,

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -151,14 +151,9 @@ _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "malformed_completion_output",
         "empty_completion_output",
         "thinking_leaked",
-        "empty_completion_output",
-        "thinking_leaked",
         "worker_timeout",
         "worker_dead",
         "unknown_generation_exception",
-        "malformed_completion_output",
-        "empty_completion_output",
-        "thinking_leaked",
     },
     "method": {
         "apply_chat_template",
@@ -3323,10 +3318,6 @@ class RelayClient:
     ) -> Tuple[Any, Dict[str, Any]]:
         """Call Qwen render-then-plain-completion while filtering rejected kwargs."""
 
-        allowed_plain_kwargs = {
-            "max_tokens", "temperature", "top_p", "top_k", "min_p", "stop",
-            "presence_penalty", "frequency_penalty", "repeat_penalty", "seed", "stream",
-        }
         removed: List[str] = []
         attempted_names: List[str] = []
         while True:
@@ -3492,7 +3483,14 @@ class RelayClient:
             return message
 
         if isinstance(completion, str) and completion.strip():
-            return {"role": "assistant", "content": completion}
+            model_profile = getattr(self.model_manager, "model_profile", {}) or {}
+            cleaned_content, invalid_reason = self._api_v1_normalize_qwen_non_thinking_content(
+                model_profile, completion
+            )
+            if invalid_reason is not None:
+                self._last_api_v1_invalid_model_output_reason = invalid_reason
+                return None
+            return {"role": "assistant", "content": cleaned_content}
 
         # API v1 relay inference is explicitly non-streaming; runtimes must return
         # a complete chat completion object for this path.


### PR DESCRIPTION
### Motivation
- Qwen 64K readiness reached the render-then-complete branch but failed because the subprocess worker sent chat/sampling-shaped kwargs to plain completion and did not return precise child-worker diagnostics.
- The change aims to make the child-worker plain completion invocation minimal and to surface exact, safe diagnostics so readiness failures point to the rejected kwarg or method-shape immediately.

### Description
- Make the subprocess plain-completion smoke call truly minimal by sending only `max_tokens` (with safe defaults) plus non-sensitive render metadata such as `token_place_provider` and `enable_thinking`, and avoid sending `stream`, sampling, `stop`, or other chat-only fields by default; adjust `relay_client` to enforce this minimal call for Qwen render-then-complete.
- Add bounded child-worker fallback method shapes inside the subprocess facade: try `create_completion(prompt=..., max_tokens=...)`, fall back to `create_completion(rendered_prompt, max_tokens=...)`, then to callable `llama(rendered_prompt, max_tokens=...)`, and capture method-specific failures without returning the rendered prompt.
- Add robust parsing and classification of rejected kwargs and method-shape errors (`_extract_unsupported_generation_kwarg`, `_plain_completion_method_shape_category`) and extend worker diagnostics allowlist with keys such as `rejected_generation_kwarg`, `attempted_plain_completion_methods`, `attempted_generation_kwargs`, and `result_shape` while redacting prompt/content.
- Normalize accepted plain-completion result shapes (`choices[0].text`, `choices[0].message.content`, direct string) to an API v1 assistant message and reject empty/non-string/malformed/think-leaking outputs; strip only empty `<think></think>` wrappers and trailing `<|im_end|>` artifacts.
- Map new safe completion exception categories to more specific readiness reasons (e.g. `runtime_completion_smoke_plain_completion_unexpected_kwarg`, `runtime_completion_smoke_plain_completion_method_shape`, `runtime_completion_smoke_plain_completion_malformed_output`, etc.) and include safe fields like `rejected_kwarg`, `attempted_methods`, `attempted_kwarg_names`, `result_shape`, `exception_type`, and `exception_category` in readiness diagnostics.
- Keep Qwen API v1 on render-then-complete by default and reject unproven client sampling options (returning `compute_node_options_unsupported`) instead of silently sending them in the minimal readiness call.
- Add and update unit and integration tests covering minimal kwargs, fallback shapes, rejected kwarg parsing, normalization of outputs, and packaged 64K fake-runtime scenarios; adjust test assertions accordingly.

### Testing
- Ran focused test suites and checks locally: `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/unit/test_relay_client.py -q`, `python -m pytest tests/unit/test_compute_node_runtime.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, and `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q`, and all ran green in this environment after the changes.
- Ran repository checks: `pre-commit run --all-files` passed and `git diff --check` returned no issues.
- Verification commands used are listed above and succeeded; remaining risks are runtime-specific (llama-cpp-python signatures across packaged macOS runtimes) so further staging verification on packaged macOS desktop with the real Metal runtime is recommended before shipping.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4acf6c3e0c832f8b53eacd7790a99a)