### PR TITLE
Fix Qwen API v1 readiness diagnostics

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -493,6 +493,7 @@ _SAFE_READINESS_DIAGNOSTIC_KEYS = {
     "api_v1_readiness_completion_smoke_result",
     "api_v1_readiness_completion_smoke_failure_reason",
     "api_v1_readiness_completion_smoke_error_code",
+    "api_v1_readiness_completion_smoke_safe_summary",
     "api_v1_readiness_completion_smoke_internal_reason",
     "api_v1_readiness_completion_smoke_exception_category",
     "api_v1_readiness_completion_smoke_exception_type",

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -486,6 +486,52 @@ def emit(payload: Dict[str, Any]) -> None:
     sys.stdout.flush()
 
 
+_SAFE_READINESS_DIAGNOSTIC_KEYS = {
+    "api_v1_readiness_result",
+    "api_v1_readiness_error_code",
+    "api_v1_readiness_error_reason",
+    "api_v1_readiness_completion_smoke_result",
+    "api_v1_readiness_completion_smoke_failure_reason",
+    "api_v1_readiness_completion_smoke_error_code",
+    "api_v1_readiness_completion_smoke_internal_reason",
+    "api_v1_readiness_completion_smoke_exception_category",
+    "api_v1_readiness_completion_smoke_exception_type",
+    "api_v1_readiness_completion_smoke_rejected_generation_kwarg",
+    "api_v1_readiness_completion_smoke_attempted_generation_kwargs",
+    "api_v1_readiness_completion_smoke_attempted_plain_completion_methods",
+    "api_v1_readiness_completion_smoke_method",
+    "api_v1_readiness_completion_smoke_generation_exception_category",
+    "api_v1_readiness_completion_smoke_result_shape",
+    "api_v1_readiness_completion_smoke_plain_completion_create_completion_callable",
+    "api_v1_readiness_completion_smoke_plain_completion_llama_call_callable",
+    "api_v1_readiness_completion_smoke_plain_completion_signature_inspectable",
+    "api_v1_readiness_completion_smoke_plain_completion_accepts_prompt_kwarg",
+    "api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg",
+    "api_v1_readiness_completion_smoke_plain_completion_accepts_var_kwargs",
+    "api_v1_readiness_completion_smoke_qwen_api_v1_non_thinking_template_fallback",
+}
+_SAFE_READINESS_DIAGNOSTIC_STRING_RE = re.compile(r"^[A-Za-z0-9_.:/@,+\-]{0,256}$")
+
+
+def _safe_readiness_diagnostics(model_manager: Any) -> Dict[str, Any]:
+    diagnostics = getattr(model_manager, "last_compute_diagnostics", None)
+    if not isinstance(diagnostics, dict):
+        return {}
+    safe: Dict[str, Any] = {}
+    for key in _SAFE_READINESS_DIAGNOSTIC_KEYS:
+        if key not in diagnostics:
+            continue
+        value = diagnostics.get(key)
+        if isinstance(value, bool) or value is None:
+            safe[key] = value
+        elif isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value)):
+            safe[key] = value
+        elif isinstance(value, str):
+            bounded = value[:256]
+            if _SAFE_READINESS_DIAGNOSTIC_STRING_RE.fullmatch(bounded):
+                safe[key] = bounded
+    return safe
+
 def _relay_runtime_state(
     warm_load_state: str, *, running: bool, warm_load_enabled: bool = True
 ) -> str:
@@ -987,6 +1033,7 @@ def run(args: argparse.Namespace) -> int:
             "runtime_path": runtime_path,
             "relay_runtime_path": relay_runtime_path,
         }
+        payload.update(_safe_readiness_diagnostics(runtime.model_manager))
         payload.update(worker_lifecycle_status())
         if extra:
             payload.update(extra)

--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -249,7 +249,20 @@ def test_qwen64k_packaged_subprocess_generation_error_preserves_safe_diagnostics
         diagnostics = manager.last_compute_diagnostics
         assert diagnostics['api_v1_readiness_error_reason'] == 'runtime_completion_smoke_kv_cache_allocation'
         assert diagnostics['api_v1_readiness_error_reason'] != 'runtime_completion_smoke_exception'
-        assert 'SECRET_PROMPT' not in str(diagnostics)
+        assert diagnostics['api_v1_readiness_completion_smoke_method'] == 'create_completion_keyword_prompt'
+        assert diagnostics['api_v1_readiness_completion_smoke_attempted_generation_kwargs'] == 'max_tokens,prompt'
+        assert diagnostics['api_v1_readiness_completion_smoke_attempted_plain_completion_methods'] == 'create_completion_keyword_prompt'
+        assert diagnostics['api_v1_readiness_completion_smoke_generation_exception_category'] == 'kv_cache_allocation'
+        assert diagnostics['api_v1_readiness_completion_smoke_plain_completion_create_completion_callable'] is True
+        assert diagnostics['api_v1_readiness_completion_smoke_plain_completion_llama_call_callable'] is False
+        assert diagnostics['api_v1_readiness_completion_smoke_plain_completion_signature_inspectable'] is True
+        assert diagnostics['api_v1_readiness_completion_smoke_plain_completion_accepts_prompt_kwarg'] is True
+        assert diagnostics['api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg'] is True
+        assert diagnostics['api_v1_readiness_completion_smoke_plain_completion_accepts_var_kwargs'] is True
+        dumped = json.dumps(diagnostics)
+        assert 'SECRET_PROMPT' not in dumped
+        for unsafe in ('assistant_output', 'decrypted_payload', 'key', 'tool_args', 'ciphertext'):
+            assert f'"{unsafe}"' not in dumped
     finally:
         proxy.close()
 

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -2148,6 +2148,69 @@ def test_qwen_64k_completion_smoke_worker_exception_gets_specific_safe_reason():
     assert "SECRET" not in json.dumps(diagnostics)
 
 
