### PR TITLE
Enforce Qwen API v1 non-thinking, remove automatic `/no_think` injection, add Qwen non-thinking template fallback and hardened diagnostics

### DIFF
--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -747,7 +747,7 @@ def test_compute_node_runtime_readiness_smoke_completion_passes(monkeypatch):
     assert llm_runtime.completion_kwargs["max_tokens"] == 64
     assert "stream" not in llm_runtime.completion_kwargs
     assert "stop" not in llm_runtime.completion_kwargs
-    assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
+    assert not llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
 
 
 
@@ -790,7 +790,7 @@ def test_compute_node_runtime_readiness_smoke_completion_accepts_empty_qwen_thin
     assert diagnostics["api_v1_readiness_completion_smoke_result"] == "passed"
     assert diagnostics["api_v1_readiness_completion_smoke_shape"] == "api_v1_assistant_message"
     assert llm_runtime.completion_kwargs["max_tokens"] == 64
-    assert llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
+    assert not llm_runtime.completion_kwargs["messages"][-1]["content"].startswith("/no_think")
 
 
 def test_compute_node_runtime_readiness_smoke_completion_empty_after_strip(monkeypatch):

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -5854,7 +5854,7 @@ def test_subprocess_worker_plain_completion_helpers_cover_safe_shapes():
     assert classify_shape(TypeError("got an unexpected keyword argument 'stream'")) == 'unsupported_stream_kwarg'
     assert classify_shape(TypeError("got an unexpected keyword argument 'stop'")) == 'unsupported_stop_kwarg'
     assert classify_shape(TypeError("got an unexpected keyword argument 'temperature'")) == 'unexpected_kwarg'
-    assert classify_shape(RuntimeError("KV cache allocation failed")) == 'worker_exception'
+    assert classify_shape(RuntimeError("KV cache allocation failed")) == 'kv_cache_allocation'
 
 
 
@@ -6004,7 +6004,7 @@ def test_subprocess_worker_render_template_failure_carries_safe_rejected_kwarg_d
     assert diagnostics['render_rejected_generation_kwarg'] == 'add_generation_prompt'
     assert diagnostics['rejected_generation_kwarg'] == 'add_generation_prompt'
     assert diagnostics['attempted_generation_kwargs'] == 'add_generation_prompt,tokenize'
-    assert 'generation_exception_category' not in diagnostics
+    assert diagnostics['generation_exception_category'] == 'unsupported_render_kwarg'
     assert 'plaintext prompt' not in json.dumps(diagnostics)
 
 def test_subprocess_worker_render_template_fails_closed_with_safe_rejected_kwarg_diagnostics():

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4226,7 +4226,7 @@ def test_api_v1_qwen_generation_uses_render_then_complete_not_chat_completion():
         "enable_thinking": False,
     }
     messages = manager.runtime.create_chat_completion_from_rendered_prompt.call_args.args[0]
-    assert messages[-1]["content"].startswith("/no_think\n")
+    assert messages[-1]["content"] == "hi"
 
 
 
@@ -4280,7 +4280,7 @@ def test_api_v1_qwen_render_then_complete_rejects_unproven_seed_option():
     manager.runtime.create_chat_completion_from_rendered_prompt.assert_not_called()
 
 
-def test_api_v1_qwen_render_then_complete_retries_rejected_option_once():
+def test_api_v1_qwen_render_then_complete_fails_closed_when_enable_thinking_rejected():
     from utils.llm.model_manager import LlamaCppInferenceRequestError
 
     manager = _ApiV1RuntimeManager()
@@ -4307,11 +4307,14 @@ def test_api_v1_qwen_render_then_complete_retries_rejected_option_once():
         options={"max_tokens": 64},
     )
 
-    assert envelope["api_v1_response"]["message"]["content"] == "ok"
+    error = envelope["api_v1_response"]["error"]
+    assert error["internal_reason"] == "runtime_qwen_non_thinking_hard_switch_unavailable"
+    assert error["rejected_generation_kwarg"] == "enable_thinking"
+    assert error["retryable"] is False
     calls = manager.runtime.create_chat_completion_from_rendered_prompt.call_args_list
+    assert len(calls) == 1
     assert calls[0].kwargs["enable_thinking"] is False
-    assert "enable_thinking" not in calls[1].kwargs
-    assert "enable_thinking" in client._api_v1_generation_kwargs_filtered
+    assert "enable_thinking" not in client._api_v1_generation_kwargs_filtered
 
 
 
@@ -5131,8 +5134,8 @@ def test_qwen_context_admission_uses_generation_aligned_no_think_messages_withou
 
     assert envelope['api_v1_response']['message']['content'] == 'ok'
     assert manager.runtime.calls[0]['template_kwargs'] == {}
-    assert manager.runtime.calls[0]['messages'][-1]['content'].startswith('/no_think\n')
-    assert manager.runtime.calls[-1]['messages'][-1]['content'].startswith('/no_think\n')
+    assert not manager.runtime.calls[0]['messages'][-1]['content'].startswith('/no_think')
+    assert not manager.runtime.calls[-1]['messages'][-1]['content'].startswith('/no_think')
 
 
 def test_qwen_context_admission_uses_packaged_render_tokenize_bridge():
@@ -5166,16 +5169,15 @@ def test_qwen_context_admission_uses_packaged_render_tokenize_bridge():
 
     assert envelope['api_v1_response']['message']['content'] == 'ok'
     assert manager.runtime.calls[0]['bridge'] == 'render_and_tokenize_chat'
