### PR TITLE
Add bounded token-ID fallback for Qwen API v1 plain completion

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -509,6 +509,12 @@ _SAFE_READINESS_DIAGNOSTIC_KEYS = {
     "api_v1_readiness_completion_smoke_plain_completion_accepts_prompt_kwarg",
     "api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg",
     "api_v1_readiness_completion_smoke_plain_completion_accepts_var_kwargs",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_attempted",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_token_count",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_error_category",
+    "api_v1_readiness_completion_smoke_plain_completion_reset_after_failure_count",
     "api_v1_readiness_completion_smoke_qwen_api_v1_non_thinking_template_fallback",
 }
 _SAFE_READINESS_DIAGNOSTIC_STRING_RE = re.compile(r"^[A-Za-z0-9_.:/@,+\-]{0,256}$")

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -267,6 +267,12 @@ const SAFE_READINESS_DIAGNOSTIC_KEYS: &[&str] = &[
     "api_v1_readiness_completion_smoke_plain_completion_accepts_prompt_kwarg",
     "api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg",
     "api_v1_readiness_completion_smoke_plain_completion_accepts_var_kwargs",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_attempted",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_token_count",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_error_category",
+    "api_v1_readiness_completion_smoke_plain_completion_reset_after_failure_count",
     "api_v1_readiness_completion_smoke_qwen_api_v1_non_thinking_template_fallback",
 ];
 

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -62,6 +62,9 @@ _COMPLETION_SMOKE_REASON_BY_CATEGORY = {
     "empty_completion_output": "runtime_completion_smoke_plain_completion_empty_output",
     "thinking_leaked": "runtime_completion_smoke_plain_completion_thinking_leaked",
     "worker_exception": "runtime_completion_smoke_plain_completion_worker_exception",
+    "prompt_tokenization_failure": "runtime_completion_smoke_plain_completion_prompt_tokenization_failure",
+    "prompt_eval_failure": "runtime_completion_smoke_plain_completion_eval_failure",
+    "sampling_failure": "runtime_completion_smoke_plain_completion_sampling_failure",
     "worker_timeout": "runtime_completion_smoke_worker_timeout",
     "worker_dead": "runtime_completion_smoke_worker_dead",
 }
@@ -81,6 +84,12 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_KEYS = {
     "plain_completion_accepts_prompt_kwarg",
     "plain_completion_accepts_max_tokens_kwarg",
     "plain_completion_accepts_var_kwargs",
+    "plain_completion_prompt_tokenization_attempted",
+    "plain_completion_prompt_token_count",
+    "plain_completion_prompt_tokenization_method",
+    "plain_completion_prompt_tokenization_special",
+    "plain_completion_prompt_tokenization_error_category",
+    "plain_completion_reset_after_failure_count",
     "qwen_api_v1_non_thinking_template_fallback",
     "result_shape",
     "method",
@@ -133,6 +142,10 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "unsupported_stop_kwarg",
         "method_shape",
         "worker_exception",
+        "prompt_tokenization_failure",
+        "prompt_eval_failure",
+        "sampling_failure",
+        "tokenizer_unavailable",
         "empty_completion_output",
         "thinking_leaked",
         "worker_timeout",
@@ -152,6 +165,9 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "create_completion_keyword_prompt",
         "create_completion_positional_prompt",
         "llama_call_positional_prompt",
+        "create_completion_keyword_token_ids",
+        "create_completion_positional_token_ids",
+        "llama.tokenize",
         "tokenize",
     },
     "kv_cache_mode": {"f16", "q8_0", "q4_0", "auto", "unknown"},