+def test_qwen_64k_completion_smoke_exception_promotes_safe_nested_worker_diagnostics():
+    from utils.llm.model_manager import LlamaCppInferenceRequestError
+
+    unsafe_fields = {
+        "prompt": "SECRET_PROMPT",
+        "rendered_prompt": "SECRET_RENDERED_PROMPT",
+        "assistant_output": "SECRET_OUTPUT",
+        "decrypted_payload": "SECRET_PAYLOAD",
+        "ciphertext": "SECRET_CIPHERTEXT",
+        "key": "SECRET_KEY",
+        "tool_args": {"secret": True},
+    }
+
+    class FailingRuntime(_Qwen64kRuntime):
+        def create_chat_completion_from_rendered_prompt(self, messages, **_kwargs):
+            raise LlamaCppInferenceRequestError(
+                "outer wrapper with SECRET_PROMPT",
+                diagnostics={
+                    **unsafe_fields,
+                    "method": "create_completion_keyword_prompt",
+                    "attempted_generation_kwargs": "max_tokens,prompt",
+                    "attempted_plain_completion_methods": "create_completion_keyword_prompt",
+                    "generation_exception_category": "worker_timeout",
+                    "exception_type": "TimeoutError",
+                    "sanitized_error_summary": "TimeoutError:redacted",
+                    "plain_completion_create_completion_callable": True,
+                    "plain_completion_llama_call_callable": True,
+                    "plain_completion_signature_inspectable": True,
+                    "plain_completion_accepts_prompt_kwarg": True,
+                    "plain_completion_accepts_max_tokens_kwarg": True,
+                    "plain_completion_accepts_var_kwargs": False,
+                    "qwen_api_v1_non_thinking_template_fallback": True,
+                },
+            )
+
+    model_manager = _qwen_64k_model_manager(FailingRuntime())
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=_ready_relay_client(),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_method"] == "create_completion_keyword_prompt"
+    assert diagnostics["api_v1_readiness_completion_smoke_attempted_generation_kwargs"] == "max_tokens,prompt"
+    assert diagnostics["api_v1_readiness_completion_smoke_attempted_plain_completion_methods"] == "create_completion_keyword_prompt"
+    assert diagnostics["api_v1_readiness_completion_smoke_generation_exception_category"] == "worker_timeout"
+    assert diagnostics["api_v1_readiness_completion_smoke_exception_type"] == "TimeoutError"
+    assert diagnostics["api_v1_readiness_completion_smoke_plain_completion_create_completion_callable"] is True
+    assert diagnostics["api_v1_readiness_completion_smoke_plain_completion_llama_call_callable"] is True
+    assert diagnostics["api_v1_readiness_completion_smoke_plain_completion_signature_inspectable"] is True
+    assert diagnostics["api_v1_readiness_completion_smoke_plain_completion_accepts_prompt_kwarg"] is True
+    assert diagnostics["api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg"] is True
+    assert diagnostics["api_v1_readiness_completion_smoke_plain_completion_accepts_var_kwargs"] is False
+    assert diagnostics["api_v1_readiness_completion_smoke_qwen_api_v1_non_thinking_template_fallback"] is True
+    dumped = json.dumps(diagnostics)
+    for unsafe_key in unsafe_fields:
+        assert f'"{unsafe_key}"' not in dumped
+    assert "SECRET_" not in dumped
+
+
 def test_qwen_64k_yarn_eval_exception_fails_closed_before_registration():
     class FailingRuntime(_Qwen64kRuntime):
         def create_chat_completion_from_rendered_prompt(self, messages, **_kwargs):

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -980,6 +980,86 @@ def test_compute_node_runtime_readiness_smoke_completion_rejects_missing_content
     assert diagnostics["api_v1_readiness_error_reason"] == "runtime_completion_smoke_invalid_model_output"
 
 