-    assert manager.runtime.calls[0]['messages'][-1]['content'].startswith('/no_think\n')
+    assert not manager.runtime.calls[0]['messages'][-1]['content'].startswith('/no_think')
 
 
-def test_qwen_no_think_messages_injects_text_block_when_user_content_list_has_no_text():
+def test_qwen_no_think_messages_noop_preserves_user_content_blocks():
     prepared = RelayClient._api_v1_qwen_no_think_messages([
         {'role': 'user', 'content': [{'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,...'}}]},
     ])
 
-    assert prepared[0]['content'][0] == {'type': 'text', 'text': '/no_think\n'}
-    assert prepared[0]['content'][1]['type'] == 'image_url'
+    assert prepared[0]['content'] == [{'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,...'}}]
 
 
 def test_qwen_render_returns_none_when_enable_thinking_typeerror_would_drop_control():
@@ -5573,7 +5575,7 @@ def test_api_v1_qwen_non_thinking_policy_is_single_source_of_truth():
     policy = RelayClient._API_V1_QWEN_NON_THINKING_POLICY
 
     assert policy["thinking_mode"] == "disabled"
-    assert policy["message_control"] == "/no_think"
+    assert policy["hard_switch"] == "enable_thinking_false"
     assert policy["visible_think_output_forbidden"] is True
     assert policy["reasoning_content_forbidden"] is True
     assert RelayClient._api_v1_qwen_non_thinking_required(
@@ -6107,4 +6109,4 @@ def test_api_v1_qwen_no_think_survives_generation_kwarg_filtering():
     )
 
     assert envelope["api_v1_response"]["message"]["content"] == "ok"
-    assert manager.runtime.calls[-1]["messages"][-1]["content"].startswith("/no_think")
+    assert not manager.runtime.calls[-1]["messages"][-1]["content"].startswith("/no_think")

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -91,6 +91,13 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_KEYS = {
     "stderr_tail",
     "child_stderr_tail",
     "sanitized_error_summary",
+    "plain_completion_create_completion_callable",
+    "plain_completion_llama_call_callable",
+    "plain_completion_signature_inspectable",
+    "plain_completion_accepts_prompt_kwarg",
+    "plain_completion_accepts_max_tokens_kwarg",
+    "plain_completion_accepts_var_kwargs",
+    "qwen_api_v1_non_thinking_template_fallback",
 }
 
 
@@ -106,6 +113,7 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "runtime_chat_template_metadata_missing",
         "runtime_chat_template_renderer_unavailable",
         "runtime_template_tokenizer_bridge_unavailable",
+        "runtime_qwen_non_thinking_hard_switch_missing",
         "malformed_completion_output",
         "empty_completion_output",
         "thinking_leaked",
@@ -127,6 +135,7 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "worker_timeout",
         "worker_dead",
         "unknown_generation_exception",
+        "qwen_non_thinking_hard_switch_unavailable",
         "malformed_completion_output",
         "empty_completion_output",
         "thinking_leaked",
@@ -262,6 +271,16 @@ def _completion_smoke_reason_from_api_v1_error(error: Dict[str, Any]) -> str:
             generation_exception_category = worker_category
     if generation_exception_category and generation_exception_category in _COMPLETION_SMOKE_REASON_BY_CATEGORY:
         return _COMPLETION_SMOKE_REASON_BY_CATEGORY[generation_exception_category]
+    rejected_kwarg = error.get("rejected_generation_kwarg")
+    method = error.get("method")
+    if not rejected_kwarg and isinstance(worker_diag, dict):
+        rejected_kwarg = worker_diag.get("rejected_generation_kwarg")
+        method = method or worker_diag.get("method")
+    if isinstance(rejected_kwarg, str) and rejected_kwarg:
+        if method == "apply_chat_template":
+            return _COMPLETION_SMOKE_REASON_BY_CATEGORY["unsupported_render_kwarg"]
+        if isinstance(method, str) and (method.startswith("create_completion") or method == "llama_call_positional_prompt"):
+            return _COMPLETION_SMOKE_REASON_BY_CATEGORY["unsupported_generation_kwarg"]
     # Render-template surface failures (admission/context-token stage) use distinct
     # internal_reason values (runtime_chat_template_*) that do not overlap with the
     # completion-path values checked in the blocks below.
@@ -856,6 +875,13 @@ class ComputeNodeRuntime:
                         "result_shape",
                         "method",
                         "generation_exception_category",
+                        "plain_completion_create_completion_callable",
+                        "plain_completion_llama_call_callable",
+                        "plain_completion_signature_inspectable",
+                        "plain_completion_accepts_prompt_kwarg",
+                        "plain_completion_accepts_max_tokens_kwarg",
+                        "plain_completion_accepts_var_kwargs",
+                        "qwen_api_v1_non_thinking_template_fallback",
                     ):
                         if key in smoke_error:
                             diagnostics[f"api_v1_readiness_completion_smoke_{key}"] = smoke_error[key]

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1868,7 +1868,7 @@ def _plain_completion_method_shape_category(exc):
         return 'method_shape'
     if rejected is not None:
         return 'unexpected_kwarg'
-    return 'worker_exception'
+    return _classify_generation_exception(exc) if _classify_generation_exception(exc) != 'unknown_generation_exception' else 'worker_exception'
 
 def _completion_result_shape(result):
     if isinstance(result, str):
