### PR TITLE
Fix operator-log token metadata sanitization

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1874,6 +1874,83 @@ mod tests {
     }
 
     #[test]
+    fn operator_log_path_preserves_safe_64k_token_metadata_and_redacts_token_material() {
+        let payload = serde_json::json!({
+            "type": "status",
+            "operator_session_id": "s64k",
+            "sequence": 64,
+            "running": true,
+            "registered": true,
+            "context_tier": "64k-full",
+            "context_window_tokens": 65536,
+            "api_v1_readiness_result": "passed",
+            "api_v1_readiness_yarn_requested_context_tokens": 65536,
+            "api_v1_readiness_yarn_original_context_tokens": 32768,
+            "api_v1_readiness_completion_smoke_result": "passed",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count": 28,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts": "50,28",
+            "token": "SECRET_TOKEN",
+            "prompt_token_ids": [1, 2, 3],
+            "api_token": {"value": "SECRET_API_TOKEN"},
+        });
+
+        let stdout = sanitize_operator_diagnostic_line(&summarize_bridge_stdout_payload(&payload));
+        assert!(stdout.len() <= 3500);
+        let stdout_event: Value = serde_json::from_str(&stdout).expect("stdout json");
+        assert_eq!(
+            stdout_event
+                .get("context_window_tokens")
+                .and_then(Value::as_u64),
+            Some(65536)
+        );
+        assert!(stdout_event.get("token").is_none());
+        assert!(stdout_event.get("prompt_token_ids").is_none());
+        assert!(!stdout.contains("SECRET_"));
+
+        let chunks = readiness_operator_log_chunks(&payload);
+        assert!(!chunks.is_empty());
+        let mut reconstructed = Map::new();
+        for chunk in chunks {
+            let sanitized = sanitize_operator_diagnostic_line(&chunk);
+            assert!(sanitized.len() <= 3500);
+            let event: Value = serde_json::from_str(&sanitized).expect("readiness json");
+            assert_eq!(
+                event.get("type").and_then(Value::as_str),
+                Some("readiness_diagnostics")
+            );
+            let diagnostics = event
+                .get("diagnostics")
+                .and_then(Value::as_object)
+                .expect("diagnostics");
+            for (key, value) in diagnostics {
+                reconstructed.insert(key.clone(), value.clone());
+            }
+            assert!(!sanitized.contains("SECRET_"));
+        }
+        assert_eq!(
+            reconstructed
+                .get("api_v1_readiness_yarn_requested_context_tokens")
+                .and_then(Value::as_u64),
+            Some(65536)
+        );
+        assert_eq!(
+            reconstructed
+                .get("api_v1_readiness_yarn_original_context_tokens")
+                .and_then(Value::as_u64),
+            Some(32768)
+        );
+        assert_eq!(
+            reconstructed
+                .get("api_v1_readiness_completion_smoke_result")
+                .and_then(Value::as_str),
+            Some("passed")
+        );
+        assert!(reconstructed.get("token").is_none());
+        assert!(reconstructed.get("prompt_token_ids").is_none());
+        assert!(reconstructed.get("api_token").is_none());
+    }
+
+    #[test]
     fn safe_readiness_diagnostics_rejects_free_text_strings() {
         let diagnostics = safe_readiness_diagnostics_from_payload(&serde_json::json!({
             "api_v1_readiness_completion_smoke_method": "rendered prompt leaked",

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -254,7 +254,11 @@ fn sanitize_operator_json_value(value: &serde_json::Value) -> serde_json::Value 
             let mut sanitized = serde_json::Map::new();
             for (key, value) in map {
                 let normalized = key.to_ascii_lowercase();
-                if normalized.contains("api_key")
+                if let Some(safe_token_metadata) =
+                    sanitize_safe_token_metadata_value(&normalized, value)
+                {
+                    sanitized.insert(key.clone(), safe_token_metadata);
+                } else if normalized.contains("api_key")
                     || normalized.contains("token")
                     || normalized.contains("prompt")
                     || normalized.contains("output")
@@ -262,7 +266,7 @@ fn sanitize_operator_json_value(value: &serde_json::Value) -> serde_json::Value 
                     || normalized.contains("private_key")
                     || normalized.contains("payload")
                 {
-                    sanitized.insert(key.clone(), serde_json::Value::String("<redacted>".into()));
+                    sanitized.insert(key.clone(), redacted_json_value());
                 } else {
                     sanitized.insert(key.clone(), sanitize_operator_json_value(value));
                 }
@@ -282,6 +286,138 @@ fn sanitize_operator_json_value(value: &serde_json::Value) -> serde_json::Value 
         _ => value.clone(),
     }
 }
+
+fn redacted_json_value() -> serde_json::Value {
+    serde_json::Value::String("<redacted>".into())
+}
+
+fn sanitize_safe_token_metadata_value(
+    normalized_key: &str,
+    value: &serde_json::Value,
+) -> Option<serde_json::Value> {
+    let valid = if SAFE_TOKEN_INTEGER_OR_NULL_KEYS.contains(&normalized_key) {
+        value.is_null() || value.as_u64().is_some()
+    } else if SAFE_TOKEN_BOOL_OR_NULL_KEYS.contains(&normalized_key) {
+        value.is_null() || value.as_bool().is_some()
+    } else if SAFE_TOKEN_IDENTIFIER_OR_NULL_KEYS.contains(&normalized_key) {
+        value.is_null() || value.as_str().is_some_and(is_bounded_safe_token_identifier)
+    } else if SAFE_TOKEN_CSV_IDENTIFIER_OR_NULL_KEYS.contains(&normalized_key) {
+        value.is_null()
+            || value
+                .as_str()
+                .is_some_and(is_bounded_safe_token_identifier_csv)
+    } else if SAFE_TOKEN_CSV_INTEGER_OR_NULL_KEYS.contains(&normalized_key) {
+        value.is_null()
+            || value
+                .as_str()
+                .is_some_and(is_bounded_safe_token_integer_csv)
+    } else {
+        return None;
+    };
+
+    Some(if valid {
+        value.clone()
+    } else {
+        redacted_json_value()
+    })
+}
+
+fn is_bounded_safe_token_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 256
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(byte, b'_' | b'.' | b':' | b'/' | b'@' | b'+' | b'-')
+        })
+}
+
+fn is_bounded_safe_token_identifier_csv(value: &str) -> bool {
+    validate_bounded_csv(value, is_bounded_safe_token_identifier)
+}
+
+fn is_bounded_safe_token_integer_csv(value: &str) -> bool {
+    validate_bounded_csv(value, |entry| {
+        !entry.is_empty()
+            && entry.bytes().all(|byte| byte.is_ascii_digit())
+            && entry.parse::<u64>().is_ok()
+    })
+}
+
+fn validate_bounded_csv(value: &str, entry_validator: impl Fn(&str) -> bool) -> bool {
+    if value.len() > 256 {
+        return false;
+    }
+    let mut count = 0usize;
+    for entry in value.split(',') {
+        if entry.is_empty() || !entry_validator(entry) {
+            return false;
+        }
+        count += 1;
+        if count > 64 {
+            return false;
+        }
+    }
+    count > 0
+}
+
+const SAFE_TOKEN_INTEGER_OR_NULL_KEYS: &[&str] = &[
+    "context_window_tokens",
+    "prompt_tokens",
+    "requested_output_tokens",
+    "required_total_tokens",
+    "max_tokens",
+    "native_context_tokens",
+    "maximum_validated_context_tokens",
+    "requested_context_tokens",
+    "original_context_tokens",
+    "context_size_tokens",
+    "qwen_yarn_requested_context_tokens",
+    "qwen_yarn_original_context_tokens",
+    "plain_completion_prompt_token_count",
+    "plain_completion_prompt_tokenization_variant_count",
+    "plain_completion_prompt_tokenization_selected_token_count",
+    "api_v1_readiness_context_window_tokens",
+    "api_v1_readiness_prompt_tokens",
+    "api_v1_readiness_yarn_requested_context_tokens",
+    "api_v1_readiness_yarn_original_context_tokens",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_token_count",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_count",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count",
+];
+
+const SAFE_TOKEN_BOOL_OR_NULL_KEYS: &[&str] = &[
+    "plain_completion_accepts_max_tokens_kwarg",
+    "plain_completion_prompt_tokenization_special",
+    "plain_completion_prompt_tokenization_attempted",
+    "plain_completion_prompt_tokenization_selected_special",
+    "api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_attempted",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_special",
+];
+
+const SAFE_TOKEN_IDENTIFIER_OR_NULL_KEYS: &[&str] = &[
+    "plain_completion_prompt_tokenization_error_category",
+    "plain_completion_prompt_tokenization_method",
+    "plain_completion_prompt_tokenization_selected_variant",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_error_category",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant",
+];
+
+const SAFE_TOKEN_CSV_IDENTIFIER_OR_NULL_KEYS: &[&str] = &[
+    "plain_completion_prompt_tokenization_variant_ids",
+    "plain_completion_prompt_tokenization_special_values",
+    "plain_completion_attempt_tokenization_variants",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values",
+    "api_v1_readiness_completion_smoke_plain_completion_attempt_tokenization_variants",
+];
+
+const SAFE_TOKEN_CSV_INTEGER_OR_NULL_KEYS: &[&str] = &[
+    "plain_completion_prompt_tokenization_token_counts",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts",
+];
 
 fn sanitize_url_display(value: &str) -> String {
     let trimmed = value.trim_matches(|ch: char| matches!(ch, '\'' | '"' | ',' | ';' | ')' | '('));
@@ -492,6 +628,181 @@ mod tests {
                 .and_then(serde_json::Value::as_bool),
             Some(true)
         );
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_preserves_safe_token_metadata() {
+        let sanitized = sanitize_operator_diagnostic_line(
+            &serde_json::json!({
+                "context_window_tokens": 65536,
+                "api_v1_readiness_yarn_requested_context_tokens": 65536,
+                "api_v1_readiness_yarn_original_context_tokens": 32768,
+                "api_v1_readiness_completion_smoke_plain_completion_prompt_token_count": 50,
+                "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count": 28,
+                "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_count": 2,
+                "api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg": true,
+                "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_special": false,
+                "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method": "llama.tokenize",
+                "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant": "tokenize_add_bos_false_special_false",
+                "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids": "tokenize_add_bos_false_special_false,tokenize_add_bos_false_special_true",
+                "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts": "50,28",
+                "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values": "false,true",
+            })
+            .to_string(),
+        );
+        let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
+
+        assert_eq!(payload["context_window_tokens"].as_u64(), Some(65536));
+        assert_eq!(
+            payload["api_v1_readiness_yarn_requested_context_tokens"].as_u64(),
+            Some(65536)
+        );
+        assert_eq!(
+            payload["api_v1_readiness_yarn_original_context_tokens"].as_u64(),
+            Some(32768)
+        );
+        assert_eq!(
+            payload["api_v1_readiness_completion_smoke_plain_completion_prompt_token_count"]
+                .as_u64(),
+            Some(50)
+        );
+        assert_eq!(
+            payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count"].as_u64(),
+            Some(28)
+        );
+        assert_eq!(
+            payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_count"].as_u64(),
+            Some(2)
+        );
+        assert_eq!(
+            payload["api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg"]
+                .as_bool(),
+            Some(true)
+        );
+        assert_eq!(
+            payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_special"].as_bool(),
+            Some(false)
+        );
+        assert_eq!(
+            payload
+                ["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method"]
+                .as_str(),
+            Some("llama.tokenize")
+        );
+        assert_eq!(
+            payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant"].as_str(),
+            Some("tokenize_add_bos_false_special_false")
+        );
+        assert_eq!(
+            payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids"].as_str(),
+            Some("tokenize_add_bos_false_special_false,tokenize_add_bos_false_special_true")
+        );
+        assert_eq!(
+            payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts"].as_str(),
+            Some("50,28")
+        );
+        assert_eq!(
+            payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values"].as_str(),
+            Some("false,true")
+        );
+        assert!(!sanitized.contains("<redacted>"));
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_redacts_real_token_material() {
+        let sanitized = sanitize_operator_diagnostic_line(
+            &serde_json::json!({
+                "token": "SECRET_A",
+                "tokens": ["SECRET_B"],
+                "token_ids": [1, 2, 3],
+                "prompt_token_ids": ["SECRET_C"],
+                "access_token": "SECRET_D",
+                "refresh_token": {"nested": "SECRET_E"},
+                "cancel_token": 42,
+                "session_token": "SECRET_F",
+                "api_token": "SECRET_G"
+            })
+            .to_string(),
+        );
+        let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
+
+        for key in [
+            "token",
+            "tokens",
+            "token_ids",
+            "prompt_token_ids",
+            "access_token",
+            "refresh_token",
+            "cancel_token",
+            "session_token",
+            "api_token",
+        ] {
+            assert_eq!(payload[key].as_str(), Some("<redacted>"), "{key}");
+        }
+        assert!(!sanitized.contains("SECRET_"));
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_redacts_unsafe_safe_token_metadata_values() {
+        let many_entries = (0..65)
+            .map(|idx| format!("id{idx}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let sanitized = sanitize_operator_diagnostic_line(
+            &serde_json::json!({
+                "context_window_tokens": "SECRET",
+                "api_v1_readiness_yarn_requested_context_tokens": -1,
+                "api_v1_readiness_yarn_original_context_tokens": 32768.5,
+                "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count": [28],
+                "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts": "50,text",
+                "plain_completion_prompt_tokenization_method": "has spaces",
+                "plain_completion_prompt_tokenization_error_category": "has\"quote",
+                "plain_completion_prompt_tokenization_selected_variant": "has\\backslash",
+                "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method": "bad\u{0001}control",
+                "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids": many_entries,
+            })
+            .to_string(),
+        );
+        let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
+        let object = payload.as_object().expect("object");
+        for (key, value) in object {
+            assert_eq!(value.as_str(), Some("<redacted>"), "{key}");
+        }
+        assert!(!sanitized.contains("SECRET"));
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_preserves_nested_safe_metadata_and_redacts_nested_tokens()
+    {
+        let sanitized = sanitize_operator_diagnostic_line(
+            &serde_json::json!({
+                "outer": {
+                    "context_window_tokens": 65536,
+                    "token": "SECRET_A",
+                    "items": [
+                        {"api_v1_readiness_yarn_original_context_tokens": 32768},
+                        {"prompt_token_ids": ["SECRET_B"]}
+                    ]
+                }
+            })
+            .to_string(),
+        );
+        let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
+
+        assert_eq!(
+            payload["outer"]["context_window_tokens"].as_u64(),
+            Some(65536)
+        );
+        assert_eq!(payload["outer"]["token"].as_str(), Some("<redacted>"));
+        assert_eq!(
+            payload["outer"]["items"][0]["api_v1_readiness_yarn_original_context_tokens"].as_u64(),
+            Some(32768)
+        );
+        assert_eq!(
+            payload["outer"]["items"][1]["prompt_token_ids"].as_str(),
+            Some("<redacted>")
+        );
+        assert!(!sanitized.contains("SECRET_"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Operator logs were over-redacting safe token-count and tokenization metadata because any key containing `token` was redacted before safe metadata classification, causing numeric counts like `context_window_tokens` to become `"<redacted>"`.
- Preserve the default-deny privacy posture while allowing a narrow, exact allowlist of safe token diagnostic keys when their values meet strict validators.

### Description

- Added an exact allowlist and validators for safe token metadata in `desktop-tauri/src-tauri/src/operator_logs.rs`, with classifications for integer-or-null, bool-or-null, bounded identifier-or-null, bounded CSV identifier-or-null, and bounded CSV integer-or-null fields.
- Implemented `sanitize_safe_token_metadata_value(...)` and CSV/identifier validators, and made the safe-key exception run before the generic token/api_key/prompt/payload redaction so valid safe keys keep native JSON types.
- Preserved default-deny redaction for all other keys containing `token` and for any allowlisted key whose value fails validation (they are replaced with `"<redacted>"`).
- Added unit tests exercising: preservation of safe metadata, redaction of real token material, failing-closed on invalid safe values, nested JSON parseability, and an end-to-end compute-node stdout/readiness operator-log path test; tests live in `operator_logs.rs` and an added compute-node test in `compute_node.rs`.

### Testing

- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml operator_logs` and all operator-log unit tests passed.
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node` and compute-node tests (including the new operator-log path test) passed.
- Ran `cargo fmt --manifest-path desktop-tauri/src-tauri/Cargo.toml -- --check` which passed.
- Ran `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` which passed (120 tests passed).
- Ran repository checks: `git diff --check` showed no whitespace errors.
- Ran `pre-commit run --all-files`; it failed due to environment/dependency issues unrelated to this change (vulture reported unused symbols in generated `.token_place_desktop_site` files and `run-checks` execution failed because Python test-run dependencies like `flask`, `openai`, `cryptography`, and `bandit` were not available in the execution environment). The core Rust tests and targeted Python unit tests used by this change passed; the pre-commit failure is an environment/setup gap rather than a behavior regression introduced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52fa915ccc832f9b0bc5188e535c36)