+def test_compute_node_runtime_exception_path_promotes_nested_worker_failure_details(monkeypatch):
+    class NestedWorkerDiagnosticException(Exception):
+        def __init__(self):
+            super().__init__("outer wrapper with SECRET_PROMPT")
+            self.diagnostics = {
+                "worker_diagnostics": {
+                    "prompt": "SECRET_PROMPT",
+                    "rendered_prompt": "SECRET_RENDERED_PROMPT",
+                    "assistant_output": "SECRET_OUTPUT",
+                    "decrypted_payload": "SECRET_PAYLOAD",
+                    "ciphertext": "SECRET_CIPHERTEXT",
+                    "key": "SECRET_KEY",
+                    "tool_args": {"secret": True},
+                    "method": "create_completion_keyword_prompt",
+                    "attempted_generation_kwargs": "max_tokens,prompt",
+                    "attempted_plain_completion_methods": "create_completion_keyword_prompt",
+                    "generation_exception_category": "worker_timeout",
+                    "exception_type": "TimeoutError",
+                    "sanitized_error_summary": "TimeoutError:redacted",
+                    "plain_completion_create_completion_callable": True,
+                    "plain_completion_llama_call_callable": True,
+                    "plain_completion_signature_inspectable": True,
+                    "plain_completion_accepts_prompt_kwarg": True,
+                    "plain_completion_accepts_max_tokens_kwarg": True,
+                    "plain_completion_accepts_var_kwargs": False,
+                    "qwen_api_v1_non_thinking_template_fallback": True,
+                }
+            }
+
+    class RaisingRelayClient:
+        def _api_v1_authoritative_context_admission(self, **_kwargs):
+            return True, None, 2
+
+        def _generate_api_v1_response_with_runtime_model(self, **_kwargs):
+            raise NestedWorkerDiagnosticException()
+
+    monkeypatch.setenv("TOKEN_PLACE_API_V1_READINESS_SMOKE_COMPLETION", "1")
+    model_manager = MagicMock()
+    model_manager.use_mock_llm = True
+    model_manager.model_profile = {"provider": "local", "thinking_mode": "n/a"}
+    model_manager.context_tier = "8k-fast"
+    model_manager.context_window_tokens = 8192
+    model_manager.api_model_id = "local-model"
+    model_manager.last_compute_diagnostics = {}
+    model_manager.get_llm_instance.return_value = _ReadyRuntime()
+    runtime = ComputeNodeRuntime(
+        ComputeNodeRuntimeConfig(relay_url="https://token.place", relay_port=None),
+        model_manager=model_manager,
+        relay_client=RaisingRelayClient(),
+        crypto_manager=MagicMock(),
+    )
+
+    assert runtime.ensure_api_v1_runtime_ready() is False
+    diagnostics = model_manager.last_compute_diagnostics
+    assert diagnostics["api_v1_readiness_completion_smoke_method"] == "create_completion_keyword_prompt"
+    assert diagnostics["api_v1_readiness_completion_smoke_attempted_generation_kwargs"] == "max_tokens,prompt"
+    assert diagnostics["api_v1_readiness_completion_smoke_attempted_plain_completion_methods"] == "create_completion_keyword_prompt"
+    assert diagnostics["api_v1_readiness_completion_smoke_generation_exception_category"] == "worker_timeout"
+    assert diagnostics["api_v1_readiness_completion_smoke_exception_type"] == "TimeoutError"
+    assert diagnostics["api_v1_readiness_completion_smoke_safe_summary"] == "TimeoutError:redacted"
+    assert diagnostics["api_v1_readiness_completion_smoke_plain_completion_create_completion_callable"] is True
+    assert diagnostics["api_v1_readiness_completion_smoke_plain_completion_llama_call_callable"] is True
+    assert diagnostics["api_v1_readiness_completion_smoke_plain_completion_signature_inspectable"] is True
+    assert diagnostics["api_v1_readiness_completion_smoke_plain_completion_accepts_prompt_kwarg"] is True
+    assert diagnostics["api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg"] is True
+    assert diagnostics["api_v1_readiness_completion_smoke_plain_completion_accepts_var_kwargs"] is False
+    assert diagnostics["api_v1_readiness_completion_smoke_qwen_api_v1_non_thinking_template_fallback"] is True
+    dumped = json.dumps(diagnostics)
+    for unsafe_key in (
+        "prompt",
+        "rendered_prompt",
+        "assistant_output",
+        "decrypted_payload",
+        "ciphertext",
+        "key",
+        "tool_args",
+    ):
+        assert f'"{unsafe_key}"' not in dumped
+    assert "SECRET_" not in dumped
+
 def test_compute_node_runtime_promotes_nested_worker_diagnostics_to_flat_readiness_fields(monkeypatch):
     class NestedWorkerDiagnosticRelayClient:
         def _api_v1_authoritative_context_admission(self, **_kwargs):

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -4797,6 +4797,7 @@ def test_safe_readiness_diagnostics_allowlists_scalar_fields_and_drops_unsafe_fi
             'api_v1_readiness_completion_smoke_safe_summary': 'RuntimeError:worker_timeout',
             'api_v1_readiness_completion_smoke_plain_completion_create_completion_callable': True,
             'api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg': False,
+            'api_v1_readiness_completion_smoke_plain_completion_accepts_var_kwargs': True,
             'api_v1_readiness_completion_smoke_exception_type': 'RuntimeError',
             'api_v1_readiness_completion_smoke_result_shape': 'dict_malformed',
             'prompt': 'SECRET_PROMPT',
@@ -4818,6 +4819,7 @@ def test_safe_readiness_diagnostics_allowlists_scalar_fields_and_drops_unsafe_fi
     assert safe['api_v1_readiness_completion_smoke_safe_summary'] == 'RuntimeError:worker_timeout'
     assert safe['api_v1_readiness_completion_smoke_plain_completion_create_completion_callable'] is True
     assert safe['api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg'] is False
+    assert safe['api_v1_readiness_completion_smoke_plain_completion_accepts_var_kwargs'] is True
     dumped = json.dumps(safe)
     assert 'SECRET_' not in dumped
     assert 'prompt text' not in dumped

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -4784,3 +4784,39 @@ def test_desktop_runtime_context_shim_uses_legacy_call_when_signature_uninspecta
         'runtime_action': 'legacy_uninspectable'
     }
     assert calls == ['auto']