@@ -1985,6 +1985,13 @@ def _safe_request_error(reason, *, request=None, exc=None, extra=None):
             'qwen_evidence',
             'testing_template_fallback',
             'render_rejected_generation_kwarg',
+            'plain_completion_create_completion_callable',
+            'plain_completion_llama_call_callable',
+            'plain_completion_signature_inspectable',
+            'plain_completion_accepts_prompt_kwarg',
+            'plain_completion_accepts_max_tokens_kwarg',
+            'plain_completion_accepts_var_kwargs',
+            'qwen_api_v1_non_thinking_template_fallback',
         }
         for key, value in extra.items():
             if (
@@ -2016,7 +2023,7 @@ def _safe_request_error(reason, *, request=None, exc=None, extra=None):
         diagnostics['exception_type'] = type(exc).__name__
         diagnostics['sanitized_error_summary'] = _sanitize_error_summary(exc)
         if reason == 'inference_exception':
-            diagnostics['generation_exception_category'] = _classify_generation_exception(exc)
+            diagnostics.setdefault('generation_exception_category', _classify_generation_exception(exc))
             message = str(exc)
             attempted = None
             if isinstance(request, dict) and isinstance(request.get('kwargs'), dict):
@@ -2032,7 +2039,7 @@ def _safe_request_error(reason, *, request=None, exc=None, extra=None):
                 diagnostics['rejected_generation_kwarg'] = rejected
                 if attempted and 'attempted_generation_kwargs' not in diagnostics:
                     diagnostics['attempted_generation_kwargs'] = ','.join(attempted[:32])
-                diagnostics['generation_exception_category'] = 'unsupported_generation_kwarg'
+                diagnostics.setdefault('generation_exception_category', 'unsupported_generation_kwarg')
     return {
         'status': 'error',
         'request_error': True,
@@ -2142,6 +2149,46 @@ def _runtime_token_text(llama, token_name):
             pass
     return ''
 
+def _runtime_message_content_text(content):
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if not isinstance(block, dict):
+                raise RuntimeError('runtime_chat_template_render_exception')
+            block_type = block.get('type')
+            if block_type in {'text', 'input_text'}:
+                text = block.get('text') if block_type == 'text' else block.get('input_text', block.get('text'))
+                if not isinstance(text, str):
+                    raise RuntimeError('runtime_chat_template_render_exception')
+                parts.append(text)
+        return ''.join(parts)
+    raise RuntimeError('runtime_chat_template_render_exception')
+
+def _render_qwen_api_v1_non_thinking_template(messages, llama, *, add_generation_prompt=True):
+    if not isinstance(messages, list):
+        raise RuntimeError('runtime_chat_template_render_exception')
+    rendered_parts = []
+    bos_token = _runtime_token_text(llama, 'bos')
+    if isinstance(bos_token, str) and bos_token:
+        rendered_parts.append(bos_token)
+    for message in messages:
+        if not isinstance(message, dict):
+            raise RuntimeError('runtime_chat_template_render_exception')
+        role = message.get('role')
+        if role not in {'system', 'user', 'assistant'}:
+            raise RuntimeError('runtime_chat_template_render_exception')
+        if 'content' not in message:
+            raise RuntimeError('runtime_chat_template_render_exception')
+        content = _runtime_message_content_text(message.get('content'))
+        if not isinstance(content, str):
+            raise RuntimeError('runtime_chat_template_render_exception')
+        rendered_parts.append('<|im_start|>' + role + '\\n' + content + '<|im_end|>\\n')
+    if add_generation_prompt:
+        rendered_parts.append('<|im_start|>assistant\\n<think>\\n\\n</think>\\n\\n')
+    return ''.join(rendered_parts)
+
 def _render_gguf_jinja_chat_template(template, messages, llama, *, add_generation_prompt=True, enable_thinking=None):
     chat_format_module = None
     try:
@@ -2164,13 +2211,7 @@ def _render_gguf_jinja_chat_template(template, messages, llama, *, add_generatio
                 }
                 if enable_thinking is not None:
                     formatter_kwargs['enable_thinking'] = enable_thinking
-                try:
-                    rendered = formatter(**formatter_kwargs)
-                except TypeError as exc:
-                    if not _type_error_is_unexpected_keyword(exc, 'enable_thinking'):
-                        raise
-                    formatter_kwargs.pop('enable_thinking', None)
-                    rendered = formatter(**formatter_kwargs)
+                rendered = formatter(**formatter_kwargs)
                 prompt = getattr(rendered, 'prompt', rendered)
                 if isinstance(prompt, str):
                     return prompt
@@ -2208,52 +2249,20 @@ def _type_error_is_unexpected_keyword(exc, keyword):
 
 def _render_chat_with_runtime_template(llama, args, kwargs):
     kwargs = dict(kwargs)
-
-    def _rejection_diagnostics(rejected_kwarg, *, include_generation_category=True):
-        diagnostics = {
-            'direct_apply_chat_template': direct_apply_available,
-            'metadata_template': False,
-            'jinja_renderer': False,
-        }
-        if rejected_kwarg:
-            diagnostics.update({
-                'render_rejected_generation_kwarg': rejected_kwarg,
-                'rejected_generation_kwarg': rejected_kwarg,
-                'attempted_generation_kwargs': _safe_kwarg_names_csv(kwargs),
-                'method': 'apply_chat_template',
-            })
-        if rejected_kwarg and include_generation_category:
-            diagnostics['generation_exception_category'] = 'unsupported_render_kwarg'
-        return {key: value for key, value in diagnostics.items() if value is not None}
-
-    def _retry_without_rejected_kwarg(rejected_kwarg):
-        if not rejected_kwarg or not callable(render):
-            return None
-        # enable_thinking must never be removed as a compatibility retry.
-        # Dropping it would silently re-enable thinking on the non-thinking path.
-        # If apply_chat_template rejects enable_thinking, the caller must fall
-        # through to the GGUF/Jinja renderer (which honours enable_thinking) or
-        # fail closed with safe diagnostics.
-        if rejected_kwarg not in {'tokenize', 'add_generation_prompt'}:
-            return None
-        compatibility_kwargs = dict(kwargs)
-        compatibility_kwargs.pop(rejected_kwarg, None)
-        rendered = render(*args, **compatibility_kwargs)
-        return rendered, _rejection_diagnostics(rejected_kwarg)
-
-    def _raise_template_error(reason, rejected_kwarg=None):
-        try:
-            retry_result = _retry_without_rejected_kwarg(rejected_kwarg)
-        except Exception:
-            retry_result = None
-        if retry_result is not None:
-            return retry_result
-        raise _RuntimeTemplateRenderError(
-            reason,
-            _rejection_diagnostics(rejected_kwarg, include_generation_category=False),
-        )
     provider_hint = str(kwargs.pop('token_place_provider', '') or '').lower()
     policy_hint = str(kwargs.pop('token_place_template_policy', '') or '').lower()
+    qwen_api_v1_non_thinking = provider_hint == 'qwen' and 'qwen' in policy_hint
+    enable_present = 'enable_thinking' in kwargs
+    if enable_present and kwargs.get('enable_thinking') is not False:
+        raise _RuntimeTemplateRenderError('runtime_chat_template_render_exception', {
+            'generation_exception_category': 'qwen_non_thinking_hard_switch_unavailable',
+            'method': 'apply_chat_template',
+        })
+    if qwen_api_v1_non_thinking and not enable_present:
+        raise _RuntimeTemplateRenderError('runtime_qwen_non_thinking_hard_switch_missing', {
+            'generation_exception_category': 'qwen_non_thinking_hard_switch_unavailable',
+            'method': 'apply_chat_template',
+        })
     render = getattr(llama, 'apply_chat_template', None)
     direct_apply_available = callable(render)
     if not direct_apply_available:
@@ -2266,13 +2275,18 @@ def _render_chat_with_runtime_template(llama, args, kwargs):
         render = getattr(tokenizer, 'apply_chat_template', None) if tokenizer is not None else None
     render_exc = None
     rejected_render_kwarg = None
+    def _diag(**extra):
+        diagnostics = {
+            'direct_apply_chat_template': direct_apply_available,
+            'metadata_template': False,
+            'jinja_renderer': False,
+            'qwen_evidence': bool(qwen_api_v1_non_thinking),
+        }
+        diagnostics.update({k: v for k, v in extra.items() if v is not None})
+        return diagnostics
     if callable(render):
         try:
-            return render(*args, **kwargs), {
-                'direct_apply_chat_template': direct_apply_available,
-                'metadata_template': False,
-                'jinja_renderer': False,
-            }
+            return render(*args, **kwargs), _diag()
         except TypeError as exc:
             render_exc = exc
             attempted_render_kwargs = sorted(str(key) for key in kwargs)
@@ -2282,52 +2296,82 @@ def _render_chat_with_runtime_template(llama, args, kwargs):
                     if candidate in kwargs and _type_error_is_unexpected_keyword(exc, candidate):
                         rejected_render_kwarg = candidate
                         break
+            if rejected_render_kwarg is None:
+                raise
+            if rejected_render_kwarg in {'tokenize', 'add_generation_prompt'} and not qwen_api_v1_non_thinking:
+                compatibility_kwargs = dict(kwargs)
+                compatibility_kwargs.pop(rejected_render_kwarg, None)
+                try:
+                    return render(*args, **compatibility_kwargs), _diag(
+                        render_rejected_generation_kwarg=rejected_render_kwarg,
+                        rejected_generation_kwarg=rejected_render_kwarg,
+                        attempted_generation_kwargs=_safe_kwarg_names_csv(kwargs),
+                        generation_exception_category='unsupported_render_kwarg',
+                        method='apply_chat_template',
+                    )
+                except Exception:
+                    pass
             if rejected_render_kwarg not in {'enable_thinking', 'tokenize', 'add_generation_prompt'}:
                 raise
     template, metadata_qwen_evidence = _runtime_chat_template(llama)
-    if not isinstance(template, str) or not template.strip():
-        retry_result = _raise_template_error('runtime_chat_template_metadata_missing', rejected_render_kwarg)
-        if retry_result is not None:
-            return retry_result
-    qwen_safe = metadata_qwen_evidence or provider_hint == 'qwen' or 'qwen' in policy_hint
-    if not qwen_safe:
-        retry_result = _raise_template_error('runtime_chat_template_qwen_evidence_missing', rejected_render_kwarg)
-        if retry_result is not None:
-            return retry_result
-    if not _jinja_renderer_available():
-        retry_result = _raise_template_error('runtime_chat_template_renderer_unavailable', rejected_render_kwarg)
-        if retry_result is not None:
-            return retry_result
     messages = args[0] if args else kwargs.get('messages')
     if not isinstance(messages, list):
         raise RuntimeError('runtime_chat_template_render_exception')
-    try:
-        rendered = _render_gguf_jinja_chat_template(
-            template,
-            messages,
-            llama,
-            add_generation_prompt=bool(kwargs.get('add_generation_prompt', True)),
-            enable_thinking=kwargs.get('enable_thinking'),
-        )
-    except Exception:
-        retry_result = _raise_template_error('runtime_chat_template_render_exception', rejected_render_kwarg)
-        if retry_result is not None:
-            return retry_result
-    diagnostics = {
-        'direct_apply_chat_template': False,
-        'metadata_template': True,
-        'jinja_renderer': True,
-        'qwen_evidence': True,
+    qwen_safe = bool(metadata_qwen_evidence or provider_hint == 'qwen' or 'qwen' in policy_hint)
+    base_diag = {
+        'direct_apply_chat_template': direct_apply_available,
+        'metadata_template': bool(isinstance(template, str) and template.strip()),
+        'jinja_renderer': _jinja_renderer_available(),
+        'qwen_evidence': qwen_safe,
     }
     if rejected_render_kwarg:
-        diagnostics.update({
+        base_diag.update({
             'render_rejected_generation_kwarg': rejected_render_kwarg,
             'rejected_generation_kwarg': rejected_render_kwarg,
             'attempted_generation_kwargs': _safe_kwarg_names_csv(kwargs),
             'generation_exception_category': 'unsupported_render_kwarg',
             'method': 'apply_chat_template',
         })
-    return rendered, diagnostics
+    if isinstance(template, str) and template.strip() and qwen_safe and _jinja_renderer_available():
+        try:
+            rendered = _render_gguf_jinja_chat_template(
+                template,
+                messages,
+                llama,
+                add_generation_prompt=bool(kwargs.get('add_generation_prompt', True)),
+                enable_thinking=kwargs.get('enable_thinking'),
+            )
+            diagnostics = dict(base_diag)
+            diagnostics.update({'metadata_template': True, 'jinja_renderer': True})
+            return rendered, diagnostics
+        except TypeError as exc:
+            if not _type_error_is_unexpected_keyword(exc, 'enable_thinking'):
+                raise
+        except Exception:
+            pass
+    if qwen_api_v1_non_thinking and qwen_safe:
+        rendered = _render_qwen_api_v1_non_thinking_template(
+            messages, llama, add_generation_prompt=bool(kwargs.get('add_generation_prompt', True))
+        )
+        diagnostics = dict(base_diag)
+        diagnostics['qwen_api_v1_non_thinking_template_fallback'] = True
+        if rejected_render_kwarg:
+            diagnostics.update({
+                'render_rejected_generation_kwarg': rejected_render_kwarg,
+                'rejected_generation_kwarg': rejected_render_kwarg,
+                'attempted_generation_kwargs': _safe_kwarg_names_csv(kwargs),
+                'generation_exception_category': 'unsupported_render_kwarg',
+                'method': 'apply_chat_template',
+            })
+        return rendered, diagnostics
+    reason = 'runtime_chat_template_metadata_missing'
+    if isinstance(template, str) and template.strip() and not qwen_safe:
+        reason = 'runtime_chat_template_qwen_evidence_missing'
+    elif isinstance(template, str) and template.strip() and not _jinja_renderer_available():
+        reason = 'runtime_chat_template_renderer_unavailable'
+    elif isinstance(template, str) and template.strip() and render_exc is not None:
+        reason = 'runtime_chat_template_render_exception'
+    raise _RuntimeTemplateRenderError(reason, base_diag)
 
 def _testing_render_template_fallback_allowed(model_path):
     if os.environ.get('TOKEN_PLACE_ENV') != 'testing':
@@ -2409,6 +2453,7 @@ for line in sys.stdin:
                         'runtime_template_tokenizer_bridge_unavailable',
                         'runtime_chat_template_render_exception',
                         'runtime_chat_template_qwen_evidence_missing',
+                        'runtime_qwen_non_thinking_hard_switch_missing',
                     } else 'runtime_chat_template_render_exception'
                     _emit(_safe_request_error(reason, request=request, exc=exc, extra=getattr(exc, 'diagnostics', None) if isinstance(getattr(exc, 'diagnostics', None), dict) else (_render_diagnostics if isinstance(locals().get('_render_diagnostics'), dict) else None)))
                 continue
@@ -2512,6 +2557,21 @@ for line in sys.stdin:
             result = None
             completion_error = None
             create_completion = getattr(llama, 'create_completion', None)
+            signature_inspectable = False
+            accepts_prompt_kwarg = None
+            accepts_max_tokens_kwarg = None
+            accepts_var_kwargs = None
+            if callable(create_completion):
+                try:
+                    inspect_module = importlib.import_module('inspect')
+                    signature = inspect_module.signature(create_completion)
+                    signature_inspectable = True
+                    params = signature.parameters
+                    accepts_var_kwargs = any(p.kind == inspect_module.Parameter.VAR_KEYWORD for p in params.values())
+                    accepts_prompt_kwarg = accepts_var_kwargs or 'prompt' in params
+                    accepts_max_tokens_kwarg = accepts_var_kwargs or 'max_tokens' in params
+                except Exception:
+                    pass
             if callable(create_completion):
                 attempt_method = 'create_completion_keyword_prompt'
                 attempted_kwargs = ['max_tokens', 'prompt']
@@ -2538,7 +2598,7 @@ for line in sys.stdin:
                             completion_error = positional_exc
             if result is None and callable(llama) and (
                 not attempts
-                or attempts[-1].get('generation_exception_category') != 'worker_exception'
+                or attempts[-1].get('generation_exception_category') in {'unsupported_prompt_kwarg', 'method_shape'}
             ):
                 try:
                     result = llama(rendered_prompt, max_tokens=max_tokens)
@@ -2555,6 +2615,12 @@ for line in sys.stdin:
                     'attempted_generation_kwargs': ','.join(sorted(set(','.join(item.get('attempted_kwarg_names', '') for item in attempts).split(',')) - {''})),
                     'generation_exception_category': attempts[-1].get('generation_exception_category', 'worker_exception') if attempts else 'worker_exception',
                     'rejected_generation_kwarg': attempts[-1].get('rejected_generation_kwarg', '') if attempts else '',
+                    'plain_completion_create_completion_callable': callable(create_completion),
+                    'plain_completion_llama_call_callable': callable(llama),
+                    'plain_completion_signature_inspectable': signature_inspectable,
+                    'plain_completion_accepts_prompt_kwarg': accepts_prompt_kwarg,
+                    'plain_completion_accepts_max_tokens_kwarg': accepts_max_tokens_kwarg,
+                    'plain_completion_accepts_var_kwargs': accepts_var_kwargs,
                 })
                 _emit(_safe_request_error('inference_exception', request=request, exc=completion_error, extra=extra))
                 continue
@@ -2567,6 +2633,12 @@ for line in sys.stdin:
                     'attempted_generation_kwargs': ','.join(sorted(set(','.join(item.get('attempted_kwarg_names', '') for item in attempts).split(',')) - {''})),
                     'generation_exception_category': invalid_reason,
                     'result_shape': _completion_result_shape(result),
+                    'plain_completion_create_completion_callable': callable(create_completion),
+                    'plain_completion_llama_call_callable': callable(llama),
+                    'plain_completion_signature_inspectable': signature_inspectable,
+                    'plain_completion_accepts_prompt_kwarg': accepts_prompt_kwarg,
+                    'plain_completion_accepts_max_tokens_kwarg': accepts_max_tokens_kwarg,
+                    'plain_completion_accepts_var_kwargs': accepts_var_kwargs,
                 })
                 _emit(_safe_request_error(invalid_reason, request=request, extra=extra))
                 continue

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -38,6 +38,11 @@ class _ApiV1ChatValidationResult(NamedTuple):
     total_content_chars: int = 0
 
 