@@ -160,7 +176,7 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-
 _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_CLASS_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]{0,127}$")
 _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_REDACTED_SUMMARY_RE = re.compile(
     r"^[A-Za-z_][A-Za-z0-9_.]{0,127}:(?:redacted|metal_memory_allocation|kv_cache_allocation|"
-    r"rope_yarn_eval_failure|unsupported_kwarg)$"
+    r"rope_yarn_eval_failure|unsupported_kwarg|prompt_tokenization_failure|prompt_eval_failure|sampling_failure)$"
 )
 _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_TAIL_WORDS = {
     "llama", "llama_context", "ggml", "metal", "kv", "cache", "alloc", "allocation",
@@ -890,6 +906,12 @@ class ComputeNodeRuntime:
                         "plain_completion_accepts_prompt_kwarg",
                         "plain_completion_accepts_max_tokens_kwarg",
                         "plain_completion_accepts_var_kwargs",
+                        "plain_completion_prompt_tokenization_attempted",
+                        "plain_completion_prompt_token_count",
+                        "plain_completion_prompt_tokenization_method",
+                        "plain_completion_prompt_tokenization_special",
+                        "plain_completion_prompt_tokenization_error_category",
+                        "plain_completion_reset_after_failure_count",
                         "qwen_api_v1_non_thinking_template_fallback",
                     ):
                         if key in smoke_error:
@@ -964,6 +986,12 @@ class ComputeNodeRuntime:
                     "plain_completion_accepts_prompt_kwarg",
                     "plain_completion_accepts_max_tokens_kwarg",
                     "plain_completion_accepts_var_kwargs",
+    "plain_completion_prompt_tokenization_attempted",
+    "plain_completion_prompt_token_count",
+    "plain_completion_prompt_tokenization_method",
+    "plain_completion_prompt_tokenization_special",
+    "plain_completion_prompt_tokenization_error_category",
+    "plain_completion_reset_after_failure_count",
                     "qwen_api_v1_non_thinking_template_fallback",
                 ):
                     if key in exception_diagnostics:
@@ -996,6 +1024,12 @@ class ComputeNodeRuntime:
                         "plain_completion_accepts_prompt_kwarg",
                         "plain_completion_accepts_max_tokens_kwarg",
                         "plain_completion_accepts_var_kwargs",
+                        "plain_completion_prompt_tokenization_attempted",
+                        "plain_completion_prompt_token_count",
+                        "plain_completion_prompt_tokenization_method",
+                        "plain_completion_prompt_tokenization_special",
+                        "plain_completion_prompt_tokenization_error_category",
+                        "plain_completion_reset_after_failure_count",
                         "qwen_api_v1_non_thinking_template_fallback",
                     ):
                         if key in safe_worker_diagnostics:

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -1831,18 +1831,6 @@ def _extract_unsupported_generation_kwarg(message, attempted=None):
                 return rejected
     return None
 
-def _sanitize_error_summary(message):
-    text = str(message or '').lower()
-    if 'metal' in text and any(term in text for term in ('alloc', 'memory', 'out of memory', 'oom')):
-        return type(message).__name__ + ':metal_memory_allocation'
-    if 'kv' in text and any(term in text for term in ('alloc', 'cache', 'memory', 'out of memory', 'oom')):
-        return type(message).__name__ + ':kv_cache_allocation'
-    if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'eval'))):
-        return type(message).__name__ + ':rope_yarn_eval_failure'
-    if _extract_unsupported_generation_kwarg(str(message or '')) is not None:
-        return type(message).__name__ + ':unsupported_kwarg'
-    return type(message).__name__ + ':redacted'
-
 def _classify_generation_exception(exc):
     text = str(exc or '').lower()
     if 'metal' in text and any(term in text for term in ('alloc', 'memory', 'out of memory', 'oom')):
@@ -1861,9 +1849,23 @@ def _classify_generation_exception(exc):
         return 'context_length_exceeded'
     if any(term in text for term in ('token overflow', 'too many tokens', 'exceeds token')):
         return 'token_overflow'