+
+
+def test_safe_readiness_diagnostics_allowlists_scalar_fields_and_drops_unsafe_fields():
+    manager = SimpleNamespace(
+        last_compute_diagnostics={
+            'api_v1_readiness_result': 'failed',
+            'api_v1_readiness_error_code': 'compute_node_internal_error',
+            'api_v1_readiness_error_reason': 'runtime_completion_smoke_plain_completion_worker_exception',
+            'api_v1_readiness_completion_smoke_method': 'create_completion_keyword_prompt',
+            'api_v1_readiness_completion_smoke_attempted_generation_kwargs': 'max_tokens,prompt',
+            'api_v1_readiness_completion_smoke_plain_completion_create_completion_callable': True,
+            'api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg': False,
+            'api_v1_readiness_completion_smoke_exception_type': 'RuntimeError',
+            'api_v1_readiness_completion_smoke_result_shape': 'dict_malformed',
+            'prompt': 'SECRET_PROMPT',
+            'rendered_prompt': '<|im_start|>SECRET_PROMPT',
+            'assistant_output': 'SECRET_OUTPUT',
+            'decrypted_payload': 'SECRET_PAYLOAD',
+            'ciphertext': 'SECRET_CIPHERTEXT_INTERNALS',
+            'key': 'SECRET_KEY',
+            'tool_args': {'secret': True},
+            'api_v1_readiness_completion_smoke_internal_reason': 'bad value with spaces and secret prompt',
+        }
+    )
+
+    safe = compute_node_bridge._safe_readiness_diagnostics(manager)
+
+    assert safe['api_v1_readiness_result'] == 'failed'
+    assert safe['api_v1_readiness_completion_smoke_method'] == 'create_completion_keyword_prompt'
+    assert safe['api_v1_readiness_completion_smoke_attempted_generation_kwargs'] == 'max_tokens,prompt'
+    assert safe['api_v1_readiness_completion_smoke_plain_completion_create_completion_callable'] is True
+    assert safe['api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg'] is False
+    dumped = json.dumps(safe)
+    assert 'SECRET_' not in dumped
+    assert 'prompt text' not in dumped
+    assert 'api_v1_readiness_completion_smoke_internal_reason' not in safe

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -4794,6 +4794,7 @@ def test_safe_readiness_diagnostics_allowlists_scalar_fields_and_drops_unsafe_fi
             'api_v1_readiness_error_reason': 'runtime_completion_smoke_plain_completion_worker_exception',
             'api_v1_readiness_completion_smoke_method': 'create_completion_keyword_prompt',
             'api_v1_readiness_completion_smoke_attempted_generation_kwargs': 'max_tokens,prompt',
+            'api_v1_readiness_completion_smoke_safe_summary': 'RuntimeError:worker_timeout',
             'api_v1_readiness_completion_smoke_plain_completion_create_completion_callable': True,
             'api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg': False,
             'api_v1_readiness_completion_smoke_exception_type': 'RuntimeError',
@@ -4814,6 +4815,7 @@ def test_safe_readiness_diagnostics_allowlists_scalar_fields_and_drops_unsafe_fi
     assert safe['api_v1_readiness_result'] == 'failed'
     assert safe['api_v1_readiness_completion_smoke_method'] == 'create_completion_keyword_prompt'
     assert safe['api_v1_readiness_completion_smoke_attempted_generation_kwargs'] == 'max_tokens,prompt'
+    assert safe['api_v1_readiness_completion_smoke_safe_summary'] == 'RuntimeError:worker_timeout'
     assert safe['api_v1_readiness_completion_smoke_plain_completion_create_completion_callable'] is True
     assert safe['api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg'] is False
     dumped = json.dumps(safe)

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -7083,6 +7083,62 @@ def test_llama_worker_render_complete_continues_to_llama_after_generic_create_co
     assert result == {'choices': [{'message': {'role': 'assistant', 'content': 'callable recovered'}}]}
 
 
