### PR TITLE
Fix operator log over-redaction by allowlisting safe token metadata with strict validators

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -83,6 +83,11 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Run targeted Rust regressions
+        run: |
+          cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml operator_logs
+          cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node
+
       - name: Install tauri-driver
         run: cargo install tauri-driver
 

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1874,6 +1874,80 @@ mod tests {
     }
 
     #[test]
+    fn operator_log_path_preserves_64k_safe_token_metadata_and_redacts_tokens() {
+        let payload = serde_json::json!({
+            "type": "status",
+            "operator_session_id": "s64k",
+            "sequence": 64,
+            "running": true,
+            "registered": true,
+            "context_tier": "64k-full",
+            "context_window_tokens": 65536,
+            "api_v1_readiness_result": "passed",
+            "api_v1_readiness_completion_smoke_result": "passed",
+            "api_v1_readiness_yarn_requested_context_tokens": 65536,
+            "api_v1_readiness_yarn_original_context_tokens": 32768,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_token_count": 50,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count": 28,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_count": 2,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method": "llama.tokenize",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant": "tokenize_add_bos_false_special_false",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids": "tokenize_add_bos_false_special_false,tokenize_add_bos_false_special_true",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts": "50,28",
+            "token": "SECRET_STATUS_TOKEN",
+            "token_ids": [1, 2, 3],
+            "api_token": "SECRET_API_TOKEN",
+        });
+
+        let stdout = sanitize_operator_diagnostic_line(&summarize_bridge_stdout_payload(&payload));
+        assert!(stdout.len() <= 3500);
+        let stdout_event: Value = serde_json::from_str(&stdout).expect("stdout json");
+        assert_eq!(stdout_event["context_window_tokens"].as_u64(), Some(65536));
+        assert!(stdout_event.get("token").is_none());
+        assert!(stdout_event.get("token_ids").is_none());
+
+        let chunks = readiness_operator_log_chunks(&payload);
+        assert!(!chunks.is_empty());
+        let mut saw_readiness_smoke = false;
+        let mut saw_requested = false;
+        let mut saw_original = false;
+        for chunk in chunks {
+            let sanitized = sanitize_operator_diagnostic_line(&chunk);
+            assert!(sanitized.len() <= 3500);
+            let event: Value = serde_json::from_str(&sanitized).expect("readiness json");
+            let diagnostics = event
+                .get("diagnostics")
+                .and_then(Value::as_object)
+                .expect("diagnostics");
+            if diagnostics
+                .get("api_v1_readiness_completion_smoke_result")
+                .and_then(Value::as_str)
+                == Some("passed")
+            {
+                saw_readiness_smoke = true;
+            }
+            if diagnostics
+                .get("api_v1_readiness_yarn_requested_context_tokens")
+                .and_then(Value::as_u64)
+                == Some(65536)
+            {
+                saw_requested = true;
+            }
+            if diagnostics
+                .get("api_v1_readiness_yarn_original_context_tokens")
+                .and_then(Value::as_u64)
+                == Some(32768)
+            {
+                saw_original = true;
+            }
+            assert!(!sanitized.contains("SECRET_"));
+        }
+        assert!(saw_readiness_smoke);
+        assert!(saw_requested);
+        assert!(saw_original);
+    }
+
+    #[test]
     fn safe_readiness_diagnostics_rejects_free_text_strings() {
         let diagnostics = safe_readiness_diagnostics_from_payload(&serde_json::json!({
             "api_v1_readiness_completion_smoke_method": "rendered prompt leaked",

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -254,7 +254,10 @@ fn sanitize_operator_json_value(value: &serde_json::Value) -> serde_json::Value 
             let mut sanitized = serde_json::Map::new();
             for (key, value) in map {
                 let normalized = key.to_ascii_lowercase();
-                if normalized.contains("api_key")
+                if let Some(safe_token_metadata) = sanitize_safe_token_metadata(&normalized, value)
+                {
+                    sanitized.insert(key.clone(), safe_token_metadata);
+                } else if normalized.contains("api_key")
                     || normalized.contains("token")
                     || normalized.contains("prompt")
                     || normalized.contains("output")
@@ -262,7 +265,7 @@ fn sanitize_operator_json_value(value: &serde_json::Value) -> serde_json::Value 
                     || normalized.contains("private_key")
                     || normalized.contains("payload")
                 {
-                    sanitized.insert(key.clone(), serde_json::Value::String("<redacted>".into()));
+                    sanitized.insert(key.clone(), redacted_json_value());
                 } else {
                     sanitized.insert(key.clone(), sanitize_operator_json_value(value));
                 }
@@ -281,6 +284,163 @@ fn sanitize_operator_json_value(value: &serde_json::Value) -> serde_json::Value 
         }
         _ => value.clone(),
     }
+}
+
+fn redacted_json_value() -> serde_json::Value {
+    serde_json::Value::String("<redacted>".into())
+}
+
+fn sanitize_safe_token_metadata(key: &str, value: &serde_json::Value) -> Option<serde_json::Value> {
+    if is_safe_token_u64_or_null_key(key) {
+        return Some(match value {
+            serde_json::Value::Null => serde_json::Value::Null,
+            serde_json::Value::Number(number) => number
+                .as_u64()
+                .map(|_| serde_json::Value::Number(number.clone()))
+                .unwrap_or_else(redacted_json_value),
+            _ => redacted_json_value(),
+        });
+    }
+    if is_safe_token_bool_or_null_key(key) {
+        return Some(match value {
+            serde_json::Value::Bool(_) | serde_json::Value::Null => value.clone(),
+            _ => redacted_json_value(),
+        });
+    }
+    if is_safe_token_identifier_or_null_key(key) {
+        return Some(match value {
+            serde_json::Value::Null => serde_json::Value::Null,
+            serde_json::Value::String(text) if is_bounded_token_identifier(text) => value.clone(),
+            _ => redacted_json_value(),
+        });
+    }
+    if is_safe_token_csv_identifier_or_null_key(key) {
+        return Some(match value {
+            serde_json::Value::Null => serde_json::Value::Null,
+            serde_json::Value::String(text) if is_bounded_token_csv_identifiers(text) => {
+                value.clone()
+            }
+            _ => redacted_json_value(),
+        });
+    }
+    if is_safe_token_csv_u64_or_null_key(key) {
+        return Some(match value {
+            serde_json::Value::Null => serde_json::Value::Null,
+            serde_json::Value::String(text) if is_bounded_token_csv_u64s(text) => value.clone(),
+            _ => redacted_json_value(),
+        });
+    }
+    None
+}
+
+fn is_safe_token_u64_or_null_key(key: &str) -> bool {
+    matches!(
+        key,
+        "context_window_tokens"
+            | "prompt_tokens"
+            | "requested_output_tokens"
+            | "required_total_tokens"
+            | "max_tokens"
+            | "native_context_tokens"
+            | "maximum_validated_context_tokens"
+            | "requested_context_tokens"
+            | "original_context_tokens"
+            | "context_size_tokens"
+            | "qwen_yarn_requested_context_tokens"
+            | "qwen_yarn_original_context_tokens"
+            | "plain_completion_prompt_token_count"
+            | "plain_completion_prompt_tokenization_variant_count"
+            | "plain_completion_prompt_tokenization_selected_token_count"
+            | "api_v1_readiness_context_window_tokens"
+            | "api_v1_readiness_prompt_tokens"
+            | "api_v1_readiness_yarn_requested_context_tokens"
+            | "api_v1_readiness_yarn_original_context_tokens"
+            | "api_v1_readiness_completion_smoke_plain_completion_prompt_token_count"
+            | "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_count"
+            | "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count"
+    )
+}
+
+fn is_safe_token_bool_or_null_key(key: &str) -> bool {
+    matches!(
+        key,
+        "plain_completion_accepts_max_tokens_kwarg"
+            | "plain_completion_prompt_tokenization_special"
+            | "plain_completion_prompt_tokenization_attempted"
+            | "plain_completion_prompt_tokenization_selected_special"
+            | "api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg"
+            | "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special"
+            | "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_attempted"
+            | "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_special"
+    )
+}
+
+fn is_safe_token_identifier_or_null_key(key: &str) -> bool {
+    matches!(
+        key,
+        "plain_completion_prompt_tokenization_error_category"
+            | "plain_completion_prompt_tokenization_method"
+            | "plain_completion_prompt_tokenization_selected_variant"
+            | "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_error_category"
+            | "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method"
+            | "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant"
+    )
+}
+
+fn is_safe_token_csv_identifier_or_null_key(key: &str) -> bool {
+    matches!(
+        key,
+        "plain_completion_prompt_tokenization_variant_ids"
+            | "plain_completion_prompt_tokenization_special_values"
+            | "plain_completion_attempt_tokenization_variants"
+            | "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids"
+            | "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values"
+            | "api_v1_readiness_completion_smoke_plain_completion_attempt_tokenization_variants"
+    )
+}
+
+fn is_safe_token_csv_u64_or_null_key(key: &str) -> bool {
+    matches!(
+        key,
+        "plain_completion_prompt_tokenization_token_counts"
+            | "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts"
+    )
+}
+
+fn is_bounded_token_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 256
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(byte, b'_' | b'.' | b':' | b'/' | b'@' | b'+' | b'-')
+        })
+}
+
+fn is_bounded_token_csv_identifiers(value: &str) -> bool {
+    value.len() <= 256 && validate_bounded_csv(value, |entry| is_bounded_token_identifier(entry))
+}
+
+fn is_bounded_token_csv_u64s(value: &str) -> bool {
+    value.len() <= 256
+        && validate_bounded_csv(value, |entry| {
+            !entry.is_empty()
+                && entry.bytes().all(|byte| byte.is_ascii_digit())
+                && entry.parse::<u64>().is_ok()
+        })
+}
+
+fn validate_bounded_csv(value: &str, validate_entry: impl Fn(&str) -> bool) -> bool {
+    let mut count = 0usize;
+    for entry in value.split(',') {
+        if entry.is_empty() || !validate_entry(entry) {
+            return false;
+        }
+        count += 1;
+        if count > 64 {
+            return false;
+        }
+    }
+    count > 0
 }
 
 fn sanitize_url_display(value: &str) -> String {
@@ -477,6 +637,153 @@ mod tests {
         );
         assert!(!sanitized.contains("secret value"));
         assert!(!sanitized.contains("secret token"));
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_preserves_safe_token_metadata() {
+        let sanitized = sanitize_operator_diagnostic_line(&serde_json::json!({
+            "context_window_tokens": 65536,
+            "api_v1_readiness_yarn_requested_context_tokens": 65536,
+            "api_v1_readiness_yarn_original_context_tokens": 32768,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_token_count": 50,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count": 28,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_count": 2,
+            "api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg": true,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_special": false,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method": "llama.tokenize",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant": "tokenize_add_bos_false_special_false",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids": "tokenize_add_bos_false_special_false,tokenize_add_bos_false_special_true",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts": "50,28",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values": "false,true",
+        }).to_string());
+        let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
+
+        assert_eq!(payload["context_window_tokens"].as_u64(), Some(65536));
+        assert_eq!(
+            payload["api_v1_readiness_yarn_requested_context_tokens"].as_u64(),
+            Some(65536)
+        );
+        assert_eq!(
+            payload["api_v1_readiness_yarn_original_context_tokens"].as_u64(),
+            Some(32768)
+        );
+        assert_eq!(
+            payload["api_v1_readiness_completion_smoke_plain_completion_prompt_token_count"]
+                .as_u64(),
+            Some(50)
+        );
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count"].as_u64(), Some(28));
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_count"].as_u64(), Some(2));
+        assert_eq!(
+            payload["api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg"]
+                .as_bool(),
+            Some(true)
+        );
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_special"].as_bool(), Some(false));
+        assert_eq!(
+            payload
+                ["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method"]
+                .as_str(),
+            Some("llama.tokenize")
+        );
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant"].as_str(), Some("tokenize_add_bos_false_special_false"));
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids"].as_str(), Some("tokenize_add_bos_false_special_false,tokenize_add_bos_false_special_true"));
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts"].as_str(), Some("50,28"));
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values"].as_str(), Some("false,true"));
+        assert!(!sanitized.contains("<redacted>"));
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_redacts_real_token_material() {
+        let sanitized = sanitize_operator_diagnostic_line(
+            &serde_json::json!({
+                "token": "SECRET_TOKEN_A",
+                "tokens": ["SECRET_TOKEN_B"],
+                "token_ids": [1, 2, 3],
+                "prompt_token_ids": {"secret": "SECRET_TOKEN_C"},
+                "access_token": "SECRET_TOKEN_D",
+                "refresh_token": 123,
+                "cancel_token": ["SECRET_TOKEN_E"],
+                "session_token": {"nested": "SECRET_TOKEN_F"},
+                "api_token": "SECRET_TOKEN_G",
+            })
+            .to_string(),
+        );
+        let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
+
+        for key in [
+            "token",
+            "tokens",
+            "token_ids",
+            "prompt_token_ids",
+            "access_token",
+            "refresh_token",
+            "cancel_token",
+            "session_token",
+            "api_token",
+        ] {
+            assert_eq!(payload[key].as_str(), Some("<redacted>"), "{key}");
+        }
+        assert!(!sanitized.contains("SECRET_TOKEN_"));
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_redacts_unsafe_safe_token_metadata_values() {
+        let too_many_entries = (0..65)
+            .map(|idx| format!("v{idx}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let sanitized = sanitize_operator_diagnostic_line(&serde_json::json!({
+            "context_window_tokens": "SECRET",
+            "api_v1_readiness_yarn_requested_context_tokens": -1,
+            "api_v1_readiness_yarn_original_context_tokens": 32768.5,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count": [28],
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts": "50,text",
+            "plain_completion_prompt_tokenization_method": "llama tokenize",
+            "plain_completion_prompt_tokenization_selected_variant": "bad\"quote",
+            "plain_completion_prompt_tokenization_error_category": "bad\\slash",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method": "bad\u{0001}control",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids": too_many_entries,
+        }).to_string());
+        let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
+
+        for (_, value) in payload.as_object().expect("object") {
+            assert_eq!(value.as_str(), Some("<redacted>"));
+        }
+        assert!(!sanitized.contains("SECRET"));
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_keeps_nested_json_safe_and_parseable() {
+        let sanitized = sanitize_operator_diagnostic_line(
+            &serde_json::json!({
+                "outer": {
+                    "context_window_tokens": 65536,
+                    "token": "SECRET_NESTED_TOKEN",
+                    "items": [
+                        {"api_v1_readiness_yarn_original_context_tokens": 32768},
+                        {"token_ids": ["SECRET_NESTED_ID"]}
+                    ]
+                }
+            })
+            .to_string(),
+        );
+        let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
+
+        assert_eq!(
+            payload["outer"]["context_window_tokens"].as_u64(),
+            Some(65536)
+        );
+        assert_eq!(payload["outer"]["token"].as_str(), Some("<redacted>"));
+        assert_eq!(
+            payload["outer"]["items"][0]["api_v1_readiness_yarn_original_context_tokens"].as_u64(),
+            Some(32768)
+        );
+        assert_eq!(
+            payload["outer"]["items"][1]["token_ids"].as_str(),
+            Some("<redacted>")
+        );
+        assert!(!sanitized.contains("SECRET_NESTED"));
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -410,19 +410,95 @@ fn is_safe_token_csv_u64_or_null_key(key: &str) -> bool {
     )
 }
 
-fn is_safe_token_identifier_value(_key: &str, value: &str) -> bool {
-    is_bounded_token_identifier(value)
+fn is_safe_token_identifier_value(key: &str, value: &str) -> bool {
+    // Generic subprocess diagnostic JSON is untrusted: a bounded identifier
+    // shape is only a first gate, and only producer-defined token metadata
+    // values may bypass the default token/prompt redaction path.
+    if !value.is_empty() && !is_bounded_token_identifier(value) {
+        return false;
+    }
+
+    match unprefixed_readiness_token_key(key) {
+        "plain_completion_prompt_tokenization_error_category" => {
+            is_safe_tokenization_error_category(value)
+        }
+        "plain_completion_prompt_tokenization_method" => matches!(value, "" | "llama.tokenize"),
+        "plain_completion_prompt_tokenization_selected_variant" => {
+            value.is_empty() || is_safe_tokenization_variant(value)
+        }
+        _ => false,
+    }
 }
 
-fn is_safe_token_csv_identifier_value(_key: &str, value: &str) -> bool {
-    is_bounded_token_identifier_csv(value)
+fn is_safe_token_csv_identifier_value(key: &str, value: &str) -> bool {
+    if !is_bounded_token_identifier_csv(value) {
+        return false;
+    }
+
+    match unprefixed_readiness_token_key(key) {
+        "plain_completion_prompt_tokenization_variant_ids"
+        | "plain_completion_attempt_tokenization_variants" => {
+            validate_bounded_identifier_csv(value, is_safe_tokenization_variant)
+        }
+        "plain_completion_prompt_tokenization_special_values" => {
+            validate_bounded_identifier_csv(value, is_safe_tokenization_special_value)
+        }
+        _ => false,
+    }
+}
+
+fn unprefixed_readiness_token_key(key: &str) -> &str {
+    key.strip_prefix("api_v1_readiness_completion_smoke_")
+        .unwrap_or(key)
+}
+
+fn is_safe_tokenization_variant(value: &str) -> bool {
+    matches!(
+        value,
+        "tokenize_add_bos_false_special_false"
+            | "tokenize_add_bos_false_no_special"
+            | "tokenize_add_bos_false_special_true"
+    )
+}
+
+fn is_safe_tokenization_special_value(value: &str) -> bool {
+    matches!(value, "false" | "none" | "true")
+}
+
+fn is_safe_tokenization_error_category(value: &str) -> bool {
+    matches!(
+        value,
+        "" | "context_length_exceeded"
+            | "context_window_exceeded"
+            | "tokenizer_unavailable"
+            | "method_shape"
+            | "tokenizer_special_rejected"
+            | "token_overflow"
+            | "prompt_tokenization_failure"
+            | "prompt_eval_failure"
+            | "prompt_eval_decode_failure"
+            | "prompt_eval_invalid_batch"
+            | "backend_allocation_failure"
+            | "backend_graph_compute_failure"
+            | "metal_graph_compute_failure"
+            | "kv_slot_unavailable"
+            | "decode_aborted"
+            | "backend_decode_failure"
+            | "prompt_eval_backend_failure"
+            | "prompt_eval_invalid_token_failure"
+            | "prompt_eval_state_failure"
+            | "prompt_eval_context_failure"
+            | "sampling_failure"
+    )
 }
 
 fn is_bounded_token_identifier(value: &str) -> bool {
-    value.len() <= 256
-        && value
-            .chars()
-            .all(|ch| !ch.is_control() && ch != ',' && ch != '"' && ch != '\\')
+    !value.is_empty()
+        && value.len() <= 256
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(byte, b'_' | b'.' | b':' | b'/' | b'@' | b'+' | b'-')
+        })
 }
 
 fn is_bounded_token_identifier_csv(value: &str) -> bool {
@@ -678,9 +754,9 @@ mod tests {
             "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_special": false,
             "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method": "llama.tokenize",
             "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant": "tokenize_add_bos_false_special_false",
-            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids": "tokenize_add_bos_false_special_false,tokenize_add_bos_false_special_true",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids": "tokenize_add_bos_false_special_false,tokenize_add_bos_false_no_special,tokenize_add_bos_false_special_true",
             "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts": "50,28",
-            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values": "false,true",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values": "false,none,true",
         }).to_string());
         let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
 
@@ -713,9 +789,9 @@ mod tests {
             Some("llama.tokenize")
         );
         assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant"].as_str(), Some("tokenize_add_bos_false_special_false"));
-        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids"].as_str(), Some("tokenize_add_bos_false_special_false,tokenize_add_bos_false_special_true"));
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids"].as_str(), Some("tokenize_add_bos_false_special_false,tokenize_add_bos_false_no_special,tokenize_add_bos_false_special_true"));
         assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts"].as_str(), Some("50,28"));
-        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values"].as_str(), Some("false,true"));
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values"].as_str(), Some("false,none,true"));
         assert!(!sanitized.contains("<redacted>"));
     }
 
@@ -785,7 +861,8 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_operator_diagnostic_line_sanitizes_allowlisted_identifier_strings() {
+    fn sanitize_operator_diagnostic_line_redacts_semantically_invalid_allowlisted_identifier_strings(
+    ) {
         let sanitized = sanitize_operator_diagnostic_line(&serde_json::json!({
             "plain_completion_prompt_tokenization_method": "https://user:pass@example.com/private/model.gguf?token=secret",
             "plain_completion_prompt_tokenization_selected_variant": "/home/alice/private/model.gguf",
@@ -796,15 +873,15 @@ mod tests {
 
         assert_eq!(
             payload["plain_completion_prompt_tokenization_method"].as_str(),
-            Some("https://example.com")
+            Some("<redacted>")
         );
         assert_eq!(
             payload["plain_completion_prompt_tokenization_selected_variant"].as_str(),
-            Some("<path:model.gguf>")
+            Some("<redacted>")
         );
         assert_eq!(
             payload["plain_completion_prompt_tokenization_variant_ids"].as_str(),
-            Some("<path:model.gguf>")
+            Some("<redacted>")
         );
         assert_eq!(
             payload["plain_completion_prompt_tokenization_token_counts"].as_str(),
@@ -882,13 +959,17 @@ mod tests {
             "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count": [28],
             "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts": "50,text",
             "plain_completion_prompt_tokenization_method": "llama tokenize",
-            "plain_completion_prompt_tokenization_selected_variant": "bad\"quote",
-            "plain_completion_prompt_tokenization_error_category": "bad\\slash",
+            "plain_completion_prompt_tokenization_selected_variant": "tok_abc123",
+            "plain_completion_prompt_tokenization_error_category": "SECRET_API_TOKEN",
             "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method": "bad\u{0001}control",
             "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids": too_many_entries,
-            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant": "bad,comma",
-            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values": "false,bad\\slash",
-            "plain_completion_attempt_tokenization_variants": "tokenize_add_bos_false_special_false,bad\"quote",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant": "https://example.com/private/token",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values": "false,none,SECRET_API_TOKEN",
+            "plain_completion_attempt_tokenization_variants": "tokenize_add_bos_false_special_false,tok_abc123",
+            "plain_completion_prompt_tokenization_variant_ids": "tokenize_add_bos_false_special_false,tok_abc123",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_error_category": "arbitrary_text",
+            "plain_completion_prompt_tokenization_special_values": "false,☃",
+            "api_v1_readiness_completion_smoke_plain_completion_attempt_tokenization_variants": "/home/alice/private/model.gguf",
         }).to_string());
         let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
 
@@ -896,6 +977,11 @@ mod tests {
             assert_eq!(value.as_str(), Some("<redacted>"));
         }
         assert!(!sanitized.contains("SECRET"));
+        assert!(!sanitized.contains("tok_abc123"));
+        assert!(!sanitized.contains("arbitrary_text"));
+        assert!(!sanitized.contains("☃"));
+        assert!(!sanitized.contains("/home/alice"));
+        assert!(!sanitized.contains("https://example.com/private"));
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -310,15 +310,17 @@ fn sanitize_safe_token_metadata(key: &str, value: &serde_json::Value) -> Option<
     if is_safe_token_identifier_or_null_key(key) {
         return Some(match value {
             serde_json::Value::Null => serde_json::Value::Null,
-            serde_json::Value::String(text) if is_bounded_token_identifier(text) => value.clone(),
+            serde_json::Value::String(text) if is_safe_token_identifier_value(key, text) => {
+                serde_json::Value::String(sanitize_operator_diagnostic_token(text))
+            }
             _ => redacted_json_value(),
         });
     }
     if is_safe_token_csv_identifier_or_null_key(key) {
         return Some(match value {
             serde_json::Value::Null => serde_json::Value::Null,
-            serde_json::Value::String(text) if is_bounded_token_csv_identifiers(text) => {
-                value.clone()
+            serde_json::Value::String(text) if is_safe_token_csv_identifier_value(key, text) => {
+                serde_json::Value::String(sanitize_operator_diagnostic_token(text))
             }
             _ => redacted_json_value(),
         });
@@ -326,7 +328,9 @@ fn sanitize_safe_token_metadata(key: &str, value: &serde_json::Value) -> Option<
     if is_safe_token_csv_u64_or_null_key(key) {
         return Some(match value {
             serde_json::Value::Null => serde_json::Value::Null,
-            serde_json::Value::String(text) if is_bounded_token_csv_u64s(text) => value.clone(),
+            serde_json::Value::String(text) if is_bounded_token_csv_u64s(text) => {
+                serde_json::Value::String(sanitize_operator_diagnostic_token(text))
+            }
             _ => redacted_json_value(),
         });
     }
@@ -407,17 +411,82 @@ fn is_safe_token_csv_u64_or_null_key(key: &str) -> bool {
     )
 }
 
-fn is_bounded_token_identifier(value: &str) -> bool {
-    !value.is_empty()
-        && value.len() <= 256
-        && value.bytes().all(|byte| {
-            byte.is_ascii_alphanumeric()
-                || matches!(byte, b'_' | b'.' | b':' | b'/' | b'@' | b'+' | b'-')
-        })
+fn is_safe_token_identifier_value(key: &str, value: &str) -> bool {
+    match plain_completion_tokenization_metadata_key(key) {
+        Some("plain_completion_prompt_tokenization_error_category") => {
+            is_safe_tokenization_error_category(value)
+        }
+        Some("plain_completion_prompt_tokenization_method") => {
+            matches!(value, "" | "llama.tokenize")
+        }
+        Some("plain_completion_prompt_tokenization_selected_variant") => {
+            is_safe_tokenization_variant_id(value) || value.is_empty()
+        }
+        _ => false,
+    }
 }
 
-fn is_bounded_token_csv_identifiers(value: &str) -> bool {
-    value.len() <= 256 && validate_bounded_csv(value, |entry| is_bounded_token_identifier(entry))
+fn is_safe_token_csv_identifier_value(key: &str, value: &str) -> bool {
+    match plain_completion_tokenization_metadata_key(key) {
+        Some("plain_completion_prompt_tokenization_variant_ids")
+        | Some("plain_completion_attempt_tokenization_variants") => {
+            is_safe_tokenization_variant_csv(value)
+        }
+        Some("plain_completion_prompt_tokenization_special_values") => {
+            is_safe_tokenization_special_value_csv(value)
+        }
+        _ => false,
+    }
+}
+
+fn plain_completion_tokenization_metadata_key(key: &str) -> Option<&str> {
+    key.strip_prefix("api_v1_readiness_completion_smoke_")
+        .or(Some(key))
+}
+
+fn is_safe_tokenization_error_category(value: &str) -> bool {
+    matches!(
+        value,
+        "" | "context_length_exceeded"
+            | "context_window_exceeded"
+            | "tokenizer_unavailable"
+            | "method_shape"
+            | "tokenizer_special_rejected"
+            | "token_overflow"
+            | "prompt_tokenization_failure"
+            | "prompt_eval_failure"
+            | "prompt_eval_decode_failure"
+            | "prompt_eval_invalid_batch"
+            | "backend_allocation_failure"
+            | "backend_graph_compute_failure"
+            | "metal_graph_compute_failure"
+            | "kv_slot_unavailable"
+            | "decode_aborted"
+            | "backend_decode_failure"
+            | "prompt_eval_backend_failure"
+            | "prompt_eval_invalid_token_failure"
+            | "prompt_eval_state_failure"
+            | "prompt_eval_context_failure"
+            | "sampling_failure"
+    )
+}
+
+fn is_safe_tokenization_variant_id(value: &str) -> bool {
+    matches!(
+        value,
+        "tokenize_add_bos_false_special_false"
+            | "tokenize_add_bos_false_no_special"
+            | "tokenize_add_bos_false_special_true"
+    )
+}
+
+fn is_safe_tokenization_variant_csv(value: &str) -> bool {
+    value.len() <= 256 && validate_bounded_csv(value, is_safe_tokenization_variant_id)
+}
+
+fn is_safe_tokenization_special_value_csv(value: &str) -> bool {
+    value.len() <= 256
+        && validate_bounded_csv(value, |entry| matches!(entry, "false" | "none" | "true"))
 }
 
 fn is_bounded_token_csv_u64s(value: &str) -> bool {
@@ -744,6 +813,9 @@ mod tests {
             "plain_completion_prompt_tokenization_error_category": "bad\\slash",
             "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method": "bad\u{0001}control",
             "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids": too_many_entries,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant": "tok_abc123",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values": "false,tok_abc123",
+            "plain_completion_attempt_tokenization_variants": "tokenize_add_bos_false_special_false,tok_abc123",
         }).to_string());
         let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
 
@@ -751,6 +823,7 @@ mod tests {
             assert_eq!(value.as_str(), Some("<redacted>"));
         }
         assert!(!sanitized.contains("SECRET"));
+        assert!(!sanitized.contains("tok_abc123"));
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -254,8 +254,7 @@ fn sanitize_operator_json_value(value: &serde_json::Value) -> serde_json::Value 
             let mut sanitized = serde_json::Map::new();
             for (key, value) in map {
                 let normalized = key.to_ascii_lowercase();
-                if let Some(safe_token_metadata) = sanitize_safe_token_metadata(&normalized, value)
-                {
+                if let Some(safe_token_metadata) = sanitize_safe_token_metadata(key, value) {
                     sanitized.insert(key.clone(), safe_token_metadata);
                 } else if normalized.contains("api_key")
                     || normalized.contains("token")
@@ -411,91 +410,49 @@ fn is_safe_token_csv_u64_or_null_key(key: &str) -> bool {
     )
 }
 
-fn is_safe_token_identifier_value(key: &str, value: &str) -> bool {
-    match plain_completion_tokenization_metadata_key(key) {
-        Some("plain_completion_prompt_tokenization_error_category") => {
-            is_safe_tokenization_error_category(value)
-        }
-        Some("plain_completion_prompt_tokenization_method") => {
-            matches!(value, "" | "llama.tokenize")
-        }
-        Some("plain_completion_prompt_tokenization_selected_variant") => {
-            is_safe_tokenization_variant_id(value) || value.is_empty()
-        }
-        _ => false,
-    }
+fn is_safe_token_identifier_value(_key: &str, value: &str) -> bool {
+    is_bounded_token_identifier(value)
 }
 
-fn is_safe_token_csv_identifier_value(key: &str, value: &str) -> bool {
-    match plain_completion_tokenization_metadata_key(key) {
-        Some("plain_completion_prompt_tokenization_variant_ids")
-        | Some("plain_completion_attempt_tokenization_variants") => {
-            is_safe_tokenization_variant_csv(value)
-        }
-        Some("plain_completion_prompt_tokenization_special_values") => {
-            is_safe_tokenization_special_value_csv(value)
-        }
-        _ => false,
-    }
+fn is_safe_token_csv_identifier_value(_key: &str, value: &str) -> bool {
+    is_bounded_token_identifier_csv(value)
 }
 
-fn plain_completion_tokenization_metadata_key(key: &str) -> Option<&str> {
-    key.strip_prefix("api_v1_readiness_completion_smoke_")
-        .or(Some(key))
-}
-
-fn is_safe_tokenization_error_category(value: &str) -> bool {
-    matches!(
-        value,
-        "" | "context_length_exceeded"
-            | "context_window_exceeded"
-            | "tokenizer_unavailable"
-            | "method_shape"
-            | "tokenizer_special_rejected"
-            | "token_overflow"
-            | "prompt_tokenization_failure"
-            | "prompt_eval_failure"
-            | "prompt_eval_decode_failure"
-            | "prompt_eval_invalid_batch"
-            | "backend_allocation_failure"
-            | "backend_graph_compute_failure"
-            | "metal_graph_compute_failure"
-            | "kv_slot_unavailable"
-            | "decode_aborted"
-            | "backend_decode_failure"
-            | "prompt_eval_backend_failure"
-            | "prompt_eval_invalid_token_failure"
-            | "prompt_eval_state_failure"
-            | "prompt_eval_context_failure"
-            | "sampling_failure"
-    )
-}
-
-fn is_safe_tokenization_variant_id(value: &str) -> bool {
-    matches!(
-        value,
-        "tokenize_add_bos_false_special_false"
-            | "tokenize_add_bos_false_no_special"
-            | "tokenize_add_bos_false_special_true"
-    )
-}
-
-fn is_safe_tokenization_variant_csv(value: &str) -> bool {
-    value.len() <= 256 && validate_bounded_csv(value, is_safe_tokenization_variant_id)
-}
-
-fn is_safe_tokenization_special_value_csv(value: &str) -> bool {
+fn is_bounded_token_identifier(value: &str) -> bool {
     value.len() <= 256
-        && validate_bounded_csv(value, |entry| matches!(entry, "false" | "none" | "true"))
+        && value
+            .chars()
+            .all(|ch| !ch.is_control() && ch != ',' && ch != '"' && ch != '\\')
+}
+
+fn is_bounded_token_identifier_csv(value: &str) -> bool {
+    value.len() <= 256 && validate_bounded_identifier_csv(value, is_bounded_token_identifier)
 }
 
 fn is_bounded_token_csv_u64s(value: &str) -> bool {
+    if value.is_empty() {
+        return true;
+    }
     value.len() <= 256
         && validate_bounded_csv(value, |entry| {
             !entry.is_empty()
                 && entry.bytes().all(|byte| byte.is_ascii_digit())
                 && entry.parse::<u64>().is_ok()
         })
+}
+
+fn validate_bounded_identifier_csv(value: &str, validate_entry: impl Fn(&str) -> bool) -> bool {
+    let mut count = 0usize;
+    for entry in value.split(',').filter(|entry| !entry.is_empty()) {
+        if !validate_entry(entry) {
+            return false;
+        }
+        count += 1;
+        if count > 64 {
+            return false;
+        }
+    }
+    true
 }
 
 fn validate_bounded_csv(value: &str, validate_entry: impl Fn(&str) -> bool) -> bool {
@@ -763,6 +720,122 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_operator_diagnostic_line_accepts_empty_and_sparse_safe_token_metadata() {
+        let sanitized = sanitize_operator_diagnostic_line(&serde_json::json!({
+            "plain_completion_prompt_tokenization_method": "",
+            "plain_completion_prompt_tokenization_selected_variant": "",
+            "plain_completion_prompt_tokenization_variant_ids": "",
+            "plain_completion_prompt_tokenization_special_values": ",false,,true,",
+            "plain_completion_attempt_tokenization_variants": "tokenize_add_bos_false_special_false,,tokenize_add_bos_false_special_true",
+            "plain_completion_prompt_tokenization_token_counts": "",
+        }).to_string());
+        let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
+
+        assert_eq!(
+            payload["plain_completion_prompt_tokenization_method"].as_str(),
+            Some("")
+        );
+        assert_eq!(
+            payload["plain_completion_prompt_tokenization_selected_variant"].as_str(),
+            Some("")
+        );
+        assert_eq!(
+            payload["plain_completion_prompt_tokenization_variant_ids"].as_str(),
+            Some("")
+        );
+        assert_eq!(
+            payload["plain_completion_prompt_tokenization_special_values"].as_str(),
+            Some(",false,,true,")
+        );
+        assert_eq!(
+            payload["plain_completion_attempt_tokenization_variants"].as_str(),
+            Some("tokenize_add_bos_false_special_false,,tokenize_add_bos_false_special_true")
+        );
+        assert_eq!(
+            payload["plain_completion_prompt_tokenization_token_counts"].as_str(),
+            Some("")
+        );
+        assert!(!sanitized.contains("<redacted>"));
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_rejects_sparse_u64_csv_and_mixed_case_safe_keys() {
+        let sanitized = sanitize_operator_diagnostic_line(
+            &serde_json::json!({
+                "plain_completion_prompt_tokenization_token_counts": "50,,28",
+                "Context_Window_Tokens": 65536,
+                "Plain_Completion_Prompt_Tokenization_Method": "llama.tokenize",
+            })
+            .to_string(),
+        );
+        let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
+
+        assert_eq!(
+            payload["plain_completion_prompt_tokenization_token_counts"].as_str(),
+            Some("<redacted>")
+        );
+        assert_eq!(
+            payload["Context_Window_Tokens"].as_str(),
+            Some("<redacted>")
+        );
+        assert_eq!(
+            payload["Plain_Completion_Prompt_Tokenization_Method"].as_str(),
+            Some("<redacted>")
+        );
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_sanitizes_allowlisted_identifier_strings() {
+        let sanitized = sanitize_operator_diagnostic_line(&serde_json::json!({
+            "plain_completion_prompt_tokenization_method": "https://user:pass@example.com/private/model.gguf?token=secret",
+            "plain_completion_prompt_tokenization_selected_variant": "/home/alice/private/model.gguf",
+            "plain_completion_prompt_tokenization_variant_ids": "file:///Users/alice/private/model.gguf",
+            "plain_completion_prompt_tokenization_token_counts": "50,28",
+        }).to_string());
+        let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
+
+        assert_eq!(
+            payload["plain_completion_prompt_tokenization_method"].as_str(),
+            Some("https://example.com")
+        );
+        assert_eq!(
+            payload["plain_completion_prompt_tokenization_selected_variant"].as_str(),
+            Some("<path:model.gguf>")
+        );
+        assert_eq!(
+            payload["plain_completion_prompt_tokenization_variant_ids"].as_str(),
+            Some("<path:model.gguf>")
+        );
+        assert_eq!(
+            payload["plain_completion_prompt_tokenization_token_counts"].as_str(),
+            Some("50,28")
+        );
+        assert!(!sanitized.contains("user:pass"));
+        assert!(!sanitized.contains("/private/"));
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_preserves_null_for_safe_token_metadata_classes() {
+        let sanitized = sanitize_operator_diagnostic_line(
+            &serde_json::json!({
+                "context_window_tokens": null,
+                "plain_completion_accepts_max_tokens_kwarg": null,
+                "plain_completion_prompt_tokenization_method": null,
+                "plain_completion_prompt_tokenization_variant_ids": null,
+                "plain_completion_prompt_tokenization_token_counts": null,
+            })
+            .to_string(),
+        );
+        let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
+
+        assert!(payload["context_window_tokens"].is_null());
+        assert!(payload["plain_completion_accepts_max_tokens_kwarg"].is_null());
+        assert!(payload["plain_completion_prompt_tokenization_method"].is_null());
+        assert!(payload["plain_completion_prompt_tokenization_variant_ids"].is_null());
+        assert!(payload["plain_completion_prompt_tokenization_token_counts"].is_null());
+    }
+
+    #[test]
     fn sanitize_operator_diagnostic_line_redacts_real_token_material() {
         let sanitized = sanitize_operator_diagnostic_line(
             &serde_json::json!({
@@ -813,9 +886,9 @@ mod tests {
             "plain_completion_prompt_tokenization_error_category": "bad\\slash",
             "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method": "bad\u{0001}control",
             "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids": too_many_entries,
-            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant": "tok_abc123",
-            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values": "false,tok_abc123",
-            "plain_completion_attempt_tokenization_variants": "tokenize_add_bos_false_special_false,tok_abc123",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant": "bad,comma",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values": "false,bad\\slash",
+            "plain_completion_attempt_tokenization_variants": "tokenize_add_bos_false_special_false,bad\"quote",
         }).to_string());
         let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
 
@@ -823,7 +896,6 @@ mod tests {
             assert_eq!(value.as_str(), Some("<redacted>"));
         }
         assert!(!sanitized.contains("SECRET"));
-        assert!(!sanitized.contains("tok_abc123"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Operator logs were over-redacting any JSON key containing "token", which hid safe numeric token counts and bounded tokenization diagnostics such as `context_window_tokens` and readiness yarn counts.
- The intent is to preserve default-deny redaction for real token material while allowing a narrow set of exact, safe token-metadata keys to pass when they meet strict type/format validators.

### Description
- Add a pre-check allowlist in `desktop-tauri/src-tauri/src/operator_logs.rs` that runs before the generic `contains("token")` redaction and returns a sanitized value for exact safe keys when validators pass.
- Implement validators and classifications for five safe types: non-negative integer or `null` (`u64`), boolean or `null`, bounded identifier or `null`, bounded CSV identifiers or `null`, and bounded CSV non-negative integers or `null`.
- Keep all other keys that contain `token` (and the existing keys like `api_key`, `prompt`, `output`, `response`, `private_key`, `payload`) redacted as `"<redacted>"` and preserve native JSON scalar types for accepted safe metadata.
- Add unit tests that exercise the operator-log JSON path and the compute-node stdout/readiness path, asserting safe values survive with native types, real token material is redacted, unsafe safe-key values fail closed, and nested JSON remains parseable; update `compute_node` tests to exercise the full operator-log flow.

### Testing
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml operator_logs` and all operator-log unit tests passed. (Result: passed)
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node` and all compute-node unit tests passed. (Result: passed)
- Ran `cargo fmt --manifest-path desktop-tauri/src-tauri/Cargo.toml -- --check` for formatting check. (Result: passed)
- Ran `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` to validate Python-side readiness/compute-node integration tests. (Result: passed)
- Ran `pre-commit run --all-files` and `git diff --check` as repository checks. (Result: passed)

Commands used (examples): `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml operator_logs`, `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node`, `cargo fmt --manifest-path desktop-tauri/src-tauri/Cargo.toml -- --check`, `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q`, `pre-commit run --all-files`, `git diff --check`.

All automated checks run here passed; the change is limited to operator-log sanitization and related tests in `desktop-tauri/src-tauri/src/operator_logs.rs` and `desktop-tauri/src-tauri/src/compute_node.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52fad397dc832f933ab9bea7115c4a)