### PR TITLE
Qwen: improve render-then-plain-completion kwarg handling and readiness diagnostics

### DIFF
--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -201,7 +201,7 @@ def _runtime_for(fake_runtime):
     ("category", "reason"),
     [
         ("kv_cache_allocation", "runtime_completion_smoke_kv_cache_allocation"),
-        ("unsupported_generation_kwarg", "runtime_completion_smoke_unsupported_generation_kwarg"),
+        ("unsupported_generation_kwarg", "runtime_completion_smoke_plain_completion_unexpected_kwarg"),
         ("rope_yarn_eval_failure", "runtime_completion_smoke_rope_yarn_eval_failure"),
         ("worker_timeout", "runtime_completion_smoke_worker_timeout"),
         ("worker_dead", "runtime_completion_smoke_worker_dead"),
@@ -226,6 +226,40 @@ def test_qwen64k_packaged_fake_runtime_generation_exception_has_specific_safe_re
     assert diagnostics["api_v1_readiness_error_reason"] == reason
     assert diagnostics["api_v1_readiness_error_reason"] != "runtime_completion_smoke_exception"
     assert diagnostics["api_v1_readiness_completion_smoke_path"] == "shared_api_v1_generation"
+
+
+def test_qwen64k_packaged_runtime_readiness_surfaces_safe_rejected_kwarg_fields():
+    class FailingRuntime(_Qwen64kFakeRuntime):
+        def create_chat_completion_from_rendered_prompt(self, messages, **_kwargs):
+            raise LlamaCppInferenceRequestError(
+                "llama_cpp request failed",
+                diagnostics={
+                    "generation_exception_category": "unsupported_generation_kwarg",
+                    "exception_type": "TypeError",
+                    "method": "create_completion_keyword_prompt",
+                    "rejected_generation_kwarg": "max_tokens",
+                    "attempted_generation_kwargs": "max_tokens,prompt",
+                    "attempted_plain_completion_methods": (
+                        "create_completion_keyword_prompt,"
+                        "create_completion_positional_prompt,"
+                        "llama_call_positional_prompt"
+                    ),
+                    "result_shape": "dict_malformed",
+                },
+            )
+
+    runtime, manager = _runtime_for(FailingRuntime())
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_error_reason"] == (
+        "runtime_completion_smoke_plain_completion_unexpected_kwarg"
+    )
+    assert diagnostics["api_v1_readiness_completion_smoke_rejected_generation_kwarg"] == "max_tokens"
+    assert diagnostics["api_v1_readiness_completion_smoke_attempted_generation_kwargs"] == "max_tokens,prompt"
+    assert diagnostics["api_v1_readiness_completion_smoke_method"] == "create_completion_keyword_prompt"
+    assert diagnostics["api_v1_readiness_completion_smoke_result_shape"] == "dict_malformed"
+    assert "Reply with exactly" not in json.dumps(diagnostics)
 
 
 def test_qwen64k_packaged_subprocess_generation_error_preserves_safe_diagnostics(tmp_path, monkeypatch):

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -145,8 +145,16 @@ def test_completion_smoke_worker_diagnostic_sanitizer_drops_unsafe_shapes():
         ({"worker_diagnostics": {"generation_exception_category": "empty_completion_output"}}, "runtime_completion_smoke_plain_completion_empty_output"),
         ({"worker_diagnostics": {"generation_exception_category": "thinking_leaked"}}, "runtime_completion_smoke_plain_completion_thinking_leaked"),
         ({"worker_diagnostics": {"generation_exception_category": "malformed_completion_output"}}, "runtime_completion_smoke_plain_completion_malformed_output"),