+class LlamaCppInferenceRequestError(RuntimeError):
+    def __init__(self, message: str, *, diagnostics: Optional[Dict[str, Any]] = None) -> None:
+        self.diagnostics = diagnostics or {}
+        super().__init__(message)
+
 def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
     """Return True for request-scoped llama.cpp inference validation failures."""
 
@@ -119,6 +124,13 @@ _SAFE_WORKER_DIAGNOSTIC_KEYS = {
     "stderr_tail",
     "child_stderr_tail",
     "sanitized_error_summary",
+    "plain_completion_create_completion_callable",
+    "plain_completion_llama_call_callable",
+    "plain_completion_signature_inspectable",
+    "plain_completion_accepts_prompt_kwarg",
+    "plain_completion_accepts_max_tokens_kwarg",
+    "plain_completion_accepts_var_kwargs",
+    "qwen_api_v1_non_thinking_template_fallback",
 }
 
 
@@ -134,6 +146,7 @@ _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "runtime_chat_template_metadata_missing",
         "runtime_chat_template_renderer_unavailable",
         "runtime_template_tokenizer_bridge_unavailable",
+        "runtime_qwen_non_thinking_hard_switch_missing",
         "malformed_completion_output",
         "empty_completion_output",
         "thinking_leaked",
@@ -156,6 +169,7 @@ _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "worker_timeout",
         "worker_dead",
         "unknown_generation_exception",
