### PR TITLE
Fix Qwen render-then-plain-completion: render-kwarg retry, Jinja fallback, and precise readiness diagnostics

### DIFF
--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -201,7 +201,7 @@ def _runtime_for(fake_runtime):
     ("category", "reason"),
     [
         ("kv_cache_allocation", "runtime_completion_smoke_kv_cache_allocation"),
-        ("unsupported_generation_kwarg", "runtime_completion_smoke_unsupported_generation_kwarg"),
+        ("unsupported_generation_kwarg", "runtime_completion_smoke_plain_completion_unexpected_kwarg"),
         ("rope_yarn_eval_failure", "runtime_completion_smoke_rope_yarn_eval_failure"),
         ("worker_timeout", "runtime_completion_smoke_worker_timeout"),
         ("worker_dead", "runtime_completion_smoke_worker_dead"),

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -145,8 +145,8 @@ def test_completion_smoke_worker_diagnostic_sanitizer_drops_unsafe_shapes():
         ({"worker_diagnostics": {"generation_exception_category": "empty_completion_output"}}, "runtime_completion_smoke_plain_completion_empty_output"),
         ({"worker_diagnostics": {"generation_exception_category": "thinking_leaked"}}, "runtime_completion_smoke_plain_completion_thinking_leaked"),
         ({"worker_diagnostics": {"generation_exception_category": "malformed_completion_output"}}, "runtime_completion_smoke_plain_completion_malformed_output"),
-        # Top-level takes precedence over nested.
-        ({"generation_exception_category": "empty_completion_output", "worker_diagnostics": {"generation_exception_category": "thinking_leaked"}}, "runtime_completion_smoke_plain_completion_empty_output"),
+        # Nested worker diagnostics take precedence over generic/top-level bridge categories.
+        ({"generation_exception_category": "empty_completion_output", "worker_diagnostics": {"generation_exception_category": "thinking_leaked"}}, "runtime_completion_smoke_plain_completion_thinking_leaked"),
     ],
 )
 def test_completion_smoke_reason_from_api_v1_error_maps_runtime_reasons(error, expected_reason):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -5811,6 +5811,95 @@ def test_subprocess_worker_plain_completion_helpers_cover_safe_shapes():
 
 
 