-        # Top-level takes precedence over nested.
-        ({"generation_exception_category": "empty_completion_output", "worker_diagnostics": {"generation_exception_category": "thinking_leaked"}}, "runtime_completion_smoke_plain_completion_empty_output"),
+        # Nested worker diagnostics take precedence over the parent's generic
+        # or stale category.
+        ({"generation_exception_category": "empty_completion_output", "worker_diagnostics": {"generation_exception_category": "thinking_leaked"}}, "runtime_completion_smoke_plain_completion_thinking_leaked"),
+        (
+            {
+                "internal_reason": "unsupported_generation_option",
+                "worker_diagnostics": {"generation_exception_category": "unsupported_generation_kwarg"},
+            },
+            "runtime_completion_smoke_plain_completion_unexpected_kwarg",
+        ),
     ],
 )
 def test_completion_smoke_reason_from_api_v1_error_maps_runtime_reasons(error, expected_reason):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -6478,3 +6478,91 @@ def test_llama_worker_render_complete_empty_and_thinking_fail_safely(tmp_path, m
     assert empty_exc.value.diagnostics['generation_exception_category'] == 'empty_completion_output'
     assert think_exc.value.diagnostics['generation_exception_category'] == 'thinking_leaked'
     assert 'secret reasoning' not in json.dumps(think_exc.value.diagnostics)
+
+
+def test_llama_worker_render_complete_falls_back_to_qwen_jinja_when_render_kwarg_rejected(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'render kwarg fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    metadata = {\n"
+        "        'general.name': 'Qwen3 test',\n"
+        "        'tokenizer.chat_template': \"{% for message in messages %}{{ message['role'] }}:{{ message['content'] }}\\n{% endfor %}{% if enable_thinking == false %}/no_think\\n{% endif %}{% if add_generation_prompt %}assistant:{% endif %}\",\n"
+        "    }\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def apply_chat_template(self, messages, **kwargs):\n"
+        "        if 'tokenize' in kwargs:\n"
+        "            raise TypeError(\"got an unexpected keyword argument 'tokenize'\")\n"
+        "        return 'unsafe direct render'\n"
+        "    def create_completion(self, prompt, **kwargs):\n"
+        "        if '/no_think' not in prompt:\n"
+        "            return {'choices': [{'text': '<think>leaked</think> unsafe'}]}\n"
+        "        return {'choices': [{'text': 'ok'}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'Qwen3-8B-Q4_K_M.gguf'),
+        timeout_seconds=5,
+    )
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt(
+            [{'role': 'user', 'content': 'secret prompt text'}],
+            max_tokens=4,
+            token_place_provider='qwen',
+            token_place_template_policy='gguf-jinja',
+            enable_thinking=False,
+        )
+    finally:
+        proxy.close()
+
+    assert result['choices'][0]['message']['content'] == 'ok'
+
+
+def test_llama_worker_render_complete_reports_safe_render_kwarg_diagnostics(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'render kwarg failure fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def apply_chat_template(self, messages, **kwargs):\n"
+        "        if 'add_generation_prompt' in kwargs:\n"
+        "            raise TypeError(\"got an unexpected keyword argument 'add_generation_prompt'\")\n"
+        "        return 'unsafe direct render'\n"
+        "    def create_completion(self, prompt, **kwargs):\n"
+        "        return {'choices': [{'text': 'should not run'}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'Qwen3-8B-Q4_K_M.gguf'),
+        timeout_seconds=5,
+    )
+    try:
+        with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as exc_info:
+            proxy.create_chat_completion_from_rendered_prompt(
+                [{'role': 'user', 'content': 'secret prompt text'}],
+                max_tokens=4,
+                token_place_provider='qwen',
+                token_place_template_policy='gguf-jinja',
+                enable_thinking=False,
+            )
+    finally:
+        proxy.close()
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics['generation_exception_category'] == 'unsupported_generation_kwarg'
+    assert diagnostics['rejected_generation_kwarg'] == 'add_generation_prompt'
+    assert diagnostics['attempted_generation_kwargs'] == 'add_generation_prompt,enable_thinking,tokenize'
+    assert diagnostics['method'] == 'apply_chat_template'
+    assert 'secret prompt text' not in json.dumps(diagnostics)

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -244,6 +244,18 @@ def _classify_completion_smoke_exception(exc: BaseException) -> Tuple[str, str, 
 
 
 def _completion_smoke_reason_from_api_v1_error(error: Dict[str, Any]) -> str:
+    # Prefer precise worker diagnostics from the packaged llama-cpp bridge over
+    # the parent relay's generic ``unsupported_generation_option`` internal
+    # reason.  The parent reason is intentionally coarse, while the worker
+    # category distinguishes plain-completion shape/kwarg/template failures.
+    generation_exception_category = error.get("generation_exception_category")
+    worker_diag = error.get("worker_diagnostics")
+    if isinstance(worker_diag, dict):
+        worker_category = worker_diag.get("generation_exception_category")
+        if worker_category in _COMPLETION_SMOKE_REASON_BY_CATEGORY:
+            generation_exception_category = worker_category
+    if generation_exception_category and generation_exception_category in _COMPLETION_SMOKE_REASON_BY_CATEGORY:
+        return _COMPLETION_SMOKE_REASON_BY_CATEGORY[generation_exception_category]
     internal_reason = error.get("internal_reason")
     if internal_reason == "qwen_thinking_output_leaked":
         return "runtime_completion_smoke_thinking_leaked"
@@ -265,16 +277,6 @@ def _completion_smoke_reason_from_api_v1_error(error: Dict[str, Any]) -> str:
         return "runtime_completion_smoke_worker_timeout"
     if internal_reason in {"worker_dead", "runtime_worker_dead"}:
         return "runtime_completion_smoke_worker_dead"
-    # Map plain-completion diagnostic categories surfaced by the subprocess worker.
-    # Check both the top-level error dict and nested worker_diagnostics, since the
-    # relay path carries child-worker details inside worker_diagnostics.
-    generation_exception_category = error.get("generation_exception_category")
-    if not generation_exception_category:
-        worker_diag = error.get("worker_diagnostics")
-        if isinstance(worker_diag, dict):
-            generation_exception_category = worker_diag.get("generation_exception_category")
-    if generation_exception_category and generation_exception_category in _COMPLETION_SMOKE_REASON_BY_CATEGORY:
-        return _COMPLETION_SMOKE_REASON_BY_CATEGORY[generation_exception_category]
     if error.get("code") == "compute_node_invalid_model_output":
         return "runtime_completion_smoke_invalid_model_output"
     if error.get("code") == "compute_node_options_unsupported":
@@ -841,6 +843,8 @@ class ComputeNodeRuntime:
                         "attempted_generation_kwargs",
                         "attempted_plain_completion_methods",
                         "result_shape",
+                        "method",
+                        "generation_exception_category",
                     ):
                         if key in smoke_error:
                             diagnostics[f"api_v1_readiness_completion_smoke_{key}"] = smoke_error[key]

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -2138,10 +2138,18 @@ def _type_error_is_unexpected_keyword(exc, keyword):
         or ('got an unexpected keyword argument %s' % keyword) in message
     )
 
