### PR TITLE
Fix Qwen packaged readiness diagnostics and render-template/plain-completion kwarg handling

### DIFF
--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -56,11 +56,22 @@ class Llama:
         if os.environ.get('TOKEN_PLACE_FAIL_ALL_PROFILES') == '1' or 'type_k' not in kwargs:
             print('ggml_metal: KV cache allocation failed while creating llama_context', file=sys.stderr, flush=True)
             raise ValueError('Failed to create llama_context')
+    metadata = {'tokenizer.chat_template': r'''{{ bos_token }}{% for message in messages %}<|im_start|>{{ message.role }}\n{{ message.content }}<|im_end|>{% endfor %}{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}'''}
     def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+        rejected = os.environ.get('TOKEN_PLACE_RENDER_REJECT_KWARG')
+        if rejected in {'tokenize', 'add_generation_prompt', 'enable_thinking'}:
+            raise TypeError(f"got an unexpected keyword argument '{rejected}'")
         return '<qwen>'
     def tokenize(self, payload, add_bos=False):
         return [1] * 42
-    def create_completion(self, prompt, **kwargs):
+    def create_completion(self, *args, **kwargs):
+        rejected = os.environ.get('TOKEN_PLACE_PLAIN_REJECT_KWARG')
+        if rejected == 'prompt' and 'prompt' in kwargs:
+            raise TypeError("got an unexpected keyword argument 'prompt'")
+        if rejected == 'max_tokens' and 'max_tokens' in kwargs:
+            raise TypeError("got an unexpected keyword argument 'max_tokens'")
+        if not args and 'prompt' not in kwargs:
+            raise TypeError("missing required positional argument 'prompt'")
 """
         + completion_branch,
         encoding='utf-8',
@@ -201,7 +212,7 @@ def _runtime_for(fake_runtime):
     ("category", "reason"),
     [
         ("kv_cache_allocation", "runtime_completion_smoke_kv_cache_allocation"),
-        ("unsupported_generation_kwarg", "runtime_completion_smoke_unsupported_generation_kwarg"),
+        ("unsupported_generation_kwarg", "runtime_completion_smoke_plain_completion_unexpected_kwarg"),
         ("rope_yarn_eval_failure", "runtime_completion_smoke_rope_yarn_eval_failure"),
         ("worker_timeout", "runtime_completion_smoke_worker_timeout"),
         ("worker_dead", "runtime_completion_smoke_worker_dead"),
@@ -253,6 +264,48 @@ def test_qwen64k_packaged_subprocess_generation_error_preserves_safe_diagnostics
     finally:
         proxy.close()
 
+
+
+def test_qwen64k_packaged_subprocess_render_kwarg_rejection_uses_safe_jinja_fallback(tmp_path, monkeypatch):
+    runtime_root = tmp_path / 'runtime'
+    _write_fake_llama_cpp_runtime(runtime_root)
+    monkeypatch.syspath_prepend(str(runtime_root))
+    monkeypatch.setenv('TOKEN_PLACE_RENDER_REJECT_KWARG', 'tokenize')
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='Qwen3-8B-Q4_K_M.gguf', type_k=8, type_v=8, timeout_seconds=5)
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt([{'role': 'user', 'content': 'SECRET_PROMPT'}], max_tokens=1, enable_thinking=False, token_place_provider='qwen')
+        assert result['choices'][0]['message']['content'] == 'ok'
+        assert 'SECRET_PROMPT' not in str(getattr(proxy, 'last_diagnostics', {}))
+    finally:
+        proxy.close()
+
+
+def test_qwen64k_packaged_subprocess_plain_completion_max_tokens_rejection_is_precise_safe(tmp_path, monkeypatch):
+    runtime_root = tmp_path / 'runtime'
+    _write_fake_llama_cpp_runtime(runtime_root)
+    monkeypatch.syspath_prepend(str(runtime_root))
+    monkeypatch.setenv('TOKEN_PLACE_PLAIN_REJECT_KWARG', 'max_tokens')
+
+    proxy = model_manager_module._SubprocessLlamaProxy(model_path='Qwen3-8B-Q4_K_M.gguf', type_k=8, type_v=8, timeout_seconds=5)
+    try:
+        with pytest.raises(LlamaCppInferenceRequestError) as exc_info:
+            proxy.create_chat_completion_from_rendered_prompt([{'role': 'user', 'content': 'SECRET_PROMPT'}], max_tokens=1, enable_thinking=False, token_place_provider='qwen')
+        diagnostics = exc_info.value.diagnostics
+        assert diagnostics['generation_exception_category'] in {'unexpected_kwarg', 'unsupported_generation_kwarg'}
+        assert diagnostics['rejected_generation_kwarg'] == 'max_tokens'
+        assert diagnostics['attempted_plain_completion_methods'] == 'create_completion_keyword_prompt'
+        assert 'SECRET_PROMPT' not in str(diagnostics)
+
+        runtime, manager = _runtime_for(proxy)
+        assert runtime.ensure_api_v1_runtime_ready() is False
+        ready_diagnostics = manager.last_compute_diagnostics
+        assert ready_diagnostics['api_v1_readiness_error_reason'] == 'runtime_completion_smoke_plain_completion_unexpected_kwarg'
+        assert ready_diagnostics['api_v1_readiness_completion_smoke_rejected_generation_kwarg'] == 'max_tokens'
+        assert ready_diagnostics['api_v1_readiness_completion_smoke_attempted_plain_completion_methods'] == 'create_completion_keyword_prompt'
+        assert 'SECRET_PROMPT' not in str(ready_diagnostics)
+    finally:
+        proxy.close()
 
 def test_qwen64k_packaged_fake_runtime_valid_generation_passes_readiness():
     runtime, manager = _runtime_for(_Qwen64kFakeRuntime())

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -145,8 +145,9 @@ def test_completion_smoke_worker_diagnostic_sanitizer_drops_unsafe_shapes():
         ({"worker_diagnostics": {"generation_exception_category": "empty_completion_output"}}, "runtime_completion_smoke_plain_completion_empty_output"),
         ({"worker_diagnostics": {"generation_exception_category": "thinking_leaked"}}, "runtime_completion_smoke_plain_completion_thinking_leaked"),
         ({"worker_diagnostics": {"generation_exception_category": "malformed_completion_output"}}, "runtime_completion_smoke_plain_completion_malformed_output"),
-        # Top-level takes precedence over nested.
-        ({"generation_exception_category": "empty_completion_output", "worker_diagnostics": {"generation_exception_category": "thinking_leaked"}}, "runtime_completion_smoke_plain_completion_empty_output"),
+        # Nested worker diagnostics take precedence over generic or stale top-level wrappers.
+        ({"generation_exception_category": "empty_completion_output", "worker_diagnostics": {"generation_exception_category": "thinking_leaked"}}, "runtime_completion_smoke_plain_completion_thinking_leaked"),
+        ({"internal_reason": "unsupported_generation_option", "worker_diagnostics": {"generation_exception_category": "unsupported_generation_kwarg"}}, "runtime_completion_smoke_plain_completion_unexpected_kwarg"),
     ],
 )
 def test_completion_smoke_reason_from_api_v1_error_maps_runtime_reasons(error, expected_reason):

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -249,6 +249,16 @@ def _completion_smoke_reason_from_api_v1_error(error: Dict[str, Any]) -> str:
         return "runtime_completion_smoke_thinking_leaked"
     if internal_reason == "qwen_empty_after_think_wrapper_strip":
         return "runtime_completion_smoke_empty_after_think_strip"
+    # Prefer precise subprocess worker diagnostics over generic relay/internal
+    # wrappers such as unsupported_generation_option.  The API v1 relay path
+    # nests child-worker details inside worker_diagnostics.
+    worker_diag = error.get("worker_diagnostics")
+    nested_category = worker_diag.get("generation_exception_category") if isinstance(worker_diag, dict) else None
+    if nested_category in _COMPLETION_SMOKE_REASON_BY_CATEGORY:
+        return _COMPLETION_SMOKE_REASON_BY_CATEGORY[str(nested_category)]
+    generation_exception_category = error.get("generation_exception_category")
+    if generation_exception_category in _COMPLETION_SMOKE_REASON_BY_CATEGORY:
+        return _COMPLETION_SMOKE_REASON_BY_CATEGORY[str(generation_exception_category)]
     if internal_reason in {
         "unsupported_generation_option",
         "runtime_rejected_generation_options",
@@ -265,16 +275,6 @@ def _completion_smoke_reason_from_api_v1_error(error: Dict[str, Any]) -> str:
         return "runtime_completion_smoke_worker_timeout"
     if internal_reason in {"worker_dead", "runtime_worker_dead"}:
         return "runtime_completion_smoke_worker_dead"
-    # Map plain-completion diagnostic categories surfaced by the subprocess worker.
-    # Check both the top-level error dict and nested worker_diagnostics, since the
-    # relay path carries child-worker details inside worker_diagnostics.
-    generation_exception_category = error.get("generation_exception_category")
-    if not generation_exception_category:
-        worker_diag = error.get("worker_diagnostics")
-        if isinstance(worker_diag, dict):
-            generation_exception_category = worker_diag.get("generation_exception_category")
-    if generation_exception_category and generation_exception_category in _COMPLETION_SMOKE_REASON_BY_CATEGORY:
-        return _COMPLETION_SMOKE_REASON_BY_CATEGORY[generation_exception_category]
     if error.get("code") == "compute_node_invalid_model_output":
         return "runtime_completion_smoke_invalid_model_output"
     if error.get("code") == "compute_node_options_unsupported":

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -2142,6 +2142,8 @@ def _render_chat_with_runtime_template(llama, args, kwargs):
     kwargs = dict(kwargs)
     provider_hint = str(kwargs.pop('token_place_provider', '') or '').lower()
     policy_hint = str(kwargs.pop('token_place_template_policy', '') or '').lower()
+    template, metadata_qwen_evidence = _runtime_chat_template(llama)
+    qwen_safe = metadata_qwen_evidence or provider_hint == 'qwen' or 'qwen' in policy_hint
     render = getattr(llama, 'apply_chat_template', None)
     direct_apply_available = callable(render)
     if not direct_apply_available:
@@ -2160,19 +2162,50 @@ def _render_chat_with_runtime_template(llama, args, kwargs):
                 'jinja_renderer': False,
             }
         except TypeError as exc:
-            if 'enable_thinking' not in kwargs or not _type_error_is_unexpected_keyword(exc, 'enable_thinking'):
+            rejected_render_kwarg = None
+            for candidate in ('enable_thinking', 'tokenize', 'add_generation_prompt'):
+                if candidate in kwargs and _type_error_is_unexpected_keyword(exc, candidate):
+                    rejected_render_kwarg = candidate
+                    break
+            if rejected_render_kwarg is None:
+                raise
+            attempted_render_kwargs = ','.join(sorted(str(key) for key in kwargs))
+            if qwen_safe and isinstance(template, str) and template.strip() and _jinja_renderer_available():
+                messages = args[0] if args else kwargs.get('messages')
+                if not isinstance(messages, list):
+                    raise RuntimeError('runtime_chat_template_render_exception')
+                rendered = _render_gguf_jinja_chat_template(
+                    template,
+                    messages,
+                    llama,
+                    add_generation_prompt=bool(kwargs.get('add_generation_prompt', True)),
+                    enable_thinking=kwargs.get('enable_thinking'),
+                )
+                return rendered, {
+                    'direct_apply_chat_template': direct_apply_available,
+                    'metadata_template': True,
+                    'jinja_renderer': True,
+                    'qwen_evidence': True,
+                    'method': 'apply_chat_template',
+                    'generation_exception_category': 'unsupported_generation_kwarg',
+                    'rejected_generation_kwarg': rejected_render_kwarg,
+                    'attempted_generation_kwargs': attempted_render_kwargs,
+                }
+            if rejected_render_kwarg == 'enable_thinking' and qwen_safe:
                 raise
             compatibility_kwargs = dict(kwargs)
-            compatibility_kwargs.pop('enable_thinking', None)
+            compatibility_kwargs.pop(rejected_render_kwarg, None)
             return render(*args, **compatibility_kwargs), {
                 'direct_apply_chat_template': direct_apply_available,
                 'metadata_template': False,
                 'jinja_renderer': False,
+                'method': 'apply_chat_template',
+                'generation_exception_category': 'unsupported_generation_kwarg',
+                'rejected_generation_kwarg': rejected_render_kwarg,
+                'attempted_generation_kwargs': attempted_render_kwargs,
             }
-    template, metadata_qwen_evidence = _runtime_chat_template(llama)
     if not isinstance(template, str) or not template.strip():
         raise RuntimeError('runtime_chat_template_metadata_missing')
-    qwen_safe = metadata_qwen_evidence or provider_hint == 'qwen' or 'qwen' in policy_hint
     if not qwen_safe:
         raise RuntimeError('runtime_chat_template_qwen_evidence_missing')
     if not _jinja_renderer_available():


### PR DESCRIPTION
### Motivation
- Address a packaged desktop compute-node readiness failure where API v1 Qwen3 64k-full readiness smoke surfaced a generic `runtime_completion_smoke_unsupported_generation_kwarg` after the `qwen_render_then_plain_completion` branch. 
- Make rejected generation kwargs and attempted methods diagnosable and precise while preserving Qwen non-thinking enforcement and E2EE-safe diagnostics. 

### Description
- Add worker-level render-template recovery and diagnostics in `_render_chat_with_runtime_template` so direct `apply_chat_template` TypeErrors for `enable_thinking`, `tokenize`, or `add_generation_prompt` are detected, retried without the rejected render kwarg where safe, or else fall back to the GGUF/Jinja renderer for Qwen and return structured, safe worker diagnostics (`rejected_generation_kwarg`, `attempted_generation_kwargs`, `method`, `generation_exception_category`). 
- Keep the Qwen render-then-plain-completion path and restrict plain completion calls to minimal shapes (prompt + `max_tokens`), adding precise rejection extraction (`rejected_generation_kwarg`) and bounded attempted-method reporting for plain-completion attempts. 
- Prefer nested subprocess `worker_diagnostics` generation categories over generic top-level/internal reasons in `_completion_smoke_reason_from_api_v1_error` so subprocess-level `generation_exception_category` (e.g., `unsupported_generation_kwarg`) maps to the most specific readiness smoke reason (e.g., `runtime_completion_smoke_plain_completion_unexpected_kwarg`). 
- Add packaged-runtime regression tests that simulate: a) direct render kwarg rejection (e.g., runtime raising on `tokenize`) and verify safe GGUF/Jinja fallback and no plaintext leakage, and b) plain-completion rejection of `max_tokens` to assert precise `rejected_generation_kwarg`, `attempted_plain_completion_methods`, and readiness diagnostics are surfaced without including prompts. 
- Small test expectation updates to reflect the new precedence rule where nested worker diagnostics can override stale top-level wrappers. 

### Testing
- Ran unit and integration suites: `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/unit/test_relay_client.py -q`, `python -m pytest tests/unit/test_compute_node_runtime.py -q`, `python -m pytest tests/unit/test_context_profiles.py -q`, `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`, and `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q`, all of which passed in the verification run. 
- Ran the full unit and API test sets (`python -m pytest tests/unit/ -q`, `python -m pytest tests/test_api.py -q`) and the project checks; the test runs and `pre-commit run --all-files` completed successfully. 
- Tests explicitly assert that diagnostics include safe scalar fields (rejected kwarg, attempted kwargs, method, category) and that no plaintext prompts or rendered prompt content appear in the diagnostics output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c385c5380832fa8b8bb9f098f5f1c)