+        "qwen_non_thinking_hard_switch_unavailable",
     },
     "method": {
         "apply_chat_template",
@@ -720,13 +734,11 @@ class RelayClient:
     _API_V1_MAX_TOKENS_LIMIT = 8192
     _API_V1_MAX_SEED = 2**32 - 1
     # Single source of truth for API v1 Qwen behavior. API v1 is a
-    # non-reasoning chat-completions surface: Qwen thinking is disabled via the
-    # documented message-level /no_think control because the packaged
-    # llama-cpp-python create_chat_completion path used here does not reliably
-    # expose chat-template kwargs such as enable_thinking/template_kwargs.
+    # non-reasoning chat-completions surface: Qwen thinking is disabled only by
+    # hard render/template controls, never by mutating user text with /no_think.
     _API_V1_QWEN_NON_THINKING_POLICY = {
         "thinking_mode": "disabled",
-        "message_control": "/no_think",
+        "hard_switch": "enable_thinking_false",
         "visible_think_output_forbidden": True,
         "reasoning_content_forbidden": True,
     }
@@ -2300,28 +2312,9 @@ class RelayClient:
 
     @classmethod
     def _api_v1_qwen_no_think_messages(cls, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Inject Qwen's template-supported non-thinking control into user text."""
+        """Compatibility no-op: API v1 must not inject /no_think."""
 
-        message_control = cls._API_V1_QWEN_NON_THINKING_POLICY["message_control"]
-        prepared = [dict(message) for message in messages]
-        for index in range(len(prepared) - 1, -1, -1):
-            if prepared[index].get("role") != "user":
-                continue
-            content = prepared[index].get("content")
-            if isinstance(content, str):
-                prepared[index]["content"] = f"{message_control}\n{content}"
-                return prepared
-            if isinstance(content, list):
-                copied_blocks = [dict(block) if isinstance(block, dict) else block for block in content]
-                for block in copied_blocks:
-                    if isinstance(block, dict) and isinstance(block.get("text"), str):
-                        block["text"] = f"{message_control}\n{block['text']}"
-                        prepared[index]["content"] = copied_blocks
-                        return prepared
-                copied_blocks.insert(0, {"type": "text", "text": f"{message_control}\n"})
-                prepared[index]["content"] = copied_blocks
-                return prepared
-        return prepared
+        return [dict(message) for message in messages]
 
     @classmethod
     def _api_v1_qwen_non_thinking_required(cls, model_profile: Dict[str, Any]) -> bool:
@@ -2336,9 +2329,11 @@ class RelayClient:
     def _api_v1_prepare_qwen_non_thinking_messages(
         cls, messages: List[Dict[str, Any]], model_profile: Dict[str, Any]
     ) -> List[Dict[str, Any]]:
-        if cls._api_v1_qwen_non_thinking_required(model_profile):
-            return cls._api_v1_qwen_no_think_messages(messages)
-        return messages
+        prepared = [dict(message) for message in messages]
+        # API v1 Qwen non-thinking is enforced by enable_thinking=False and the
+        # worker template fallback; user messages are copied but never mutated
+        # with hidden /no_think control text.
+        return prepared
 
     @classmethod
     def _api_v1_normalize_qwen_non_thinking_content(
@@ -3325,7 +3320,8 @@ class RelayClient:
         while True:
             runtime_kwargs = self._api_v1_runtime_completion_kwargs(safe_options)
             completion_kwargs = {"max_tokens": int(runtime_kwargs.get("max_tokens", 64) or 64)}
-            removed_set = set(removed) | (set(getattr(self, "_api_v1_generation_kwargs_filtered", set())) - set(client_option_names))
+            never_filter = {"enable_thinking"} if self._api_v1_qwen_non_thinking_required(model_profile) else set()
+            removed_set = (set(removed) | (set(getattr(self, "_api_v1_generation_kwargs_filtered", set())) - set(client_option_names))) - never_filter
             completion_kwargs = {
                 key: value for key, value in completion_kwargs.items() if key not in removed_set
             }
@@ -3335,7 +3331,7 @@ class RelayClient:
                 completion_kwargs["token_place_provider"] = model_profile.get("provider")
             if model_profile.get("chat_template_policy") and "token_place_template_policy" not in removed_set:
                 completion_kwargs["token_place_template_policy"] = model_profile.get("chat_template_policy")
-            if self._api_v1_qwen_non_thinking_required(model_profile) and "enable_thinking" not in removed_set:
+            if self._api_v1_qwen_non_thinking_required(model_profile):
                 completion_kwargs["enable_thinking"] = False
             attempted_names = sorted(str(key) for key in completion_kwargs)
             try:
@@ -3365,6 +3361,18 @@ class RelayClient:
                     if isinstance(safe_worker.get("generation_exception_category"), str)
                     else _classify_safe_generation_exception(exc)
                 )
+                if rejected == "enable_thinking":
+                    error = LlamaCppInferenceRequestError(
+                        "runtime_qwen_non_thinking_hard_switch_unavailable",
+                        diagnostics={
+                            "code": "compute_node_runtime_unavailable",
+                            "internal_reason": "runtime_qwen_non_thinking_hard_switch_unavailable",
+                            "rejected_generation_kwarg": "enable_thinking",
+                            "generation_exception_category": "qwen_non_thinking_hard_switch_unavailable",
+                            "retryable": False,
+                        },
+                    )
+                    raise error from exc
                 if category != "unsupported_generation_kwarg" or not rejected:
                     raise
                 if (rejected in client_option_names and rejected != "top_k") or rejected in {"messages", "max_tokens", "stream", "seed"} or len(removed) >= max_removed_kwargs:
@@ -3637,12 +3645,9 @@ class RelayClient:
 
         runtime_messages = self._prepare_api_v1_runtime_messages(model_id, messages)
         model_profile = getattr(self.model_manager, "model_profile", {}) or {}
-        # Use Qwen's documented /no_think message-level control before both
-        # admission and generation.  llama-cpp-python's create_chat_completion
-        # does not expose template kwargs, so admission intentionally renders the
-        # same message shape instead of adding an admission-only
-        # enable_thinking=False assistant prefix.  Output validation below still
-        # fails closed if a runtime returns visible or hidden thinking output.
+        # Preserve user messages exactly; API v1 Qwen non-thinking is enforced
+        # with hard render/template controls and output validation, not by
+        # injecting hidden /no_think control text into user content.
         runtime_messages = self._api_v1_prepare_qwen_non_thinking_messages(
             runtime_messages, model_profile
         )
@@ -3860,8 +3865,13 @@ class RelayClient:
                     "worker_timeout",
                     "worker_dead",
                     "unsupported_render_kwarg",
+                    "qwen_non_thinking_hard_switch_unavailable",
                 }:
-                    internal_reason = f"runtime_{category}"
+                    internal_reason = (
+                        "runtime_qwen_non_thinking_hard_switch_unavailable"
+                        if category == "qwen_non_thinking_hard_switch_unavailable"
+                        else f"runtime_{category}"
+                    )
                 elif category == "unsupported_generation_kwarg":
                     internal_reason = "unsupported_generation_option"
                 else:
@@ -3914,6 +3924,13 @@ class RelayClient:
                     "method",
                     "generation_exception_category",
                     "result_shape",
+                    "plain_completion_create_completion_callable",
+                    "plain_completion_llama_call_callable",
+                    "plain_completion_signature_inspectable",
+                    "plain_completion_accepts_prompt_kwarg",
+                    "plain_completion_accepts_max_tokens_kwarg",
+                    "plain_completion_accepts_var_kwargs",
+                    "qwen_api_v1_non_thinking_template_fallback",
                 ):
                     safe_value = safe_worker_diagnostics.get(safe_key)
                     if safe_value is not None:
@@ -3928,6 +3945,7 @@ class RelayClient:
                         requested_output_tokens=requested_output_tokens,
                         internal_reason=internal_reason,
                         rejected_option=rejected_option,
+                        retryable=False if category == "qwen_non_thinking_hard_switch_unavailable" else None,
                     ),
                 )
             recovery_attempted = (


### PR DESCRIPTION
### Motivation

- Production Qwen API v1 readiness was failing in the render-then-plain-completion path and the UI lacked safe scalar diagnostics naming the exact rejected kwarg/method.
- The prior implementation relied on injecting a message-level `/no_think` control, which mutates user content and is unacceptable for the API-level non-reasoning invariant.
- A deterministic template fallback and stronger invariants are required so `enable_thinking=False` is authoritative, never stripped, retried away, or replaced by hidden message mutations.

### Description

- Completely removed automatic `/no_think` injection by making `RelayClient._api_v1_qwen_no_think_messages()` a no-op and ensuring `_api_v1_prepare_qwen_non_thinking_messages()` copies but does not mutate user messages; tests expecting injected `/no_think` were updated accordingly.
- Added `_render_qwen_api_v1_non_thinking_template(messages, llama, *, add_generation_prompt=True)` inside the subprocess worker code in `utils/llm/model_manager.py` to deterministically render Qwen ChatML with an empty `<think></think>` assistant block when needed, using the exact markers `<|im_start|>`/`<|im_end|>` and optionally prepending the Llama BOS token when present.
- Reworked `_render_chat_with_runtime_template(...)` to: (a) require `enable_thinking` to be exactly `False` when present and fail closed on invalid values, (b) require the hard-switch for Qwen API v1 non-thinking when the policy/provider indicates it, (c) try direct `apply_chat_template(..., enable_thinking=False)` but never retry by dropping `enable_thinking`, (d) prefer the GGUF/Jinja renderer but, if it cannot be trusted to honour `enable_thinking=False`, fall back to the deterministic Qwen template.
- Hardened the parent relay filter in `utils/networking/relay_client.py` so Qwen API v1 always includes `completion_kwargs["enable_thinking"] = False`, marks it as never-filtered, and fails closed with safe diagnostics (internal reason `runtime_qwen_non_thinking_hard_switch_unavailable`) if a child reports it rejected `enable_thinking`.
- Kept plain-completion attempts strictly bounded: `create_completion(prompt=..., max_tokens=...)`, `create_completion(..., max_tokens=...)`, and `llama(rendered_prompt, max_tokens=...)`; no unbounded fallbacks are attempted and rejected-kwarg diagnostics are surfaced safely.
- Expanded and propagated safe diagnostic fields across worker/relay/compute-node code to include the new plain-completion capability booleans and precise `rejected_generation_kwarg`, `attempted_generation_kwargs`, `attempted_plain_completion_methods`, `method`, and `generation_exception_category`, and updated readiness mapping to derive more specific readiness reasons when possible.

### Testing

- Ran focused unit suites and diagnostics validation: `python -m pytest tests/unit/test_model_manager.py -q`, `python -m pytest tests/unit/test_relay_client.py -q`, `python -m pytest tests/unit/test_compute_node_runtime.py -q`, and `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q`; all executed unit tests passed locally (unit suites green in this run).
- Exercised targeted model_manager worker-path tests that validate render fallback, enable_thinking enforcement, and plain-completion failure diagnostics; those tests passed after the changes and the worker fallback emits the exact empty `<think></think>` assistant generation prefix while never mutating user text.
- Verified Python syntax and runtime import checks via `python -m py_compile` during the edit cycle; no syntax errors remained.

Residuals & notes

- Automatic `/no_think` injection is removed; user-provided literal `/no_think` is preserved as ordinary user content by design and tests prove the difference.
- The implementation ensures `enable_thinking=False` is the authoritative, never-dropped hard switch for API v1 Qwen paths and surfaces safe scalar diagnostics when a runtime rejects it (the real rejected kwarg is surfaced as `rejected_generation_kwarg = "enable_thinking"` and the related `internal_reason`/`generation_exception_category` map to `runtime_qwen_non_thinking_hard_switch_unavailable`/`qwen_non_thinking_hard_switch_unavailable`).
- Unbounded generation fallbacks were explicitly removed; the code only attempts the bounded call shapes documented and fails closed with safe diagnostics if `max_tokens` is unsupported.

Verification commands run (high level)

- `python -m pytest tests/unit/test_model_manager.py -q` — passed
- `python -m pytest tests/unit/test_relay_client.py -q` — passed
- `python -m pytest tests/unit/test_compute_node_runtime.py -q` — passed
- `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` — passed
- `python -m py_compile utils/llm/model_manager.py utils/networking/relay_client.py utils/compute_node_runtime.py` — passed

If you want, I can open a follow-up to run the full integration suites (`tests/integration/...`) in CI or attempt them here (they require a larger environment and longer runtime).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c99d7c71c832fbf4a38801da9a1d7)