+class _RuntimeTemplateRenderKwargError(RuntimeError):
+    def __init__(self, rejected, attempted, category='unsupported_generation_kwarg'):
+        super().__init__('runtime_chat_template_render_exception')
+        self.rejected_generation_kwarg = rejected
+        self.attempted_generation_kwargs = attempted
+        self.generation_exception_category = category
+
 def _render_chat_with_runtime_template(llama, args, kwargs):
     kwargs = dict(kwargs)
     provider_hint = str(kwargs.pop('token_place_provider', '') or '').lower()
     policy_hint = str(kwargs.pop('token_place_template_policy', '') or '').lower()
+    qwen_hint = provider_hint == 'qwen' or 'qwen' in policy_hint
     render = getattr(llama, 'apply_chat_template', None)
     direct_apply_available = callable(render)
     if not direct_apply_available:
@@ -2160,15 +2168,56 @@ def _render_chat_with_runtime_template(llama, args, kwargs):
                 'jinja_renderer': False,
             }
         except TypeError as exc:
-            if 'enable_thinking' not in kwargs or not _type_error_is_unexpected_keyword(exc, 'enable_thinking'):
+            attempted_render_kwargs = sorted(str(key) for key in kwargs)
+            rejected_render_kwarg = _extract_unsupported_generation_kwarg(
+                str(exc), attempted_render_kwargs
+            )
+            if rejected_render_kwarg is None:
+                for candidate in ('enable_thinking', 'tokenize', 'add_generation_prompt'):
+                    if candidate in kwargs and _type_error_is_unexpected_keyword(exc, candidate):
+                        rejected_render_kwarg = candidate
+                        break
+            if rejected_render_kwarg not in {'enable_thinking', 'tokenize', 'add_generation_prompt'}:
                 raise
-            compatibility_kwargs = dict(kwargs)
-            compatibility_kwargs.pop('enable_thinking', None)
-            return render(*args, **compatibility_kwargs), {
-                'direct_apply_chat_template': direct_apply_available,
-                'metadata_template': False,
-                'jinja_renderer': False,
-            }
+            template, metadata_qwen_evidence = _runtime_chat_template(llama)
+            if (
+                qwen_hint or metadata_qwen_evidence
+            ) and isinstance(template, str) and template.strip() and _jinja_renderer_available():
+                messages = args[0] if args else kwargs.get('messages')
+                if not isinstance(messages, list):
+                    raise RuntimeError('runtime_chat_template_render_exception')
+                rendered = _render_gguf_jinja_chat_template(
+                    template,
+                    messages,
+                    llama,
+                    add_generation_prompt=bool(kwargs.get('add_generation_prompt', True)),
+                    enable_thinking=kwargs.get('enable_thinking'),
+                )
+                return rendered, {
+                    'direct_apply_chat_template': direct_apply_available,
+                    'metadata_template': True,
+                    'jinja_renderer': True,
+                    'qwen_evidence': True,
+                    'rejected_generation_kwarg': rejected_render_kwarg,
+                    'attempted_generation_kwargs': ','.join(attempted_render_kwargs[:32]),
+                    'generation_exception_category': 'unsupported_generation_kwarg',
+                    'method': 'apply_chat_template',
+                }
+            if rejected_render_kwarg == 'enable_thinking':
+                compatibility_kwargs = dict(kwargs)
+                compatibility_kwargs.pop('enable_thinking', None)
+                return render(*args, **compatibility_kwargs), {
+                    'direct_apply_chat_template': direct_apply_available,
+                    'metadata_template': False,
+                    'jinja_renderer': False,
+                    'rejected_generation_kwarg': rejected_render_kwarg,
+                    'attempted_generation_kwargs': ','.join(attempted_render_kwargs[:32]),
+                    'generation_exception_category': 'unsupported_generation_kwarg',
+                    'method': 'apply_chat_template',
+                }
+            raise _RuntimeTemplateRenderKwargError(
+                rejected_render_kwarg, ','.join(attempted_render_kwargs[:32])
+            )
     template, metadata_qwen_evidence = _runtime_chat_template(llama)
     if not isinstance(template, str) or not template.strip():
         raise RuntimeError('runtime_chat_template_metadata_missing')
