### PR TITLE
Sanitize: allowlist safe token metadata in operator logs

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1874,6 +1874,97 @@ mod tests {
     }
 
     #[test]
+    fn operator_log_path_preserves_64k_safe_token_metadata() {
+        let payload = serde_json::json!({
+            "type": "status",
+            "operator_session_id": "64k-full",
+            "sequence": 64,
+            "running": true,
+            "registered": true,
+            "relay_runtime_state": "ready",
+            "context_tier": "64k-full",
+            "context_window_tokens": 65536,
+            "token": "SECRET_TOKEN_MATERIAL",
+            "prompt_token_ids": [1, 2, 3],
+            "api_token": "SECRET_API_TOKEN",
+            "api_v1_readiness_result": "passed",
+            "api_v1_readiness_yarn_requested_context_tokens": 65536,
+            "api_v1_readiness_yarn_original_context_tokens": 32768,
+            "api_v1_readiness_completion_smoke_result": "passed",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count": 28,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_special": false,
+        });
+
+        let stdout_line =
+            sanitize_operator_diagnostic_line(&summarize_bridge_stdout_payload(&payload));
+        assert!(stdout_line.len() <= 3500);
+        let stdout_event: Value = serde_json::from_str(&stdout_line).expect("stdout json");
+        assert_eq!(
+            stdout_event
+                .get("context_window_tokens")
+                .and_then(Value::as_u64),
+            Some(65536)
+        );
+        assert!(stdout_event.get("prompt_token_ids").is_none());
+        assert!(!stdout_line.contains("SECRET_TOKEN_MATERIAL"));
+        assert!(!stdout_line.contains("SECRET_API_TOKEN"));
+
+        let readiness_chunks = readiness_operator_log_chunks(&payload);
+        assert!(!readiness_chunks.is_empty());
+        let mut diagnostics = Map::new();
+        for chunk in readiness_chunks {
+            let readiness_line = sanitize_operator_diagnostic_line(&chunk);
+            assert!(readiness_line.len() <= 3500);
+            let readiness_event: Value =
+                serde_json::from_str(&readiness_line).expect("readiness json");
+            let chunk_diagnostics = readiness_event
+                .get("diagnostics")
+                .and_then(Value::as_object)
+                .expect("diagnostics object");
+            for (key, value) in chunk_diagnostics {
+                diagnostics.insert(key.clone(), value.clone());
+            }
+            assert!(!readiness_line.contains("SECRET_TOKEN_MATERIAL"));
+            assert!(!readiness_line.contains("SECRET_API_TOKEN"));
+        }
+
+        assert_eq!(
+            diagnostics
+                .get("api_v1_readiness_yarn_requested_context_tokens")
+                .and_then(Value::as_u64),
+            Some(65536)
+        );
+        assert_eq!(
+            diagnostics
+                .get("api_v1_readiness_yarn_original_context_tokens")
+                .and_then(Value::as_u64),
+            Some(32768)
+        );
+        assert_eq!(
+            diagnostics
+                .get("api_v1_readiness_completion_smoke_result")
+                .and_then(Value::as_str),
+            Some("passed")
+        );
+
+        let raw_secret_payload = sanitize_operator_diagnostic_line(
+            &serde_json::json!({
+                "token": "SECRET_TOKEN_MATERIAL",
+                "prompt_token_ids": [1, 2, 3],
+                "api_token": "SECRET_API_TOKEN",
+            })
+            .to_string(),
+        );
+        let raw_secret_event: Value = serde_json::from_str(&raw_secret_payload).expect("json");
+        assert_eq!(raw_secret_event["token"].as_str(), Some("<redacted>"));
+        assert_eq!(
+            raw_secret_event["prompt_token_ids"].as_str(),
+            Some("<redacted>")
+        );
+        assert_eq!(raw_secret_event["api_token"].as_str(), Some("<redacted>"));
+    }
+
+    #[test]
     fn safe_readiness_diagnostics_rejects_free_text_strings() {
         let diagnostics = safe_readiness_diagnostics_from_payload(&serde_json::json!({
             "api_v1_readiness_completion_smoke_method": "rendered prompt leaked",

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -254,7 +254,11 @@ fn sanitize_operator_json_value(value: &serde_json::Value) -> serde_json::Value 
             let mut sanitized = serde_json::Map::new();
             for (key, value) in map {
                 let normalized = key.to_ascii_lowercase();
-                if normalized.contains("api_key")
+                if let Some(safe_token_metadata) =
+                    sanitize_safe_token_metadata_value(&normalized, value)
+                {
+                    sanitized.insert(key.clone(), safe_token_metadata);
+                } else if normalized.contains("api_key")
                     || normalized.contains("token")
                     || normalized.contains("prompt")
                     || normalized.contains("output")
@@ -282,6 +286,150 @@ fn sanitize_operator_json_value(value: &serde_json::Value) -> serde_json::Value 
         _ => value.clone(),
     }
 }
+
+fn sanitize_safe_token_metadata_value(
+    normalized_key: &str,
+    value: &serde_json::Value,
+) -> Option<serde_json::Value> {
+    if SAFE_TOKEN_METADATA_U64_OR_NULL_KEYS.contains(&normalized_key) {
+        return Some(match value {
+            serde_json::Value::Null => serde_json::Value::Null,
+            serde_json::Value::Number(number) if number.as_u64().is_some() => value.clone(),
+            _ => redacted_json_value(),
+        });
+    }
+    if SAFE_TOKEN_METADATA_BOOL_OR_NULL_KEYS.contains(&normalized_key) {
+        return Some(match value {
+            serde_json::Value::Bool(_) | serde_json::Value::Null => value.clone(),
+            _ => redacted_json_value(),
+        });
+    }
+    if SAFE_TOKEN_METADATA_IDENTIFIER_OR_NULL_KEYS.contains(&normalized_key) {
+        return Some(match value {
+            serde_json::Value::Null => serde_json::Value::Null,
+            serde_json::Value::String(text) if is_bounded_safe_identifier(text) => value.clone(),
+            _ => redacted_json_value(),
+        });
+    }
+    if SAFE_TOKEN_METADATA_IDENTIFIER_CSV_OR_NULL_KEYS.contains(&normalized_key) {
+        return Some(match value {
+            serde_json::Value::Null => serde_json::Value::Null,
+            serde_json::Value::String(text) if is_bounded_safe_identifier_csv(text) => {
+                value.clone()
+            }
+            _ => redacted_json_value(),
+        });
+    }
+    if SAFE_TOKEN_METADATA_U64_CSV_OR_NULL_KEYS.contains(&normalized_key) {
+        return Some(match value {
+            serde_json::Value::Null => serde_json::Value::Null,
+            serde_json::Value::String(text) if is_bounded_safe_u64_csv(text) => value.clone(),
+            _ => redacted_json_value(),
+        });
+    }
+    None
+}
+
+fn redacted_json_value() -> serde_json::Value {
+    serde_json::Value::String("<redacted>".into())
+}
+
+fn is_bounded_safe_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 256
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(byte, b'_' | b'.' | b':' | b'/' | b'@' | b'+' | b'-')
+        })
+}
+
+fn is_bounded_safe_identifier_csv(value: &str) -> bool {
+    is_bounded_safe_csv(value, is_bounded_safe_identifier)
+}
+
+fn is_bounded_safe_u64_csv(value: &str) -> bool {
+    is_bounded_safe_csv(value, |entry| {
+        !entry.is_empty()
+            && entry.bytes().all(|byte| byte.is_ascii_digit())
+            && entry.parse::<u64>().is_ok()
+    })
+}
+
+fn is_bounded_safe_csv(value: &str, validator: fn(&str) -> bool) -> bool {
+    if value.is_empty() || value.len() > 256 {
+        return false;
+    }
+    let mut count = 0usize;
+    for entry in value.split(',') {
+        if entry.is_empty() || !validator(entry) {
+            return false;
+        }
+        count += 1;
+        if count > 64 {
+            return false;
+        }
+    }
+    count > 0
+}
+
+const SAFE_TOKEN_METADATA_U64_OR_NULL_KEYS: &[&str] = &[
+    "context_window_tokens",
+    "prompt_tokens",
+    "requested_output_tokens",
+    "required_total_tokens",
+    "max_tokens",
+    "native_context_tokens",
+    "maximum_validated_context_tokens",
+    "requested_context_tokens",
+    "original_context_tokens",
+    "context_size_tokens",
+    "qwen_yarn_requested_context_tokens",
+    "qwen_yarn_original_context_tokens",
+    "plain_completion_prompt_token_count",
+    "plain_completion_prompt_tokenization_variant_count",
+    "plain_completion_prompt_tokenization_selected_token_count",
+    "api_v1_readiness_context_window_tokens",
+    "api_v1_readiness_prompt_tokens",
+    "api_v1_readiness_yarn_requested_context_tokens",
+    "api_v1_readiness_yarn_original_context_tokens",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_token_count",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_count",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count",
+];
+
+const SAFE_TOKEN_METADATA_BOOL_OR_NULL_KEYS: &[&str] = &[
+    "plain_completion_accepts_max_tokens_kwarg",
+    "plain_completion_prompt_tokenization_special",
+    "plain_completion_prompt_tokenization_attempted",
+    "plain_completion_prompt_tokenization_selected_special",
+    "api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_attempted",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_special",
+];
+
+const SAFE_TOKEN_METADATA_IDENTIFIER_OR_NULL_KEYS: &[&str] = &[
+    "plain_completion_prompt_tokenization_error_category",
+    "plain_completion_prompt_tokenization_method",
+    "plain_completion_prompt_tokenization_selected_variant",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_error_category",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant",
+];
+
+const SAFE_TOKEN_METADATA_IDENTIFIER_CSV_OR_NULL_KEYS: &[&str] = &[
+    "plain_completion_prompt_tokenization_variant_ids",
+    "plain_completion_prompt_tokenization_special_values",
+    "plain_completion_attempt_tokenization_variants",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values",
+    "api_v1_readiness_completion_smoke_plain_completion_attempt_tokenization_variants",
+];
+
+const SAFE_TOKEN_METADATA_U64_CSV_OR_NULL_KEYS: &[&str] = &[
+    "plain_completion_prompt_tokenization_token_counts",
+    "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts",
+];
 
 fn sanitize_url_display(value: &str) -> String {
     let trimmed = value.trim_matches(|ch: char| matches!(ch, '\'' | '"' | ',' | ';' | ')' | '('));
@@ -477,6 +625,165 @@ mod tests {
         );
         assert!(!sanitized.contains("secret value"));
         assert!(!sanitized.contains("secret token"));
+    }
+
+    fn sanitized_json_payload(line: &str) -> serde_json::Value {
+        let sanitized = sanitize_operator_diagnostic_line(line);
+        serde_json::from_str(&sanitized).expect("sanitized json remains parseable")
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_preserves_safe_token_metadata() {
+        let payload = sanitized_json_payload(&serde_json::json!({
+            "context_window_tokens": 65536,
+            "api_v1_readiness_yarn_requested_context_tokens": 65536,
+            "api_v1_readiness_yarn_original_context_tokens": 32768,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_token_count": 50,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count": 28,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_count": 2,
+            "api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg": true,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_special": false,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method": "llama.tokenize",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant": "tokenize_add_bos_false_special_false",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids": "tokenize_add_bos_false_special_false,tokenize_add_bos_false_special_true",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts": "50,28",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values": "false,true",
+        }).to_string());
+
+        assert_eq!(payload["context_window_tokens"].as_u64(), Some(65536));
+        assert_eq!(
+            payload["api_v1_readiness_yarn_requested_context_tokens"].as_u64(),
+            Some(65536)
+        );
+        assert_eq!(
+            payload["api_v1_readiness_yarn_original_context_tokens"].as_u64(),
+            Some(32768)
+        );
+        assert_eq!(
+            payload["api_v1_readiness_completion_smoke_plain_completion_prompt_token_count"]
+                .as_u64(),
+            Some(50)
+        );
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count"].as_u64(), Some(28));
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_count"].as_u64(), Some(2));
+        assert_eq!(
+            payload["api_v1_readiness_completion_smoke_plain_completion_accepts_max_tokens_kwarg"]
+                .as_bool(),
+            Some(true)
+        );
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_special"].as_bool(), Some(false));
+        assert_eq!(
+            payload
+                ["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method"]
+                .as_str(),
+            Some("llama.tokenize")
+        );
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_variant"].as_str(), Some("tokenize_add_bos_false_special_false"));
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids"].as_str(), Some("tokenize_add_bos_false_special_false,tokenize_add_bos_false_special_true"));
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts"].as_str(), Some("50,28"));
+        assert_eq!(payload["api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_special_values"].as_str(), Some("false,true"));
+        assert!(!payload.to_string().contains("<redacted>"));
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_redacts_real_token_material() {
+        let sanitized = sanitize_operator_diagnostic_line(
+            &serde_json::json!({
+                "token": "SECRET_TOKEN",
+                "tokens": ["SECRET_ARRAY"],
+                "token_ids": [1, 2, 3],
+                "prompt_token_ids": [4, 5],
+                "access_token": "SECRET_ACCESS",
+                "refresh_token": 123,
+                "cancel_token": {"value": "SECRET_CANCEL"},
+                "session_token": "SECRET_SESSION",
+                "api_token": "SECRET_API",
+            })
+            .to_string(),
+        );
+        let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
+
+        for key in [
+            "token",
+            "tokens",
+            "token_ids",
+            "prompt_token_ids",
+            "access_token",
+            "refresh_token",
+            "cancel_token",
+            "session_token",
+            "api_token",
+        ] {
+            assert_eq!(payload[key].as_str(), Some("<redacted>"), "{key}");
+        }
+        for sentinel in [
+            "SECRET_TOKEN",
+            "SECRET_ARRAY",
+            "SECRET_ACCESS",
+            "SECRET_CANCEL",
+            "SECRET_SESSION",
+            "SECRET_API",
+        ] {
+            assert!(!sanitized.contains(sentinel));
+        }
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_redacts_unsafe_safe_token_metadata_values() {
+        let too_many_entries = (0..65)
+            .map(|idx| format!("id{idx}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let payload = sanitized_json_payload(&serde_json::json!({
+            "context_window_tokens": "SECRET",
+            "api_v1_readiness_yarn_requested_context_tokens": -1,
+            "api_v1_readiness_yarn_original_context_tokens": 32768.5,
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_selected_token_count": [28],
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_token_counts": "50,text",
+            "plain_completion_prompt_tokenization_method": "llama tokenize",
+            "plain_completion_prompt_tokenization_error_category": "bad\"quote",
+            "plain_completion_prompt_tokenization_selected_variant": "bad\\slash",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_method": "bad\u{0007}control",
+            "api_v1_readiness_completion_smoke_plain_completion_prompt_tokenization_variant_ids": too_many_entries,
+        }).to_string());
+
+        for key in payload.as_object().expect("object").keys() {
+            assert_eq!(payload[key].as_str(), Some("<redacted>"), "{key}");
+        }
+    }
+
+    #[test]
+    fn sanitize_operator_diagnostic_line_keeps_nested_json_safe_and_parseable() {
+        let sanitized = sanitize_operator_diagnostic_line(
+            &serde_json::json!({
+                "outer": {
+                    "context_window_tokens": 65536,
+                    "token": "SECRET_NESTED_TOKEN",
+                    "items": [
+                        {"api_v1_readiness_yarn_original_context_tokens": 32768},
+                        {"token_ids": ["SECRET_TOKEN_ID"]}
+                    ]
+                }
+            })
+            .to_string(),
+        );
+        let payload: serde_json::Value = serde_json::from_str(&sanitized).expect("json");
+
+        assert_eq!(
+            payload["outer"]["context_window_tokens"].as_u64(),
+            Some(65536)
+        );
+        assert_eq!(payload["outer"]["token"].as_str(), Some("<redacted>"));
+        assert_eq!(
+            payload["outer"]["items"][0]["api_v1_readiness_yarn_original_context_tokens"].as_u64(),
+            Some(32768)
+        );
+        assert_eq!(
+            payload["outer"]["items"][1]["token_ids"].as_str(),
+            Some("<redacted>")
+        );
+        assert!(!sanitized.contains("SECRET_NESTED_TOKEN"));
+        assert!(!sanitized.contains("SECRET_TOKEN_ID"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Operator logs were over-redacting safe numeric token counts and bounded tokenization diagnostics because the sanitizer redacted any key containing the substring `token`. 
- The goal is to preserve safe observability fields (counts, small diagnostics) while keeping all real token-bearing and sensitive fields redacted and preserving E2EE/privacy invariants.

### Description

- Added a narrow, exact allowlist and validators that run before generic `token` redaction in `desktop-tauri/src-tauri/src/operator_logs.rs`, preserving default-deny behavior for all other keys. 
- Implemented type/format validators for the requested classes: non-negative `u64` or `null`, `bool` or `null`, bounded identifiers, bounded CSV identifiers, and bounded CSV `u64` (functions: `sanitize_safe_token_metadata_value`, `is_bounded_safe_identifier`, `is_bounded_safe_csv`, etc.).
- Declared the exact safe token-metadata key sets as constants (`SAFE_TOKEN_METADATA_*_KEYS`) to match the specification (Qwen/YaRN readiness keys, token-count keys, tokenization metadata keys).
- Kept all existing redaction for real token-bearing keys and other sensitive fields by applying the safe-key exception first then falling back to the original redaction path.
- Added unit tests exercising sanitization and the compute-node operator-log path by updating `desktop-tauri/src-tauri/src/operator_logs.rs` tests and adding `operator_log_path_preserves_64k_safe_token_metadata` to `desktop-tauri/src-tauri/src/compute_node.rs`.

### Testing

- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml operator_logs` and the operator-log unit tests passed. ✅
- Ran `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node` and compute-node unit tests passed. ✅
- Verified formatting with `cargo fmt --manifest-path desktop-tauri/src-tauri/Cargo.toml -- --check` which succeeded. ✅
- Ran readiness/bridge Python tests with `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` and the suite passed. ✅
- Ran repository checks `git diff --check` and `pre-commit run --all-files` which succeeded. ✅

Files changed (scope-limited):
- Modified: `desktop-tauri/src-tauri/src/operator_logs.rs` (sanitizer logic, validators, allowlists, tests).
- Modified: `desktop-tauri/src-tauri/src/compute_node.rs` (added test exercising the operator-log readiness/stdout path).

Residual notes: change is intentionally limited to operator-log sanitization and test coverage; no runtime, API, E2EE, or telemetry policy behavior was altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52faedae14832f90e064930c69c0b2)