+
+
+def test_llama_worker_render_complete_prefers_qwen_jinja_when_direct_template_rejects_enable_thinking(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'render reject fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        """
+class Llama:
+    def __init__(self, *args, **kwargs):
+        self.metadata = {
+            'general.name': 'Qwen3 test',
+            'tokenizer.chat_template': "{% for message in messages %}<|im_start|>{{ message['role'] }}\\n{{ message['content'] }}<|im_end|>{% endfor %}{% if enable_thinking == false %}<|im_start|>assistant\\n/no_think\\n{% endif %}",
+        }
+    def apply_chat_template(self, messages, **kwargs):
+        if 'enable_thinking' in kwargs:
+            raise TypeError("got an unexpected keyword argument 'enable_thinking'")
+        return 'unsafe direct template'
+    def create_completion(self, prompt, **kwargs):
+        if '/no_think' not in prompt:
+            return {'choices': [{'text': '<think>unsafe</think> visible'}]}
+        return {'choices': [{'text': 'safe ok'}]}
+""",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'Qwen3-8B-Q4_K_M.gguf'),
+        timeout_seconds=5,
+    )
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt(
+            [{'role': 'user', 'content': 'SECRET_PROMPT'}],
+            max_tokens=4,
+            token_place_provider='qwen',
+            token_place_template_policy='gguf-jinja',
+            enable_thinking=False,
+        )
+    finally:
+        proxy.close()
+
+    assert result['choices'][0]['message']['content'] == 'safe ok'
+
+
+def test_llama_worker_render_complete_reports_safe_render_kwarg_rejection(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'render failure fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        """
+class Llama:
+    def __init__(self, *args, **kwargs):
+        pass
+    def apply_chat_template(self, messages, **kwargs):
+        raise TypeError("got an unexpected keyword argument 'tokenize' for SECRET_PROMPT")
+    def create_completion(self, prompt, **kwargs):
+        return {'choices': [{'text': 'should not run'}]}
+""",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'Qwen3-8B-Q4_K_M.gguf'),
+        timeout_seconds=5,
+    )
+    try:
+        with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as exc_info:
+            proxy.create_chat_completion_from_rendered_prompt(
+                [{'role': 'user', 'content': 'SECRET_PROMPT'}],
+                max_tokens=4,
+                token_place_provider='qwen',
+                token_place_template_policy='gguf-jinja',
+                enable_thinking=False,
+            )
+    finally:
+        proxy.close()
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics['generation_exception_category'] == 'unsupported_generation_kwarg'
+    assert diagnostics['rejected_generation_kwarg'] == 'tokenize'
+    assert diagnostics['attempted_generation_kwargs'] == 'add_generation_prompt,enable_thinking,token_place_provider,token_place_template_policy,tokenize'
+    assert 'SECRET_PROMPT' not in json.dumps(diagnostics)
+
 def test_subprocess_proxy_uses_temp_worker_script_and_cleans_up(monkeypatch):
     from utils.llm import model_manager as model_manager_module
 

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -244,6 +244,16 @@ def _classify_completion_smoke_exception(exc: BaseException) -> Tuple[str, str, 
 
 
 def _completion_smoke_reason_from_api_v1_error(error: Dict[str, Any]) -> str:
+    # Prefer precise plain-completion worker diagnostics over generic bridge
+    # internal reasons.  The API v1 runtime bridge may wrap subprocess failures
+    # as ``unsupported_generation_option`` while the nested worker diagnostics
+    # still identify the exact render/plain-completion rejection surface.
+    generation_exception_category = error.get("generation_exception_category")
+    worker_diag = error.get("worker_diagnostics")
+    if isinstance(worker_diag, dict) and worker_diag.get("generation_exception_category"):
+        generation_exception_category = worker_diag.get("generation_exception_category")
+    if generation_exception_category and generation_exception_category in _COMPLETION_SMOKE_REASON_BY_CATEGORY:
+        return _COMPLETION_SMOKE_REASON_BY_CATEGORY[generation_exception_category]
     internal_reason = error.get("internal_reason")
     if internal_reason == "qwen_thinking_output_leaked":
         return "runtime_completion_smoke_thinking_leaked"
@@ -265,16 +275,6 @@ def _completion_smoke_reason_from_api_v1_error(error: Dict[str, Any]) -> str:
         return "runtime_completion_smoke_worker_timeout"
     if internal_reason in {"worker_dead", "runtime_worker_dead"}:
         return "runtime_completion_smoke_worker_dead"
-    # Map plain-completion diagnostic categories surfaced by the subprocess worker.
-    # Check both the top-level error dict and nested worker_diagnostics, since the
-    # relay path carries child-worker details inside worker_diagnostics.
-    generation_exception_category = error.get("generation_exception_category")
-    if not generation_exception_category:
-        worker_diag = error.get("worker_diagnostics")
-        if isinstance(worker_diag, dict):
-            generation_exception_category = worker_diag.get("generation_exception_category")
-    if generation_exception_category and generation_exception_category in _COMPLETION_SMOKE_REASON_BY_CATEGORY:
-        return _COMPLETION_SMOKE_REASON_BY_CATEGORY[generation_exception_category]
     if error.get("code") == "compute_node_invalid_model_output":
         return "runtime_completion_smoke_invalid_model_output"
     if error.get("code") == "compute_node_options_unsupported":

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1820,6 +1820,7 @@ def _extract_unsupported_generation_kwarg(message, attempted=None):
         r'positional-only (?:arguments?|keyword arguments?).*keyword arguments?:\\s*[\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',
         r'positional-only (?:arguments?|keyword arguments?).*[\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',
         r'(?:got an )?unexpected keyword argument [\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',
+        r'(?:got an )?unexpected keyword argument\\s+([A-Za-z_][A-Za-z0-9_]*)',
         r'unsupported option(?:\\s+[\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]|\\s*:\\s*([A-Za-z_][A-Za-z0-9_]*))',
         r'invalid keyword(?: argument)? [\\'"]([A-Za-z_][A-Za-z0-9_]*)[\\'"]',
         r'invalid keyword\\s*=\\s*([A-Za-z_][A-Za-z0-9_]*)',
@@ -2142,6 +2143,33 @@ def _render_chat_with_runtime_template(llama, args, kwargs):
     kwargs = dict(kwargs)
     provider_hint = str(kwargs.pop('token_place_provider', '') or '').lower()
     policy_hint = str(kwargs.pop('token_place_template_policy', '') or '').lower()
+    template, metadata_qwen_evidence = _runtime_chat_template(llama)
+    qwen_safe = metadata_qwen_evidence or provider_hint == 'qwen' or 'qwen' in policy_hint
+
+    def _render_with_metadata_template():
+        if not isinstance(template, str) or not template.strip():
+            raise RuntimeError('runtime_chat_template_metadata_missing')
+        if not qwen_safe:
+            raise RuntimeError('runtime_chat_template_qwen_evidence_missing')
+        if not _jinja_renderer_available():
+            raise RuntimeError('runtime_chat_template_renderer_unavailable')
+        messages = args[0] if args else kwargs.get('messages')
+        if not isinstance(messages, list):
+            raise RuntimeError('runtime_chat_template_render_exception')
+        rendered = _render_gguf_jinja_chat_template(
+            template,
+            messages,
+            llama,
+            add_generation_prompt=bool(kwargs.get('add_generation_prompt', True)),
+            enable_thinking=kwargs.get('enable_thinking'),
+        )
+        return rendered, {
+            'direct_apply_chat_template': False,
+            'metadata_template': True,
+            'jinja_renderer': True,
+            'qwen_evidence': True,
+        }
+
     render = getattr(llama, 'apply_chat_template', None)
     direct_apply_available = callable(render)
     if not direct_apply_available:
@@ -2160,39 +2188,24 @@ def _render_chat_with_runtime_template(llama, args, kwargs):
                 'jinja_renderer': False,
             }
         except TypeError as exc:
-            if 'enable_thinking' not in kwargs or not _type_error_is_unexpected_keyword(exc, 'enable_thinking'):
+            rejected = _extract_unsupported_generation_kwarg(
+                str(exc),
+                [key for key in ('enable_thinking', 'tokenize', 'add_generation_prompt') if key in kwargs],
+            )
+            if rejected not in {'enable_thinking', 'tokenize', 'add_generation_prompt'}:
                 raise
+            if qwen_safe and isinstance(template, str) and template.strip() and _jinja_renderer_available():
+                return _render_with_metadata_template()
             compatibility_kwargs = dict(kwargs)
-            compatibility_kwargs.pop('enable_thinking', None)
+            compatibility_kwargs.pop(rejected, None)
             return render(*args, **compatibility_kwargs), {
                 'direct_apply_chat_template': direct_apply_available,
                 'metadata_template': False,
                 'jinja_renderer': False,
+                'rejected_generation_kwarg': rejected,
+                'generation_exception_category': 'unsupported_generation_kwarg',
             }
-    template, metadata_qwen_evidence = _runtime_chat_template(llama)
-    if not isinstance(template, str) or not template.strip():
-        raise RuntimeError('runtime_chat_template_metadata_missing')
-    qwen_safe = metadata_qwen_evidence or provider_hint == 'qwen' or 'qwen' in policy_hint
-    if not qwen_safe:
-        raise RuntimeError('runtime_chat_template_qwen_evidence_missing')
-    if not _jinja_renderer_available():
-        raise RuntimeError('runtime_chat_template_renderer_unavailable')
-    messages = args[0] if args else kwargs.get('messages')
-    if not isinstance(messages, list):
-        raise RuntimeError('runtime_chat_template_render_exception')
-    rendered = _render_gguf_jinja_chat_template(
-        template,
-        messages,
-        llama,
-        add_generation_prompt=bool(kwargs.get('add_generation_prompt', True)),
-        enable_thinking=kwargs.get('enable_thinking'),
-    )
-    return rendered, {
-        'direct_apply_chat_template': False,
-        'metadata_template': True,
-        'jinja_renderer': True,
-        'qwen_evidence': True,
-    }
+    return _render_with_metadata_template()
 
 def _testing_render_template_fallback_allowed(model_path):
     if os.environ.get('TOKEN_PLACE_ENV') != 'testing':
@@ -2343,6 +2356,18 @@ for line in sys.stdin:
                     llama, request.get('args', []), render_kwargs
                 )
             except Exception as exc:
+                rejected = _extract_unsupported_generation_kwarg(
+                    str(exc),
+                    [key for key in ('enable_thinking', 'tokenize', 'add_generation_prompt') if key in render_kwargs],
+                )
+                render_extra = None
+                if rejected:
+                    render_extra = {
+                        'method': 'apply_chat_template',
+                        'generation_exception_category': 'unsupported_generation_kwarg',
+                        'rejected_generation_kwarg': rejected,
+                        'attempted_generation_kwargs': ','.join(sorted(render_kwargs)),
+                    }
                 reason = str(exc) if str(exc) in {
                     'runtime_chat_template_metadata_missing',
                     'runtime_chat_template_renderer_unavailable',
@@ -2368,7 +2393,7 @@ for line in sys.stdin:
                         _emit(_safe_request_error(reason, request=request, exc=fallback_exc))
                         continue
                 else:
-                    _emit(_safe_request_error(reason, request=request, exc=exc))
+                    _emit(_safe_request_error(reason, request=request, exc=exc, extra=render_extra))
                     continue
             max_tokens = kwargs.get('max_tokens', 64)
             if not isinstance(max_tokens, int) or isinstance(max_tokens, bool) or max_tokens <= 0:

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -46,6 +46,7 @@ def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
 
 _UNSUPPORTED_GENERATION_KWARG_PATTERNS = (
     re.compile(r"(?:got an )?unexpected keyword argument [\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]"),
+    re.compile(r"(?:got an )?unexpected keyword argument\s+([A-Za-z_][A-Za-z0-9_]*)"),
     re.compile(r"unexpected keyword argument\s*:\s*([A-Za-z_][A-Za-z0-9_]*)"),
     re.compile(r"unsupported option(?:\s+[\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]|\s*:\s*([A-Za-z_][A-Za-z0-9_]*))"),
     re.compile(r"invalid keyword(?: argument)?(?:\s+[\'\"]([A-Za-z_][A-Za-z0-9_]*)[\'\"]|\s*:\s*([A-Za-z_][A-Za-z0-9_]*))"),


### PR DESCRIPTION
### Motivation
- A packaged desktop Qwen 64k-full readiness smoke was failing after the API v1 path chose `qwen_render_then_plain_completion` because the render worker rejected an internal render kwarg and surfaced only `unsupported_generation_kwarg`.
- The goal is to keep API v1 on the render-then-plain-completion path while handling render-time kwarg rejections safely (avoid thinking output leaks) and make readiness errors diagnosable by surfacing the exact rejected kwarg/method where possible.

### Description
- Add worker-level render-kwarg handling in `_render_chat_with_runtime_template` to detect direct `apply_chat_template`/tokenizer `TypeError` rejections for `enable_thinking`, `tokenize`, and `add_generation_prompt`, retry by dropping only the rejected render kwarg, and prefer the GGUF/Jinja renderer (when Qwen metadata evidence exists) as a safe fallback that preserves the non-thinking `/no_think` path; record safe render diagnostics such as `rejected_generation_kwarg`. (updates in `utils/llm/model_manager.py`)
- Extend unsupported-kwarg extraction patterns so bare messages like `unexpected keyword argument enable_thinking` are recognized on both the subprocess worker and relay filtering paths. (updates in `utils/llm/model_manager.py` and `utils/networking/relay_client.py`)
- When a direct render fails, include safe, bounded render diagnostics (`method`, `generation_exception_category`, `rejected_generation_kwarg`, `attempted_generation_kwargs`) in the worker error payload so the bridge can expose the precise rejected kwarg without plaintext content. (updates in the worker proxy logic in `utils/llm/model_manager.py`)
- Prefer nested worker diagnostics over generic bridge-level `unsupported_generation_option` when mapping readiness smoke errors so compute-node readiness reports the more specific plain-completion category (e.g. map to `runtime_completion_smoke_plain_completion_unexpected_kwarg` when appropriate). (updates in `utils/compute_node_runtime.py`)
- Add regression tests that reproduce the render-then-complete failure surfaces without exposing prompt content: a test that verifies the GGUF/Jinja fallback when `apply_chat_template` rejects `enable_thinking`, and a test that asserts a `tokenize`-style rejection is reported as an `unsupported_generation_kwarg` and that diagnostics do not contain plaintext prompts. (tests added/updated in `tests/unit/test_model_manager.py`, `tests/unit/test_compute_node_runtime.py`, and `tests/integration/test_desktop_qwen64k_packaged_runtime.py`)

### Testing
- Installed verification deps: `pip install -r config/requirements_codex_verification.txt` (ran during verification).
- Ran unit and integration suites and lint hooks shown below, all succeeded:
  - `python -m pytest tests/unit/test_model_manager.py -q` — all selected unit tests passed (222 passed).
  - `python -m pytest tests/unit/test_relay_client.py -q` — all tests passed (296 passed).
  - `python -m pytest tests/unit/test_compute_node_runtime.py -q` — all tests passed (106 passed).
  - `python -m pytest tests/unit/test_context_profiles.py -q` — all tests passed (3 passed).
  - `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` — integration passed (10 passed).
  - `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q` — packaged Qwen integration passed (10 passed).
  - `pre-commit run --all-files` — pre-commit hooks completed successfully.
- The concrete rejected kwarg exercised by the regression is `tokenize` (tests include detection and safe reporting), and the render retry path also covers `enable_thinking` and `add_generation_prompt` without risking <think> leaks.

If you want, I can split the change into smaller PRs (regex + diagnostics, render-retry/fallback, and tests) to ease review, but this PR keeps the worker-level render retry, relay filtering, and readiness diagnostics consistent and covered by tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c37d11028832f8e81dbfcfa7b8c5a)