@@ -2368,7 +2417,15 @@ for line in sys.stdin:
                         _emit(_safe_request_error(reason, request=request, exc=fallback_exc))
                         continue
                 else:
-                    _emit(_safe_request_error(reason, request=request, exc=exc))
+                    render_extra = None
+                    if isinstance(exc, _RuntimeTemplateRenderKwargError):
+                        render_extra = {
+                            'method': 'apply_chat_template',
+                            'generation_exception_category': exc.generation_exception_category,
+                            'rejected_generation_kwarg': exc.rejected_generation_kwarg,
+                            'attempted_generation_kwargs': exc.attempted_generation_kwargs,
+                        }
+                    _emit(_safe_request_error(reason, request=request, exc=exc, extra=render_extra))
                     continue
             max_tokens = kwargs.get('max_tokens', 64)
             if not isinstance(max_tokens, int) or isinstance(max_tokens, bool) or max_tokens <= 0:


### PR DESCRIPTION
### Motivation
- The Qwen API v1 packaged readiness smoke could fail after selecting the `qwen_render_then_plain_completion` branch with only a generic `runtime_completion_smoke_unsupported_generation_kwarg` reason because direct runtime `apply_chat_template` rejections (e.g. `enable_thinking`, `tokenize`, `add_generation_prompt`) were not surfaced or retried safely. 
- The goal is to treat these as packaged runtime render-path compatibility issues (not relay/model-load faults), preserve Qwen non-thinking enforcement, and make readiness failures diagnosable with safe, bounded diagnostics that never contain plaintext prompts or model output.

### Description
- Detect rejected render-template kwargs in the packaged llama-cpp bridge and add a targeted fallback/retry strategy in `_render_chat_with_runtime_template` that: identifies rejected kwarg names, retries by dropping `enable_thinking` when safe, and prefers the embedded GGUF/Jinja renderer for Qwen when direct `apply_chat_template` rejects render kwargs; failing closed with a precise safe error when no safe path exists (new `_RuntimeTemplateRenderKwargError`).
- Keep the plain-completion attempts strictly bounded to the existing safe shapes (`create_completion(prompt=..., max_tokens=...)`, `create_completion(rendered_prompt, max_tokens=...)`, then `llama(rendered_prompt, max_tokens=...)`) and continue to detect unsupported plain-completion kwargs via `_plain_completion_method_shape_category` and `_extract_unsupported_generation_kwarg`.
- Surface safe worker-level render diagnostics into the readiness smoke envelope (fields like `rejected_generation_kwarg`, `attempted_generation_kwargs`, `attempted_plain_completion_methods`, `method`, `generation_exception_category`, and `result_shape`) while preserving E2EE redaction rules and never including plaintext prompts or model output.
- Make readiness error mapping prefer nested packaged-worker diagnostics over coarse parent `unsupported_generation_option` so that `unsupported_generation_kwarg` maps to the more precise `runtime_completion_smoke_plain_completion_unexpected_kwarg` when appropriate.
- Added regression tests that reproduce and verify the behaviors without leaking plaintext: two unit tests in `tests/unit/test_model_manager.py` for render-kwarg fallback and diagnostics, and an integration readiness test in `tests/integration/test_desktop_qwen64k_packaged_runtime.py` that asserts safe rejected-kwarg fields are promoted for the 64k-full Qwen packaged runtime.

### Testing
- Installed focused verification deps: `python -m pip install -r config/requirements_codex_verification.txt` (succeeded). 
- Ran the unit and integration test suites used for this change and all completed successfully: 
  - `python -m pytest tests/unit/test_model_manager.py -q` — passed.
  - `python -m pytest tests/unit/test_relay_client.py -q` — passed.
  - `python -m pytest tests/unit/test_compute_node_runtime.py -q` — passed.
  - `python -m pytest tests/unit/test_context_profiles.py -q` — passed.
  - `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` — passed.
  - `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q` — passed.
- Ran repository checks: `git diff --check` (clean) and `pre-commit run --all-files` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c3844eb3c832fb3a51a79b018af54)