+@pytest.mark.parametrize(
+    ("message", "category"),
+    [
+        ("KV cache allocation failed", "kv_cache_allocation"),
+        ("Metal buffer allocation out of memory", "metal_memory_allocation"),
+        ("RoPE YaRN eval failure", "rope_yarn_eval_failure"),
+    ],
+)
+def test_llama_worker_render_complete_fatal_plain_completion_failure_does_not_retry(
+    tmp_path, monkeypatch, message, category
+):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / f"fatal fallback fake site {category}"
+    fake_pkg = fake_site / "llama_cpp"
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / "__init__.py").write_text(
+        "MESSAGE = " + repr(message) + "\n"
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def create_completion(self, *args, **kwargs):\n"
+        "        if 'max_tokens' not in kwargs or kwargs['max_tokens'] <= 0:\n"
+        "            raise AssertionError('unbounded create_completion')\n"
+        "        if args:\n"
+        "            raise AssertionError('positional create_completion fallback attempted')\n"
+        "        raise RuntimeError(MESSAGE)\n"
+        "    def __call__(self, prompt, **kwargs):\n"
+        "        raise AssertionError('llama callable fallback attempted')\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+    monkeypatch.setenv("TOKEN_PLACE_ENV", "testing")
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / "mock.gguf"),
+        timeout_seconds=5,
+    )
+    try:
+        with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as exc_info:
+            proxy.create_chat_completion_from_rendered_prompt(
+                [{"role": "user", "content": "secret prompt text"}],
+                max_tokens=4,
+                token_place_provider="qwen",
+                token_place_template_policy="gguf-jinja",
+                enable_thinking=False,
+            )
+    finally:
+        proxy.close()
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics["generation_exception_category"] == category
+    assert diagnostics["attempted_generation_kwargs"] == "max_tokens,prompt"
+    assert diagnostics["attempted_plain_completion_methods"] == "create_completion_keyword_prompt"
+
+
 def test_llama_worker_render_complete_max_tokens_rejected_fails_closed_without_unbounded_fallback(tmp_path, monkeypatch):
     from utils.llm import model_manager as model_manager_module
 

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -6996,3 +6996,130 @@ def test_llama_worker_render_complete_empty_and_thinking_fail_safely(tmp_path, m
     assert empty_exc.value.diagnostics['generation_exception_category'] == 'empty_completion_output'
     assert think_exc.value.diagnostics['generation_exception_category'] == 'thinking_leaked'
     assert 'secret reasoning' not in json.dumps(think_exc.value.diagnostics)
+
+
+def test_llama_worker_render_complete_continues_after_generic_keyword_worker_exception(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'generic keyword fallback fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        self.calls = []\n"
+        "    def create_completion(self, *args, **kwargs):\n"
+        "        if 'prompt' in kwargs:\n"
+        "            raise RuntimeError('generic wrapper failure')\n"
+        "        if len(args) == 1 and set(kwargs) == {'max_tokens'} and kwargs['max_tokens'] > 0:\n"
+        "            return {'choices': [{'text': 'positional recovered'}]}\n"
+        "        raise TypeError('bad shape')\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'testing')
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'mock.gguf'),
+        timeout_seconds=5,
+    )
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt(
+            [{'role': 'user', 'content': 'secret prompt text'}],
+            max_tokens=4,
+            token_place_provider='qwen',
+            token_place_template_policy='gguf-jinja',
+            enable_thinking=False,
+        )
+    finally:
+        proxy.close()
+
+    assert result == {'choices': [{'message': {'role': 'assistant', 'content': 'positional recovered'}}]}
+
+
+def test_llama_worker_render_complete_continues_to_llama_after_generic_create_completion_failures(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'generic callable fallback fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def create_completion(self, *args, **kwargs):\n"
+        "        if 'max_tokens' not in kwargs:\n"
+        "            raise AssertionError('unbounded create_completion')\n"
+        "        raise RuntimeError('generic wrapper failure')\n"
+        "    def __call__(self, prompt, **kwargs):\n"
+        "        if set(kwargs) != {'max_tokens'} or kwargs['max_tokens'] <= 0:\n"
+        "            raise AssertionError('unbounded llama call')\n"
+        "        return {'choices': [{'text': 'callable recovered'}]}\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'testing')
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'mock.gguf'),
+        timeout_seconds=5,
+    )
+    try:
+        result = proxy.create_chat_completion_from_rendered_prompt(
+            [{'role': 'user', 'content': 'secret prompt text'}],
+            max_tokens=4,
+            token_place_provider='qwen',
+            token_place_template_policy='gguf-jinja',
+            enable_thinking=False,
+        )
+    finally:
+        proxy.close()
+
+    assert result == {'choices': [{'message': {'role': 'assistant', 'content': 'callable recovered'}}]}
+
+
+def test_llama_worker_render_complete_max_tokens_rejected_fails_closed_without_unbounded_fallback(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    fake_site = tmp_path / 'max token reject fake site'
+    fake_pkg = fake_site / 'llama_cpp'
+    fake_pkg.mkdir(parents=True)
+    (fake_pkg / '__init__.py').write_text(
+        "class Llama:\n"
+        "    def __init__(self, *args, **kwargs):\n"
+        "        pass\n"
+        "    def create_completion(self, *args, **kwargs):\n"
+        "        if 'max_tokens' not in kwargs:\n"
+        "            raise AssertionError('unbounded create_completion')\n"
+        "        raise TypeError(\"got an unexpected keyword argument 'max_tokens'\")\n"
+        "    def __call__(self, prompt, **kwargs):\n"
+        "        if 'max_tokens' not in kwargs:\n"
+        "            raise AssertionError('unbounded llama call')\n"
+        "        raise TypeError(\"got an unexpected keyword argument 'max_tokens'\")\n",
+        encoding='utf-8',
+    )
+    monkeypatch.syspath_prepend(str(fake_site))
+    monkeypatch.setenv('TOKEN_PLACE_ENV', 'testing')
+
+    proxy = model_manager_module._SubprocessLlamaProxy(
+        model_path=str(tmp_path / 'mock.gguf'),
+        timeout_seconds=5,
+    )
+    try:
+        with pytest.raises(model_manager_module.LlamaCppInferenceRequestError) as exc_info:
+            proxy.create_chat_completion_from_rendered_prompt(
+                [{'role': 'user', 'content': 'secret prompt text'}],
+                max_tokens=4,
+                token_place_provider='qwen',
+                token_place_template_policy='gguf-jinja',
+                enable_thinking=False,
+            )
+    finally:
+        proxy.close()
+
+    diagnostics = exc_info.value.diagnostics
+    assert diagnostics['rejected_generation_kwarg'] == 'max_tokens'
+    assert diagnostics['attempted_generation_kwargs'] == 'max_tokens,prompt'
+    assert diagnostics['attempted_plain_completion_methods'] == (
+        'create_completion_keyword_prompt,create_completion_positional_prompt,llama_call_positional_prompt'
+    )

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -6019,6 +6019,11 @@ def test_subprocess_worker_plain_completion_helpers_cover_safe_shapes():
     assert classify_shape(TypeError("got an unexpected keyword argument 'stop'")) == 'unsupported_stop_kwarg'
     assert classify_shape(TypeError("got an unexpected keyword argument 'temperature'")) == 'unexpected_kwarg'
     assert classify_shape(RuntimeError("KV cache allocation failed")) == 'kv_cache_allocation'
+    assert classify_shape(TimeoutError("llama_cpp inference timed out")) == 'worker_timeout'
+    assert classify_shape(RuntimeError("llama_cpp worker exited during liveness check")) == 'worker_dead'
+    assert classify_shape(RuntimeError("prompt exceeds context window")) == 'context_window_exceeded'
+    assert classify_shape(RuntimeError("requested context length exceeds n_ctx")) == 'context_length_exceeded'
+    assert classify_shape(RuntimeError("too many tokens in prompt")) == 'token_overflow'
 
 
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -6316,3 +6316,50 @@ def test_api_v1_qwen_preserves_user_provided_literal_no_think():
 
     assert envelope["api_v1_response"]["message"]["content"] == "ok"
     assert manager.runtime.calls[-1]["messages"][-1]["content"] == "/no_think\nhello"
+
+
+def test_api_v1_runtime_error_promotes_plain_completion_capability_diagnostics():
+    from utils.llm.model_manager import LlamaCppInferenceRequestError
+
+    manager = _ApiV1RuntimeManager()
+    worker_diagnostics = {
+        "code": "compute_node_internal_error",
+        "generation_exception_category": "worker_exception",
+        "exception_type": "RuntimeError",
+        "method": "create_completion_keyword_prompt",
+        "attempted_generation_kwargs": "max_tokens,prompt",
+        "attempted_plain_completion_methods": "create_completion_keyword_prompt",
+        "plain_completion_create_completion_callable": True,
+        "plain_completion_llama_call_callable": True,
+        "plain_completion_signature_inspectable": True,
+        "plain_completion_accepts_prompt_kwarg": False,
+        "plain_completion_accepts_max_tokens_kwarg": True,
+        "plain_completion_accepts_var_kwargs": False,
+        "qwen_api_v1_non_thinking_template_fallback": False,
+    }
+    manager.runtime.create_chat_completion.side_effect = LlamaCppInferenceRequestError(
+        "llama_cpp request failed",
+        diagnostics=worker_diagnostics,
+    )
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-plain-capabilities",
+        model_id="llama-3-8b-instruct",
+        messages=[{"role": "user", "content": "hi"}],
+        options={},
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    for key, value in worker_diagnostics.items():
+        assert error["worker_diagnostics"].get(key) == value
+    for key in (
+        "plain_completion_create_completion_callable",
+        "plain_completion_llama_call_callable",
+        "plain_completion_signature_inspectable",
+        "plain_completion_accepts_prompt_kwarg",
+        "plain_completion_accepts_max_tokens_kwarg",
+        "plain_completion_accepts_var_kwargs",
+        "qwen_api_v1_non_thinking_template_fallback",
+    ):
+        assert error[key] == worker_diagnostics[key]

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -934,7 +934,29 @@ class ComputeNodeRuntime:
                 diagnostics["api_v1_readiness_completion_smoke_exception_type"] = exception_diagnostics.get("exception_type")
                 diagnostics["api_v1_readiness_completion_smoke_safe_summary"] = exception_diagnostics.get("sanitized_error_summary")
                 if "worker_diagnostics" in exception_diagnostics:
-                    diagnostics["api_v1_readiness_completion_smoke_worker_diagnostics"] = exception_diagnostics["worker_diagnostics"]
+                    safe_worker_diagnostics = exception_diagnostics["worker_diagnostics"]
+                    diagnostics["api_v1_readiness_completion_smoke_worker_diagnostics"] = safe_worker_diagnostics
+                    for key in (
+                        "runtime_healthy",
+                        "recovery_attempted",
+                        "recovery_succeeded",
+                        "rejected_option",
+                        "rejected_generation_kwarg",
+                        "attempted_generation_kwargs",
+                        "attempted_plain_completion_methods",
+                        "result_shape",
+                        "method",
+                        "generation_exception_category",
+                        "plain_completion_create_completion_callable",
+                        "plain_completion_llama_call_callable",
+                        "plain_completion_signature_inspectable",
+                        "plain_completion_accepts_prompt_kwarg",
+                        "plain_completion_accepts_max_tokens_kwarg",
+                        "plain_completion_accepts_var_kwargs",
+                        "qwen_api_v1_non_thinking_template_fallback",
+                    ):
+                        if key in safe_worker_diagnostics:
+                            diagnostics[f"api_v1_readiness_completion_smoke_{key}"] = safe_worker_diagnostics[key]
                 diagnostics["api_v1_readiness_repair_retry_attempted"] = False
                 diagnostics["api_v1_readiness_recovery_succeeded"] = False
             diagnostics["api_v1_runtime_ready"] = bool(admitted)

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -231,7 +231,10 @@ def _classify_completion_smoke_exception(exc: BaseException) -> Tuple[str, str, 
     }
     worker_diagnostics = getattr(exc, "diagnostics", None)
     if isinstance(worker_diagnostics, dict):
-        safe_worker = _safe_completion_smoke_worker_diagnostics(worker_diagnostics)
+        raw_worker_diagnostics = worker_diagnostics.get("worker_diagnostics")
+        if not isinstance(raw_worker_diagnostics, dict):
+            raw_worker_diagnostics = worker_diagnostics
+        safe_worker = _safe_completion_smoke_worker_diagnostics(raw_worker_diagnostics)
         diagnostics["worker_diagnostics"] = safe_worker
         category = safe_worker.get("generation_exception_category")
         if category in _COMPLETION_SMOKE_REASON_BY_CATEGORY:

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -936,6 +936,14 @@ class ComputeNodeRuntime:
                 if "worker_diagnostics" in exception_diagnostics:
                     safe_worker_diagnostics = exception_diagnostics["worker_diagnostics"]
                     diagnostics["api_v1_readiness_completion_smoke_worker_diagnostics"] = safe_worker_diagnostics
+                    if safe_worker_diagnostics.get("exception_type"):
+                        diagnostics["api_v1_readiness_completion_smoke_exception_type"] = safe_worker_diagnostics[
+                            "exception_type"
+                        ]
+                    if safe_worker_diagnostics.get("sanitized_error_summary"):
+                        diagnostics["api_v1_readiness_completion_smoke_safe_summary"] = safe_worker_diagnostics[
+                            "sanitized_error_summary"
+                        ]
                     for key in (
                         "runtime_healthy",
                         "recovery_attempted",

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1851,6 +1851,16 @@ def _classify_generation_exception(exc):
         return 'kv_cache_allocation'
     if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'eval'))):
         return 'rope_yarn_eval_failure'