+    if any(term in text for term in ('failed to tokenize', 'tokenization failed', 'llama_tokenize', 'could not tokenize')):
+        return 'prompt_tokenization_failure'
+    if any(term in text for term in ('failed to eval', 'failed to evaluate', 'model failed to evaluate', 'llama_eval', 'llama_decode', 'decode failed', 'decode returned')):
+        return 'prompt_eval_failure'
+    if any(term in text for term in ('sample failed', 'sampler', 'logits', 'no logits')):
+        return 'sampling_failure'
     if _extract_unsupported_generation_kwarg(str(exc or '')) is not None:
         return 'unsupported_generation_kwarg'
     return 'unknown_generation_exception'
+
+def _sanitize_error_summary(message):
+    category = _classify_generation_exception(message)
+    if category != 'unknown_generation_exception':
+        return type(message).__name__ + ':' + category
+    if _extract_unsupported_generation_kwarg(str(message or '')) is not None:
+        return type(message).__name__ + ':unsupported_kwarg'
+    return type(message).__name__ + ':redacted'
 
 def _plain_completion_method_shape_category(exc):
     text = str(exc or '').lower()
@@ -2010,6 +2012,12 @@ def _safe_request_error(reason, *, request=None, exc=None, extra=None):
             'plain_completion_accepts_prompt_kwarg',
             'plain_completion_accepts_max_tokens_kwarg',
             'plain_completion_accepts_var_kwargs',
+            'plain_completion_prompt_tokenization_attempted',
+            'plain_completion_prompt_token_count',
+            'plain_completion_prompt_tokenization_method',
+            'plain_completion_prompt_tokenization_special',
+            'plain_completion_prompt_tokenization_error_category',
+            'plain_completion_reset_after_failure_count',
         }
         for key, value in extra.items():
             if (
@@ -2480,6 +2488,68 @@ def _render_testing_chat_template_fallback(args, kwargs):
         rendered_parts.append('<|im_start|>assistant\\n')
     return '\\n'.join(rendered_parts)
 
+
+def _tokenize_rendered_prompt_for_plain_completion(llama, rendered_prompt):
+    diagnostics = {
+        'plain_completion_prompt_tokenization_attempted': True,
+        'plain_completion_prompt_token_count': 0,
+        'plain_completion_prompt_tokenization_method': '',
+        'plain_completion_prompt_tokenization_special': None,
+        'plain_completion_prompt_tokenization_error_category': '',
+    }
+    tokenize = getattr(llama, 'tokenize', None)
+    if not callable(tokenize):
+        diagnostics['plain_completion_prompt_tokenization_error_category'] = 'tokenizer_unavailable'
+        return None, diagnostics
+    supports_special = False
+    try:
+        params = inspect.signature(tokenize).parameters
+        supports_special = 'special' in params or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+    except Exception:
+        supports_special = False
+    encoded = rendered_prompt.encode('utf-8')
+    call_specs = ([True, False] if supports_special else [False])
+    for special in call_specs:
+        try:
+            tokens = tokenize(encoded, add_bos=False, special=special) if supports_special else tokenize(encoded, add_bos=False)
+        except TypeError:
+            if special is True:
+                supports_special = True
+                try:
+                    tokens = tokenize(encoded, add_bos=False, special=False)
+                    special = False
+                except Exception as exc:
+                    diagnostics['plain_completion_prompt_tokenization_error_category'] = _classify_generation_exception(exc)
+                    continue
+            else:
+                try:
+                    tokens = tokenize(encoded, add_bos=False)
+                except Exception as exc:
+                    diagnostics['plain_completion_prompt_tokenization_error_category'] = _classify_generation_exception(exc)
+                    continue
+        except Exception as exc:
+            diagnostics['plain_completion_prompt_tokenization_error_category'] = _classify_generation_exception(exc)
+            continue
+        if isinstance(tokens, (list, tuple)) and tokens and all(isinstance(t, int) and not isinstance(t, bool) for t in tokens):
+            diagnostics['plain_completion_prompt_token_count'] = len(tokens)
+            diagnostics['plain_completion_prompt_tokenization_method'] = 'llama.tokenize'
+            diagnostics['plain_completion_prompt_tokenization_special'] = bool(special)
+            diagnostics['plain_completion_prompt_tokenization_error_category'] = ''
+            return list(tokens), diagnostics
+        diagnostics['plain_completion_prompt_tokenization_error_category'] = 'prompt_tokenization_failure'
+    return None, diagnostics
+
+
+def _reset_plain_completion_state(llama):
+    reset = getattr(llama, 'reset', None)
+    if not callable(reset):
+        return False
+    try:
+        reset()
+        return True
+    except Exception:
+        return False
+
 try:
     init_line = sys.stdin.readline()
     if not init_line:
@@ -2672,6 +2742,26 @@ for line in sys.stdin:
                 'context_length_exceeded',
                 'token_overflow',
             }
+            reset_after_failure_count = [0]
+            tokenization_diagnostics = {
+                'plain_completion_prompt_tokenization_attempted': False,
+                'plain_completion_prompt_token_count': 0,
+                'plain_completion_prompt_tokenization_method': '',
+                'plain_completion_prompt_tokenization_special': None,
+                'plain_completion_prompt_tokenization_error_category': '',
+            }
+
+            def _last_attempt_fatal():
+                return bool(attempts and attempts[-1].get('generation_exception_category') in fatal_plain_completion_categories)
+
+            def _last_attempt_rejected_max_tokens():
+                return bool(attempts and attempts[-1].get('rejected_generation_kwarg') == 'max_tokens')
+
+            def _reset_before_next_attempt():
+                if attempts and not _last_attempt_fatal():
+                    if _reset_plain_completion_state(llama):
+                        reset_after_failure_count[0] += 1
+
             def _attempt_plain_completion(method_name, attempted_kwargs, call):
                 try:
                     attempt_result = call()
@@ -2700,25 +2790,51 @@ for line in sys.stdin:
                     ['max_tokens', 'prompt'],
                     lambda: create_completion(prompt=rendered_prompt, max_tokens=max_tokens),
                 )
-            if result is None and callable(create_completion) and (
-                not attempts or attempts[-1].get('generation_exception_category') not in fatal_plain_completion_categories
-            ):
+            if result is None and callable(create_completion) and not _last_attempt_fatal():
+                _reset_before_next_attempt()
                 result, completion_error = _attempt_plain_completion(
                     'create_completion_positional_prompt',
                     ['max_tokens'],
                     lambda: create_completion(rendered_prompt, max_tokens=max_tokens),
                 )
-            if result is None and callable(llama) and (
-                not attempts or attempts[-1].get('generation_exception_category') not in fatal_plain_completion_categories
-            ):
+            if result is None and callable(llama) and not _last_attempt_fatal():
+                _reset_before_next_attempt()
                 result, completion_error = _attempt_plain_completion(
                     'llama_call_positional_prompt',
                     ['max_tokens'],
                     lambda: llama(rendered_prompt, max_tokens=max_tokens),
                 )
+            rendered_prompt_token_ids = None
+            if result is None and callable(create_completion) and not _last_attempt_fatal() and not _last_attempt_rejected_max_tokens():
+                _reset_before_next_attempt()
+                rendered_prompt_token_ids, tokenization_diagnostics = _tokenize_rendered_prompt_for_plain_completion(llama, rendered_prompt)
+                if rendered_prompt_token_ids is None:
+                    attempts.append({
+                        'method': 'create_completion_keyword_token_ids',
+                        'attempted_kwarg_names': 'max_tokens,prompt',
+                        'exception_type': 'RuntimeError',
+                        'generation_exception_category': tokenization_diagnostics.get('plain_completion_prompt_tokenization_error_category') or 'prompt_tokenization_failure',
+                        'rejected_generation_kwarg': '',
+                        'sanitized_error_summary': 'RuntimeError:prompt_tokenization_failure',
+                    })
+                else:
+                    result, completion_error = _attempt_plain_completion(
+                        'create_completion_keyword_token_ids',
+                        ['max_tokens', 'prompt'],
+                        lambda: create_completion(prompt=rendered_prompt_token_ids, max_tokens=max_tokens),
+                    )
+            if result is None and callable(create_completion) and rendered_prompt_token_ids is not None and not _last_attempt_fatal() and not _last_attempt_rejected_max_tokens():
+                _reset_before_next_attempt()
+                result, completion_error = _attempt_plain_completion(
+                    'create_completion_positional_token_ids',
+                    ['max_tokens'],
+                    lambda: create_completion(rendered_prompt_token_ids, max_tokens=max_tokens),
+                )
             if result is None:
                 extra = dict(render_diagnostics)
                 extra.update(plain_capabilities)