+    if 'timeout' in text or 'timed out' in text:
+        return 'worker_timeout'
+    if any(term in text for term in ('worker_dead', 'worker dead', 'worker exited', 'subprocess exited', 'liveness')):
+        return 'worker_dead'
+    if any(term in text for term in ('context window', 'context_window', 'maximum context', 'exceeds context')):
+        return 'context_window_exceeded'
+    if any(term in text for term in ('context length', 'n_ctx', 'ctx size')):
+        return 'context_length_exceeded'
+    if any(term in text for term in ('token overflow', 'too many tokens', 'exceeds token')):
+        return 'token_overflow'
     if _extract_unsupported_generation_kwarg(str(exc or '')) is not None:
         return 'unsupported_generation_kwarg'
     return 'unknown_generation_exception'

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -2652,41 +2652,60 @@ for line in sys.stdin:
                     plain_capabilities['plain_completion_accepts_max_tokens_kwarg'] = 'max_tokens' in params or plain_capabilities['plain_completion_accepts_var_kwargs']
                 except Exception:
                     pass
-            if callable(create_completion):
-                attempt_method = 'create_completion_keyword_prompt'
-                attempted_kwargs = ['max_tokens', 'prompt']
+            fatal_plain_completion_categories = {
+                'metal_memory_allocation',
+                'kv_cache_allocation',
+                'rope_yarn_eval_failure',
+                'worker_timeout',
+                'worker_dead',
+                'context_window_exceeded',
+                'context_length_exceeded',
+                'token_overflow',
+            }
+            def _attempt_plain_completion(method_name, attempted_kwargs, call):
                 try:
-                    result = create_completion(prompt=rendered_prompt, max_tokens=max_tokens)
-                    completion_error = None
-                    attempts.append({'method': attempt_method, 'attempted_kwarg_names': ','.join(attempted_kwargs), 'result_shape': _completion_result_shape(result)})
+                    attempt_result = call()
+                    attempts.append({
+                        'method': method_name,
+                        'attempted_kwarg_names': ','.join(attempted_kwargs),
+                        'result_shape': _completion_result_shape(attempt_result),
+                    })
+                    return attempt_result, None
                 except Exception as exc:
                     category = _plain_completion_method_shape_category(exc)
                     rejected = _extract_unsupported_generation_kwarg(str(exc), attempted_kwargs)
-                    attempts.append({'method': attempt_method, 'attempted_kwarg_names': ','.join(attempted_kwargs), 'exception_type': type(exc).__name__, 'generation_exception_category': category, 'rejected_generation_kwarg': rejected or ''})
-                    completion_error = exc
-                    if category == 'unsupported_prompt_kwarg' or rejected == 'prompt':
-                        attempt_method = 'create_completion_positional_prompt'
-                        attempted_kwargs = ['max_tokens']
-                        try:
-                            result = create_completion(rendered_prompt, max_tokens=max_tokens)
-                            completion_error = None
-                            attempts.append({'method': attempt_method, 'attempted_kwarg_names': ','.join(attempted_kwargs), 'result_shape': _completion_result_shape(result)})
-                        except Exception as positional_exc:
-                            category = _plain_completion_method_shape_category(positional_exc)
-                            rejected = _extract_unsupported_generation_kwarg(str(positional_exc), attempted_kwargs)
-                            attempts.append({'method': attempt_method, 'attempted_kwarg_names': ','.join(attempted_kwargs), 'exception_type': type(positional_exc).__name__, 'generation_exception_category': category, 'rejected_generation_kwarg': rejected or ''})
-                            completion_error = positional_exc
-            if result is None and callable(llama) and (
-                not attempts
-                or attempts[-1].get('generation_exception_category') not in {'worker_exception', 'metal_memory_allocation', 'kv_cache_allocation', 'rope_yarn_eval_failure'}
+                    attempts.append({
+                        'method': method_name,
+                        'attempted_kwarg_names': ','.join(attempted_kwargs),
+                        'exception_type': type(exc).__name__,
+                        'generation_exception_category': category,
+                        'rejected_generation_kwarg': rejected or '',
+                        'sanitized_error_summary': _sanitize_error_summary(exc),
+                    })
+                    return None, exc
+
+            if callable(create_completion):
+                result, completion_error = _attempt_plain_completion(
+                    'create_completion_keyword_prompt',
+                    ['max_tokens', 'prompt'],
+                    lambda: create_completion(prompt=rendered_prompt, max_tokens=max_tokens),
+                )
+            if result is None and callable(create_completion) and (
+                not attempts or attempts[-1].get('generation_exception_category') not in fatal_plain_completion_categories
             ):
-                try:
-                    result = llama(rendered_prompt, max_tokens=max_tokens)
-                    completion_error = None
-                    attempts.append({'method': 'llama_call_positional_prompt', 'attempted_kwarg_names': 'max_tokens', 'result_shape': _completion_result_shape(result)})
-                except Exception as exc:
-                    attempts.append({'method': 'llama_call_positional_prompt', 'attempted_kwarg_names': 'max_tokens', 'exception_type': type(exc).__name__, 'generation_exception_category': _plain_completion_method_shape_category(exc), 'rejected_generation_kwarg': _extract_unsupported_generation_kwarg(str(exc), ['max_tokens']) or ''})
-                    completion_error = exc
+                result, completion_error = _attempt_plain_completion(
+                    'create_completion_positional_prompt',
+                    ['max_tokens'],
+                    lambda: create_completion(rendered_prompt, max_tokens=max_tokens),
+                )
+            if result is None and callable(llama) and (
+                not attempts or attempts[-1].get('generation_exception_category') not in fatal_plain_completion_categories
+            ):
+                result, completion_error = _attempt_plain_completion(
+                    'llama_call_positional_prompt',
+                    ['max_tokens'],
+                    lambda: llama(rendered_prompt, max_tokens=max_tokens),
+                )
             if result is None:
                 extra = dict(render_diagnostics)
                 extra.update(plain_capabilities)

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -4012,6 +4012,13 @@ class RelayClient:
                     "method",
                     "generation_exception_category",
                     "result_shape",
+                    "plain_completion_create_completion_callable",
+                    "plain_completion_llama_call_callable",
+                    "plain_completion_signature_inspectable",
+                    "plain_completion_accepts_prompt_kwarg",
+                    "plain_completion_accepts_max_tokens_kwarg",
+                    "plain_completion_accepts_var_kwargs",
+                    "qwen_api_v1_non_thinking_template_fallback",
                 ):
                     safe_value = safe_worker_diagnostics.get(safe_key)
                     if safe_value is not None:


### PR DESCRIPTION
### Motivation
- Warm-load failures for the Qwen API v1 packaged macOS runtime collapsed to an uninformative desktop `last_error` and hid the safe scalar diagnostics needed to triage which bounded plain-completion method failed.
- The plain-completion fallback was brittle and could stop after a generic wrapper exception without trying alternate bounded call shapes, preventing recovery for method-shape-specific failures.
- Relay and compute readiness paths needed to promote plain-completion capability booleans so the desktop bridge can consume the same safe readiness fields without inferring nested shapes.

### Description
- Add a bounded allowlist and sanitizer `_safe_readiness_diagnostics(model_manager: Any)` in `desktop-tauri/src-tauri/python/compute_node_bridge.py` and merge its output into status/error payloads so desktop JSON events expose only safe scalar readiness fields.
- Promote plain-completion capability booleans and qwen non-thinking fallback flag in `utils/networking/relay_client.py` top-level `safe_error` so worker diagnostics are available both nested and flattened in API v1 error envelopes.
- Ensure `utils/compute_node_runtime.py` flattens/promotes the same safe worker diagnostics from exception diagnostics into `model_manager.last_compute_diagnostics` for readiness smoke failures.
- Improve subprocess plain-completion handling in `utils/llm/model_manager.py` to: (a) always include method, attempted methods, attempted kwargs, exception type, sanitized summary and capability booleans in failure diagnostics; (b) try bounded shapes in order `create_completion(prompt=..., max_tokens=...)`, `create_completion(rendered_prompt, max_tokens=...)`, `llama(rendered_prompt, max_tokens=...)`; and (c) stop retrying on fatal categories while never omitting `max_tokens`.
- Add unit/regression tests covering the safe desktop readiness allowlist, relay-client promotion of capability diagnostics, compute runtime promotion of nested worker diagnostics, and the bounded plain-completion fallback behaviors and failure shapes in `tests/unit` and an integration packaged runtime test.

### Testing
- Ran unit test suites and they passed: `python -m pytest tests/unit/test_model_manager.py -q` (pass), `python -m pytest tests/unit/test_relay_client.py -q` (pass), `python -m pytest tests/unit/test_compute_node_runtime.py -q` (pass), and `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` (pass).
- Ran integration tests and they passed: `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (pass) and `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q` (pass).
- Ran repository checks `git diff --check` (no issues) and `pre-commit run --all-files` (passed).
- Tests specifically added/updated: `tests/unit/test_model_manager.py`, `tests/unit/test_relay_client.py`, `tests/unit/test_compute_node_runtime.py`, `tests/unit/test_desktop_compute_node_bridge.py`, and `tests/integration/test_desktop_qwen64k_packaged_runtime.py`, and all automated checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4df3492708832f9618bb9481d16954)