+                extra.update(tokenization_diagnostics)
+                extra['plain_completion_reset_after_failure_count'] = reset_after_failure_count[0]
                 extra.update({
                     'method': attempts[-1].get('method') if attempts else 'create_completion_from_rendered_prompt',
                     'attempted_plain_completion_methods': ','.join(item.get('method', '') for item in attempts if item.get('method')),
@@ -2732,6 +2848,8 @@ for line in sys.stdin:
             if invalid_reason is not None:
                 extra = dict(render_diagnostics)
                 extra.update(plain_capabilities)
+                extra.update(tokenization_diagnostics)
+                extra['plain_completion_reset_after_failure_count'] = reset_after_failure_count[0]
                 extra.update({
                     'method': attempts[-1].get('method') if attempts else 'create_completion_from_rendered_prompt',
                     'attempted_plain_completion_methods': ','.join(item.get('method', '') for item in attempts if item.get('method')),

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -125,6 +125,12 @@ _SAFE_WORKER_DIAGNOSTIC_KEYS = {
     "plain_completion_accepts_prompt_kwarg",
     "plain_completion_accepts_max_tokens_kwarg",
     "plain_completion_accepts_var_kwargs",
+    "plain_completion_prompt_tokenization_attempted",
+    "plain_completion_prompt_token_count",
+    "plain_completion_prompt_tokenization_method",
+    "plain_completion_prompt_tokenization_special",
+    "plain_completion_prompt_tokenization_error_category",
+    "plain_completion_reset_after_failure_count",
     "qwen_api_v1_non_thinking_template_fallback",
     "result_shape",
     "method",
@@ -181,6 +187,10 @@ _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "unsupported_stop_kwarg",
         "method_shape",
         "worker_exception",
+        "prompt_tokenization_failure",
+        "prompt_eval_failure",
+        "sampling_failure",
+        "tokenizer_unavailable",
         "malformed_completion_output",
         "empty_completion_output",
         "thinking_leaked",
@@ -197,6 +207,9 @@ _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
         "create_completion_keyword_prompt",
         "create_completion_positional_prompt",
         "llama_call_positional_prompt",
+        "create_completion_keyword_token_ids",
+        "create_completion_positional_token_ids",
+        "llama.tokenize",
         "render_and_tokenize_chat",
         "tokenize",
     },
@@ -206,7 +219,7 @@ _SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_.:/@+-]{1,128}$
 _SAFE_WORKER_DIAGNOSTIC_CLASS_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]{0,127}$")
 _SAFE_WORKER_DIAGNOSTIC_REDACTED_SUMMARY_RE = re.compile(
     r"^[A-Za-z_][A-Za-z0-9_.]{0,127}:(?:redacted|metal_memory_allocation|kv_cache_allocation|"
-    r"rope_yarn_eval_failure|unsupported_kwarg)$"
+    r"rope_yarn_eval_failure|unsupported_kwarg|prompt_tokenization_failure|prompt_eval_failure|sampling_failure)$"
 )
 _SAFE_WORKER_DIAGNOSTIC_TAIL_WORDS = {
     "llama", "llama_context", "ggml", "metal", "kv", "cache", "alloc", "allocation",
@@ -4018,6 +4031,12 @@ class RelayClient:
                     "plain_completion_accepts_prompt_kwarg",
                     "plain_completion_accepts_max_tokens_kwarg",
                     "plain_completion_accepts_var_kwargs",
+                    "plain_completion_prompt_tokenization_attempted",
+                    "plain_completion_prompt_token_count",
+                    "plain_completion_prompt_tokenization_method",
+                    "plain_completion_prompt_tokenization_special",
+                    "plain_completion_prompt_tokenization_error_category",
+                    "plain_completion_reset_after_failure_count",
                     "qwen_api_v1_non_thinking_template_fallback",
                 ):
                     safe_value = safe_worker_diagnostics.get(safe_key)


### PR DESCRIPTION
### Motivation
- Qwen API v1 readiness can hit plaintext plain-completion paths where llama-cpp-python may fail during tokenization/eval and leave the worker in a dirty state, so we need a safe bounded fallback that preserves relay-blind E2EE and non-thinking invariants.
- Improve runtime diagnostics so failures inside llama-cpp-python are classified into actionable scalar categories instead of `RuntimeError:redacted` to enable correct retry/alternative selection.
- Ensure retries do not cause unbounded generation or expose sensitive data such as prompts, token IDs, or model output.

### Description
- Added classification for common llama-cpp failure types (`prompt_tokenization_failure`, `prompt_eval_failure`, `sampling_failure`) and changed `_sanitize_error_summary` to return sanitized category-prefixed summaries like `RuntimeError:prompt_tokenization_failure` in `utils/llm/model_manager.py`.
- Implemented a worker-local tokenizer helper `_tokenize_rendered_prompt_for_plain_completion(llama, rendered_prompt)` that does in-worker tokenization using `add_bos=False`, prefers `special=True` when supported, and returns only safe scalar diagnostics (tokenization attempted, token count, method, `special` used flag, and an error category) while never exposing prompt text or token IDs.
- Implemented `_reset_plain_completion_state(llama)` to call `llama.reset()` when available between failed bounded attempts and surfaced a safe scalar `plain_completion_reset_after_failure_count` diagnostic.
- Extended the plain-completion attempt sequence in the subprocess worker to: `create_completion(prompt=rendered_prompt, max_tokens=...)`, `create_completion(rendered_prompt, max_tokens=...)`, `llama(rendered_prompt, max_tokens=...)`, then token-ID bounded fallbacks `create_completion(prompt=rendered_prompt_token_ids, max_tokens=...)` and `create_completion(rendered_prompt_token_ids, max_tokens=...)` only when `create_completion` is callable and the previous failures are non-fatal.
- Preserved and extended safe-diagnostic allowlists and readiness mappings across surfaces by adding new scalar keys: `plain_completion_prompt_tokenization_attempted`, `plain_completion_prompt_token_count`, `plain_completion_prompt_tokenization_method`, `plain_completion_prompt_tokenization_special`, `plain_completion_prompt_tokenization_error_category`, and `plain_completion_reset_after_failure_count` to `utils/llm/model_manager.py`, `utils/networking/relay_client.py`, `utils/compute_node_runtime.py`, `desktop-tauri/src-tauri/python/compute_node_bridge.py`, and `desktop-tauri/src-tauri/src/compute_node.rs`.
- Kept all hard invariants: API v1-only behavior preserved, `enable_thinking=False` never injected/removed, no unbounded generation, and no prompt/token ID leakage.

### Testing
- Ran unit tests: `python -m pytest tests/unit/test_model_manager.py -q` and `python -m pytest tests/unit/test_relay_client.py -q` and `python -m pytest tests/unit/test_compute_node_runtime.py -q` and `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q`, all succeeded (all unit suites passed).
- Ran integration tests: `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` and `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q`, both succeeded.
- Ran repository checks: `git diff --check` and `pre-commit run --all-files`, both passed in this environment.
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node` but it is blocked in this container due to a missing system `glib-2.0` pkg-config dependency (`glib-2.0.pc`), so Rust tests were not executed here.
- All executed Python tests passed; residual action: run the Rust `compute_node` tests in a CI or developer machine with `glib-2.0`/`pkg-config` installed to fully validate the desktop bridge Rust changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f2247a478832f8347d8f13cbc2834)