### PR TITLE
Fix desktop CUDA Qwen64k capability handoff and Windows path redaction

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -137,8 +137,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: config/requirements_codex_verification.txt
 
       - name: Install Python dependencies
         run: |
@@ -174,8 +172,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.9'
-          cache: 'pip'
-          cache-dependency-path: config/requirements_codex_verification.txt
 
       - name: Install Python dependencies (macOS, Python 3.9 inspect)
         run: |

--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -148,6 +148,12 @@ jobs:
       - name: Run shared desktop parity checks (Windows)
         run: python desktop-tauri/scripts/run_desktop_parity_checks.py
 
+      - name: Run Windows CUDA capability handoff regressions (fakes)
+        run: |
+          python -m pytest tests/unit/test_desktop_runtime_setup.py -q
+          python -m pytest tests/unit/test_model_manager.py -q
+          cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml operator_logs
+
       - name: Upload desktop relay parity logs on failure (Windows)
         if: failure()
         uses: actions/upload-artifact@v4

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -237,18 +237,17 @@ try:
     if gpu_offload_supported and backend == "cpu":
         backend = "metal" if sys.platform == "darwin" else "cuda"
 
-    constructor_kwarg_names = LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS
     Llama = getattr(llama_cpp, "Llama", None)
     constructor_signature_inspectable = False
     constructor_has_var_kwargs = False
-    constructor_kwarg_support = {name: False for name in constructor_kwarg_names}
+    constructor_kwarg_support = {name: False for name in LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS}
     try:
         params = inspect.signature(getattr(Llama, "__init__", Llama)).parameters
         constructor_signature_inspectable = True
         constructor_has_var_kwargs = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
         constructor_kwarg_support = {
             name: bool(name in params or constructor_has_var_kwargs)
-            for name in constructor_kwarg_names
+            for name in LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS
         }
     except (TypeError, ValueError):
         pass
@@ -517,7 +516,7 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
 
     return RuntimeProbe(
         backend=str(payload.get("backend", "cpu")),
-        gpu_offload_supported=bool(payload.get("gpu_offload_supported", False)),
+        gpu_offload_supported=payload.get("gpu_offload_supported") is True,
         detected_device=str(payload.get("detected_device", "cpu")),
         interpreter=str(payload.get("interpreter", sys.executable)),
         prefix=str(payload.get("prefix", sys.prefix)),
@@ -528,21 +527,21 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
         dependency_target=str(payload.get("dependency_target", dependency_target_text)),
         pip_version=str(payload.get("pip_version", pip_version)),
         llama_cpp_python_version=str(payload.get("llama_cpp_python_version", "unknown")),
-        yarn_rope_supported=bool(payload.get("yarn_rope_supported", False)),
+        yarn_rope_supported=payload.get("yarn_rope_supported") is True,
         yarn_resolver_source=str(payload.get("yarn_resolver_source", "unsupported")),
-        rope_scaling_type_supported=bool(payload.get("rope_scaling_type_supported", False)),
-        yarn_ext_factor_supported=bool(payload.get("yarn_ext_factor_supported", False)),
-        rope_freq_scale_supported=bool(payload.get("rope_freq_scale_supported", False)),
-        yarn_orig_ctx_supported=bool(payload.get("yarn_orig_ctx_supported", False)),
+        rope_scaling_type_supported=payload.get("rope_scaling_type_supported") is True,
+        yarn_ext_factor_supported=payload.get("yarn_ext_factor_supported") is True,
+        rope_freq_scale_supported=payload.get("rope_freq_scale_supported") is True,
+        yarn_orig_ctx_supported=payload.get("yarn_orig_ctx_supported") is True,
         constructor_kwarg_support={
-            str(name): bool(value)
+            str(name): value
             for name, value in (payload.get("constructor_kwarg_support") or {}).items()
             if isinstance(name, str)
             and name in LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS
             and isinstance(value, bool)
         } if isinstance(payload.get("constructor_kwarg_support"), dict) else {},
-        constructor_has_var_kwargs=bool(payload.get("constructor_has_var_kwargs", False)),
-        constructor_signature_inspectable=bool(payload.get("constructor_signature_inspectable", False)),
+        constructor_has_var_kwargs=payload.get("constructor_has_var_kwargs") is True,
+        constructor_signature_inspectable=payload.get("constructor_signature_inspectable") is True,
         qwen_64k_yarn_support=str(payload.get("qwen_64k_yarn_support", "unsupported")),
         yarn_enum_value=payload.get("yarn_enum_value") if isinstance(payload.get("yarn_enum_value"), int) and not isinstance(payload.get("yarn_enum_value"), bool) else None,
         q8_kv_cache_type_value=payload.get("q8_kv_cache_type_value") if isinstance(payload.get("q8_kv_cache_type_value"), int) and not isinstance(payload.get("q8_kv_cache_type_value"), bool) else None,

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -9,9 +9,9 @@ import platform as platform_module
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from desktop_gpu_packaging import (
     LlamaCppInstallPlan,
@@ -21,6 +21,23 @@ from desktop_gpu_packaging import (
     backend_probe_satisfies_install_plan,
     llama_cpp_install_plan_fallbacks,
     llama_cpp_requirement_spec,
+)
+
+LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS = (
+    "type_k",
+    "type_v",
+    "flash_attn",
+    "offload_kqv",
+    "n_batch",
+    "n_ubatch",
+    "rope_scaling_type",
+    "yarn_ext_factor",
+    "yarn_attn_factor",
+    "yarn_beta_fast",
+    "yarn_beta_slow",
+    "yarn_orig_ctx",
+    "rope_freq_base",
+    "rope_freq_scale",
 )
 
 
@@ -65,6 +82,15 @@ class RuntimeProbe:
     yarn_ext_factor_supported: bool = False
     rope_freq_scale_supported: bool = False
     yarn_orig_ctx_supported: bool = False
+    constructor_kwarg_support: Dict[str, bool] = field(default_factory=dict)
+    constructor_has_var_kwargs: bool = False
+    constructor_signature_inspectable: bool = False
+    qwen_64k_yarn_support: str = "unsupported"
+    yarn_enum_value: Optional[int] = None
+    q8_kv_cache_type_value: Optional[int] = None
+    q4_kv_cache_type_value: Optional[int] = None
+    f16_kv_cache_type_value: Optional[int] = None
+    capability_source: str = "desktop_runtime_setup_probe"
 
 
 GPU_MODES = frozenset({"auto", "gpu", "hybrid"})
@@ -111,6 +137,23 @@ _PROBE_SNIPPET = r"""
 import json
 import os
 import sys
+LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS = (
+    "type_k",
+    "type_v",
+    "flash_attn",
+    "offload_kqv",
+    "n_batch",
+    "n_ubatch",
+    "rope_scaling_type",
+    "yarn_ext_factor",
+    "yarn_attn_factor",
+    "yarn_beta_fast",
+    "yarn_beta_slow",
+    "yarn_orig_ctx",
+    "rope_freq_base",
+    "rope_freq_scale",
+)
+
 
 def _strip_windows_extended_path_prefix(path_text):
     prefix = chr(92) + chr(92) + "?" + chr(92)
@@ -194,32 +237,70 @@ try:
     if gpu_offload_supported and backend == "cpu":
         backend = "metal" if sys.platform == "darwin" else "cuda"
 
-    def _accepts(cls, name):
-        try:
-            params = inspect.signature(getattr(cls, "__init__", cls)).parameters
-        except (TypeError, ValueError):
-            return False
-        return name in params or any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
-
+    constructor_kwarg_names = (
+        "type_k", "type_v", "flash_attn", "offload_kqv", "n_batch", "n_ubatch",
+        "rope_scaling_type", "yarn_ext_factor", "yarn_attn_factor", "yarn_beta_fast",
+        "yarn_beta_slow", "yarn_orig_ctx", "rope_freq_base", "rope_freq_scale",
+    )
     Llama = getattr(llama_cpp, "Llama", None)
-    rope_scaling_type_supported = _accepts(Llama, "rope_scaling_type")
-    yarn_ext_factor_supported = _accepts(Llama, "yarn_ext_factor")
-    rope_freq_scale_supported = _accepts(Llama, "rope_freq_scale")
-    yarn_orig_ctx_supported = _accepts(Llama, "yarn_orig_ctx")
-    if getattr(llama_cpp, "LLAMA_ROPE_SCALING_TYPE_YARN", None) is not None:
+    constructor_signature_inspectable = False
+    constructor_has_var_kwargs = False
+    constructor_kwarg_support = {name: False for name in constructor_kwarg_names}
+    try:
+        params = inspect.signature(getattr(Llama, "__init__", Llama)).parameters
+        constructor_signature_inspectable = True
+        constructor_has_var_kwargs = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+        constructor_kwarg_support = {
+            name: bool(name in params or constructor_has_var_kwargs)
+            for name in constructor_kwarg_names
+        }
+    except (TypeError, ValueError):
+        pass
+
+    rope_scaling_type_supported = constructor_kwarg_support.get("rope_scaling_type", False)
+    yarn_ext_factor_supported = constructor_kwarg_support.get("yarn_ext_factor", False)
+    rope_freq_scale_supported = constructor_kwarg_support.get("rope_freq_scale", False)
+    yarn_orig_ctx_supported = constructor_kwarg_support.get("yarn_orig_ctx", False)
+
+    yarn_enum_value = getattr(llama_cpp, "LLAMA_ROPE_SCALING_TYPE_YARN", None)
+    if yarn_enum_value is not None:
         yarn_resolver_source = "top_level_enum"
-    elif getattr(getattr(llama_cpp, "llama_cpp", None), "LLAMA_ROPE_SCALING_TYPE_YARN", None) is not None:
-        yarn_resolver_source = "nested_enum"
-    elif rope_scaling_type_supported:
-        yarn_resolver_source = "numeric_fallback"
     else:
-        yarn_resolver_source = "unsupported"
+        yarn_enum_value = getattr(getattr(llama_cpp, "llama_cpp", None), "LLAMA_ROPE_SCALING_TYPE_YARN", None)
+        if yarn_enum_value is not None:
+            yarn_resolver_source = "nested_enum"
+        elif rope_scaling_type_supported:
+            yarn_enum_value = 2
+            yarn_resolver_source = "numeric_fallback"
+        else:
+            yarn_resolver_source = "unsupported"
+            yarn_enum_value = None
+    if not isinstance(yarn_enum_value, int) or isinstance(yarn_enum_value, bool):
+        yarn_enum_value = None
+    def _resolve_type_constant(*names):
+        for container in (llama_cpp, getattr(llama_cpp, "llama_cpp", None)):
+            if container is None:
+                continue
+            for name in names:
+                value = getattr(container, name, None)
+                if isinstance(value, int) and not isinstance(value, bool):
+                    return value
+        return None
+    q8_kv_cache_type_value = _resolve_type_constant("GGML_TYPE_Q8_0", "LLAMA_TYPE_Q8_0")
+    q4_kv_cache_type_value = _resolve_type_constant("GGML_TYPE_Q4_0", "LLAMA_TYPE_Q4_0")
+    f16_kv_cache_type_value = _resolve_type_constant("GGML_TYPE_F16", "LLAMA_TYPE_F16")
     yarn_rope_supported = bool(
-        yarn_resolver_source != "unsupported"
+        yarn_enum_value is not None
         and rope_scaling_type_supported
         and rope_freq_scale_supported
         and yarn_orig_ctx_supported
     )
+    if yarn_rope_supported:
+        qwen_64k_yarn_support = "supported"
+    elif not constructor_signature_inspectable:
+        qwen_64k_yarn_support = "unknown"
+    else:
+        qwen_64k_yarn_support = "unsupported"
     llama_cpp_python_version = getattr(llama_cpp, "__version__", None)
     if not llama_cpp_python_version:
         try:
@@ -245,6 +326,15 @@ try:
         "yarn_ext_factor_supported": yarn_ext_factor_supported,
         "rope_freq_scale_supported": rope_freq_scale_supported,
         "yarn_orig_ctx_supported": yarn_orig_ctx_supported,
+        "constructor_kwarg_support": constructor_kwarg_support,
+        "constructor_has_var_kwargs": constructor_has_var_kwargs,
+        "constructor_signature_inspectable": constructor_signature_inspectable,
+        "qwen_64k_yarn_support": qwen_64k_yarn_support,
+        "yarn_enum_value": yarn_enum_value,
+        "q8_kv_cache_type_value": q8_kv_cache_type_value,
+        "q4_kv_cache_type_value": q4_kv_cache_type_value,
+        "f16_kv_cache_type_value": f16_kv_cache_type_value,
+        "capability_source": "desktop_runtime_setup_probe",
         "error": None,
     }
 except Exception as exc:
@@ -266,6 +356,15 @@ except Exception as exc:
         "yarn_ext_factor_supported": False,
         "rope_freq_scale_supported": False,
         "yarn_orig_ctx_supported": False,
+        "constructor_kwarg_support": {},
+        "constructor_has_var_kwargs": False,
+        "constructor_signature_inspectable": False,
+        "qwen_64k_yarn_support": "unsupported",
+        "yarn_enum_value": None,
+        "q8_kv_cache_type_value": None,
+        "q4_kv_cache_type_value": None,
+        "f16_kv_cache_type_value": None,
+        "capability_source": "desktop_runtime_setup_probe",
         "error": str(exc),
     }
 
@@ -361,6 +460,20 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
             cwd=str(repo_root),
             env=env,
         )
+    except subprocess.TimeoutExpired:
+        return RuntimeProbe(
+            backend="missing",
+            gpu_offload_supported=False,
+            detected_device="none",
+            interpreter=sys.executable,
+            prefix=sys.prefix,
+            llama_module_path="missing",
+            error="desktop_runtime_probe_timeout_after_30s",
+            python_version=_python_version_text(),
+            base_prefix=getattr(sys, "base_prefix", sys.prefix),
+            dependency_target=dependency_target_text,
+            pip_version=pip_version,
+        )
     except Exception as exc:
         return RuntimeProbe(
             backend="missing",
@@ -425,6 +538,19 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
         yarn_ext_factor_supported=bool(payload.get("yarn_ext_factor_supported", False)),
         rope_freq_scale_supported=bool(payload.get("rope_freq_scale_supported", False)),
         yarn_orig_ctx_supported=bool(payload.get("yarn_orig_ctx_supported", False)),
+        constructor_kwarg_support={
+            str(name): bool(value)
+            for name, value in (payload.get("constructor_kwarg_support") or {}).items()
+            if isinstance(name, str) and isinstance(value, bool)
+        } if isinstance(payload.get("constructor_kwarg_support"), dict) else {},
+        constructor_has_var_kwargs=bool(payload.get("constructor_has_var_kwargs", False)),
+        constructor_signature_inspectable=bool(payload.get("constructor_signature_inspectable", False)),
+        qwen_64k_yarn_support=str(payload.get("qwen_64k_yarn_support", "unsupported")),
+        yarn_enum_value=payload.get("yarn_enum_value") if isinstance(payload.get("yarn_enum_value"), int) and not isinstance(payload.get("yarn_enum_value"), bool) else None,
+        q8_kv_cache_type_value=payload.get("q8_kv_cache_type_value") if isinstance(payload.get("q8_kv_cache_type_value"), int) and not isinstance(payload.get("q8_kv_cache_type_value"), bool) else None,
+        q4_kv_cache_type_value=payload.get("q4_kv_cache_type_value") if isinstance(payload.get("q4_kv_cache_type_value"), int) and not isinstance(payload.get("q4_kv_cache_type_value"), bool) else None,
+        f16_kv_cache_type_value=payload.get("f16_kv_cache_type_value") if isinstance(payload.get("f16_kv_cache_type_value"), int) and not isinstance(payload.get("f16_kv_cache_type_value"), bool) else None,
+        capability_source=str(payload.get("capability_source", "desktop_runtime_setup_probe")),
     )
 
 
@@ -646,7 +772,7 @@ def _prepend_dependency_target_to_sys_path(runtime_root: Path) -> tuple[Optional
     return dependency_target, dependency_target_error
 
 
-def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, str]:
+def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, Any]:
     return {
         "detected_device": probe.detected_device or "cpu",
         "interpreter": probe.interpreter,
@@ -658,12 +784,23 @@ def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, str]:
         "pip_version": probe.pip_version,
         "llama_module_path": probe.llama_module_path,
         "llama_cpp_python_version": probe.llama_cpp_python_version,
-        "yarn_rope_supported": str(probe.yarn_rope_supported).lower(),
+        "backend": probe.backend,
+        "gpu_offload_supported": probe.gpu_offload_supported,
+        "constructor_kwarg_support": dict(probe.constructor_kwarg_support),
+        "constructor_has_var_kwargs": probe.constructor_has_var_kwargs,
+        "constructor_signature_inspectable": probe.constructor_signature_inspectable,
+        "qwen_64k_yarn_support": probe.qwen_64k_yarn_support,
+        "yarn_enum_value": probe.yarn_enum_value,
+        "q8_kv_cache_type_value": probe.q8_kv_cache_type_value,
+        "q4_kv_cache_type_value": probe.q4_kv_cache_type_value,
+        "f16_kv_cache_type_value": probe.f16_kv_cache_type_value,
+        "capability_source": probe.capability_source,
+        "yarn_rope_supported": probe.yarn_rope_supported,
         "yarn_resolver_source": probe.yarn_resolver_source,
-        "rope_scaling_type_supported": str(probe.rope_scaling_type_supported).lower(),
-        "yarn_ext_factor_supported": str(probe.yarn_ext_factor_supported).lower(),
-        "rope_freq_scale_supported": str(probe.rope_freq_scale_supported).lower(),
-        "yarn_orig_ctx_supported": str(probe.yarn_orig_ctx_supported).lower(),
+        "rope_scaling_type_supported": probe.rope_scaling_type_supported,
+        "yarn_ext_factor_supported": probe.yarn_ext_factor_supported,
+        "rope_freq_scale_supported": probe.rope_freq_scale_supported,
+        "yarn_orig_ctx_supported": probe.yarn_orig_ctx_supported,
     }
 
 
@@ -1190,17 +1327,28 @@ def _ensure_desktop_llama_runtime_impl(mode: str, *, repo_root: Optional[Path] =
     }
 
 
-def _record_desktop_runtime_probe(result: Dict[str, str]) -> Dict[str, str]:
+def _record_desktop_runtime_probe(result: Dict[str, Any]) -> Dict[str, Any]:
     """Expose the successful setup probe to later diagnostics in this process."""
 
     try:
         os.environ[RUNTIME_PROBE_ENV] = json.dumps(result)
     except (TypeError, ValueError):
         os.environ.pop(RUNTIME_PROBE_ENV, None)
-    return result
+        return result
+    public_result = dict(result)
+    for key in (
+        "yarn_rope_supported",
+        "rope_scaling_type_supported",
+        "yarn_ext_factor_supported",
+        "rope_freq_scale_supported",
+        "yarn_orig_ctx_supported",
+    ):
+        if isinstance(public_result.get(key), bool):
+            public_result[key] = str(public_result[key]).lower()
+    return public_result
 
 
-def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None, context_tier: Optional[str] = None) -> Dict[str, str]:
+def ensure_desktop_llama_runtime(mode: str, *, repo_root: Optional[Path] = None, context_tier: Optional[str] = None) -> Dict[str, Any]:
     """Ensure the sidecar interpreter has a GPU-capable runtime when mode prefers GPU."""
 
     return _record_desktop_runtime_probe(

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -237,11 +237,7 @@ try:
     if gpu_offload_supported and backend == "cpu":
         backend = "metal" if sys.platform == "darwin" else "cuda"
 
-    constructor_kwarg_names = (
-        "type_k", "type_v", "flash_attn", "offload_kqv", "n_batch", "n_ubatch",
-        "rope_scaling_type", "yarn_ext_factor", "yarn_attn_factor", "yarn_beta_fast",
-        "yarn_beta_slow", "yarn_orig_ctx", "rope_freq_base", "rope_freq_scale",
-    )
+    constructor_kwarg_names = LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS
     Llama = getattr(llama_cpp, "Llama", None)
     constructor_signature_inspectable = False
     constructor_has_var_kwargs = False
@@ -541,7 +537,9 @@ def _probe_llama_runtime(*, runtime_root: Optional[Path] = None) -> RuntimeProbe
         constructor_kwarg_support={
             str(name): bool(value)
             for name, value in (payload.get("constructor_kwarg_support") or {}).items()
-            if isinstance(name, str) and isinstance(value, bool)
+            if isinstance(name, str)
+            and name in LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS
+            and isinstance(value, bool)
         } if isinstance(payload.get("constructor_kwarg_support"), dict) else {},
         constructor_has_var_kwargs=bool(payload.get("constructor_has_var_kwargs", False)),
         constructor_signature_inspectable=bool(payload.get("constructor_signature_inspectable", False)),

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -196,6 +196,9 @@ pub fn read_log_tail(log_path: &Path, max_bytes: usize) -> anyhow::Result<String
 }
 
 pub fn sanitize_operator_diagnostic_line(line: &str) -> String {
+    if line.contains("TimeoutExpired") && line.contains("Command [") {
+        return "desktop.llama_cpp_worker.init_failed stage=llama_cpp_gpu_probe category=worker_timeout timeout_seconds=30".to_string();
+    }
     let line = sanitize_log_line(line);
     let trimmed = line.trim();
     if trimmed.starts_with('{') || trimmed.starts_with('[') {
@@ -579,10 +582,20 @@ fn sanitize_path_display(value: &str) -> String {
 }
 
 fn is_path_like(value: &str) -> bool {
-    let trimmed = value.trim_matches(|ch: char| matches!(ch, '\'' | '"' | ',' | ';' | ')' | '('));
+    let trimmed =
+        value.trim_matches(|ch: char| matches!(ch, '\'' | '"' | ',' | ';' | ')' | '(' | '[' | ']'));
+    let normalized = trimmed.replace("\\\\", "\\").replace('\\', "/");
+    let lower = normalized.to_ascii_lowercase();
     trimmed.starts_with('/')
         || trimmed.starts_with("~/")
         || trimmed.starts_with("file://")
+        || trimmed.starts_with("\\")
+        || lower.starts_with("//?/c:/")
+        || lower.starts_with("//?/unc/")
+        || lower.starts_with("//")
+        || lower.contains("/users/")
+        || lower.contains("/appdata/")
+        || lower.contains("/programs/python/")
         || trimmed.contains('/')
         || (trimmed.len() > 2
             && trimmed.as_bytes()[1] == b':'
@@ -1058,5 +1071,24 @@ mod tests {
         sink.append_line("desktop.compute_node.stderr", "bridge stderr line");
         let raw = fs::read_to_string(path).expect("log");
         assert!(raw.contains("desktop.compute_node.stderr bridge stderr line"));
+    }
+    #[test]
+    fn sanitize_operator_diagnostic_line_redacts_windows_timeout_paths() {
+        let raw = r#"TimeoutExpired: Command ['\\?\C:\Users\Alice\AppData\Local\Programs\Python\Python311\python.exe', '-c', 'import llama_cpp'] timed out after 30 seconds C:\Users\Alice\AppData\Local\token.place desktop"#;
+        let sanitized = sanitize_operator_diagnostic_line(raw);
+        assert!(!sanitized.contains("Alice"));
+        assert!(!sanitized.contains("AppData"));
+        assert!(!sanitized.contains("Command ["));
+        assert!(sanitized.contains("stage=llama_cpp_gpu_probe"));
+        assert!(sanitized.contains("category=worker_timeout"));
+        assert!(sanitized.contains("timeout_seconds=30"));
+
+        let json = sanitize_operator_diagnostic_line(
+            r#"{"path":"C:\\Users\\Alice\\AppData\\Local\\Programs\\Python\\Python311\\python.exe","stage":"llama_cpp_gpu_probe"}"#,
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parseable json");
+        assert_eq!(parsed["path"], "<path:python.exe>");
+        assert!(!json.contains("Alice"));
+        assert!(!json.contains("AppData"));
     }
 }

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -589,8 +589,8 @@ fn sanitize_path_display(value: &str) -> String {
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
-        .filter(|name| !name.is_empty())
-        .or(cross_platform_name);
+        .filter(|name| !name.is_empty());
+    let file_name = cross_platform_name.or(file_name);
     match file_name {
         Some(name) => format!("<path:{name}>"),
         None => "<path>".into(),
@@ -645,11 +645,17 @@ fn is_windows_extended_or_unc_path_like(value: &str) -> bool {
         value.trim_matches(|ch: char| matches!(ch, '\'' | '"' | ',' | ';' | ')' | '(' | '[' | ']'));
     let normalized = trimmed.replace("\\\\", "\\").replace('\\', "/");
     let lower = normalized.to_ascii_lowercase();
-    (lower.len() > 6
-        && lower.starts_with("//?/")
-        && lower.as_bytes().get(5) == Some(&b':')
-        && lower.as_bytes().get(6) == Some(&b'/')
-        && lower.as_bytes().get(4).is_some_and(u8::is_ascii_alphabetic))
+    (lower.len() > 5
+        && (lower.starts_with("//?/") || lower.starts_with("/?/"))
+        && lower
+            .strip_prefix("//?/")
+            .or_else(|| lower.strip_prefix("/?/"))
+            .is_some_and(|rest| {
+                rest.len() > 2
+                    && rest.as_bytes()[1] == b':'
+                    && rest.as_bytes()[2] == b'/'
+                    && rest.as_bytes()[0].is_ascii_alphabetic()
+            }))
         || lower.starts_with("//?/unc/")
         || lower.starts_with("//")
 }
@@ -663,11 +669,17 @@ fn is_path_like(value: &str) -> bool {
         || trimmed.starts_with("~/")
         || trimmed.starts_with("file://")
         || trimmed.starts_with("\\")
-        || (lower.len() > 6
-            && lower.starts_with("//?/")
-            && lower.as_bytes().get(5) == Some(&b':')
-            && lower.as_bytes().get(6) == Some(&b'/')
-            && lower.as_bytes().get(4).is_some_and(u8::is_ascii_alphabetic))
+        || (lower.len() > 5
+            && (lower.starts_with("//?/") || lower.starts_with("/?/"))
+            && lower
+                .strip_prefix("//?/")
+                .or_else(|| lower.strip_prefix("/?/"))
+                .is_some_and(|rest| {
+                    rest.len() > 2
+                        && rest.as_bytes()[1] == b':'
+                        && rest.as_bytes()[2] == b'/'
+                        && rest.as_bytes()[0].is_ascii_alphabetic()
+                }))
         || lower.starts_with("//?/unc/")
         || lower.starts_with("//")
         || lower.contains("/users/")

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -1156,7 +1156,7 @@ mod tests {
         assert!(!sanitized.contains("Alice"));
         assert!(!sanitized.contains("AppData"));
         assert!(!sanitized.contains("Command ["));
-        assert!(sanitized.contains("stage=subprocess_command"));
+        assert!(sanitized.contains("stage=subprocess_timeout"));
         assert!(sanitized.contains("category=worker_timeout"));
         assert!(sanitized.contains("timeout_seconds=30"));
 

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -196,12 +196,6 @@ pub fn read_log_tail(log_path: &Path, max_bytes: usize) -> anyhow::Result<String
 }
 
 pub fn sanitize_operator_diagnostic_line(line: &str) -> String {
-    if line.contains("TimeoutExpired") && line.contains("Command [") {
-        let timeout_seconds = parse_timeout_expired_seconds(line).unwrap_or(30);
-        return format!(
-            "desktop.llama_cpp_worker.init_failed stage=subprocess_command category=worker_timeout timeout_seconds={timeout_seconds}"
-        );
-    }
     let line = sanitize_log_line(line);
     let trimmed = line.trim();
     if trimmed.starts_with('{') || trimmed.starts_with('[') {
@@ -213,6 +207,15 @@ pub fn sanitize_operator_diagnostic_line(line: &str) -> String {
             return serde_json::to_string(&sanitize_operator_json_value(&value))
                 .unwrap_or_else(|_| r#"{"type":"operator_log_json_sanitize_error"}"#.to_string());
         }
+    }
+    if line.contains("TimeoutExpired") && line.contains("Command [") {
+        let timeout_seconds = parse_timeout_expired_seconds(&line)
+            .map(|seconds| format!(" timeout_seconds={seconds}"))
+            .unwrap_or_default();
+        let stage = parse_timeout_expired_stage(&line).unwrap_or("subprocess_timeout");
+        return format!(
+            "desktop.llama_cpp_worker.init_failed stage={stage} category=worker_timeout{timeout_seconds}"
+        );
     }
     line.split_whitespace()
         .map(sanitize_operator_diagnostic_token)
@@ -605,6 +608,29 @@ fn parse_timeout_expired_seconds(line: &str) -> Option<u64> {
     digits.parse::<u64>().ok()
 }
 
+fn parse_timeout_expired_stage(line: &str) -> Option<&'static str> {
+    const ALLOWED: &[&str] = &[
+        "llama_cpp_gpu_probe",
+        "desktop_runtime_probe",
+        "runtime_import_probe",
+        "pip_install",
+        "subprocess_timeout",
+    ];
+    for marker in ["stage=", "stage:"] {
+        if let Some(rest) = line.split(marker).nth(1) {
+            let stage = rest
+                .trim_start_matches(|ch: char| matches!(ch, '"' | '\'' | '[' | '('))
+                .split(|ch: char| !matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_'))
+                .next()
+                .unwrap_or("");
+            if let Some(allowed) = ALLOWED.iter().copied().find(|allowed| *allowed == stage) {
+                return Some(allowed);
+            }
+        }
+    }
+    None
+}
+
 fn is_windows_drive_path_like(value: &str) -> bool {
     let trimmed =
         value.trim_matches(|ch: char| matches!(ch, '\'' | '"' | ',' | ';' | ')' | '(' | '[' | ']'));
@@ -619,7 +645,13 @@ fn is_windows_extended_or_unc_path_like(value: &str) -> bool {
         value.trim_matches(|ch: char| matches!(ch, '\'' | '"' | ',' | ';' | ')' | '(' | '[' | ']'));
     let normalized = trimmed.replace("\\\\", "\\").replace('\\', "/");
     let lower = normalized.to_ascii_lowercase();
-    lower.starts_with("//?/c:/") || lower.starts_with("//?/unc/") || lower.starts_with("//")
+    (lower.len() > 6
+        && lower.starts_with("//?/")
+        && lower.as_bytes().get(5) == Some(&b':')
+        && lower.as_bytes().get(6) == Some(&b'/')
+        && lower.as_bytes().get(4).is_some_and(u8::is_ascii_alphabetic))
+        || lower.starts_with("//?/unc/")
+        || lower.starts_with("//")
 }
 
 fn is_path_like(value: &str) -> bool {
@@ -631,7 +663,11 @@ fn is_path_like(value: &str) -> bool {
         || trimmed.starts_with("~/")
         || trimmed.starts_with("file://")
         || trimmed.starts_with("\\")
-        || lower.starts_with("//?/c:/")
+        || (lower.len() > 6
+            && lower.starts_with("//?/")
+            && lower.as_bytes().get(5) == Some(&b':')
+            && lower.as_bytes().get(6) == Some(&b'/')
+            && lower.as_bytes().get(4).is_some_and(u8::is_ascii_alphabetic))
         || lower.starts_with("//?/unc/")
         || lower.starts_with("//")
         || lower.contains("/users/")

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -212,7 +212,7 @@ pub fn sanitize_operator_diagnostic_line(line: &str) -> String {
 }
 
 fn sanitize_operator_diagnostic_text(text: &str) -> String {
-    if text.contains("TimeoutExpired") && text.contains("Command [") {
+    if text.contains("TimeoutExpired") && text.contains("Command ") {
         let timeout_seconds = parse_timeout_expired_seconds(text)
             .map(|seconds| format!(" timeout_seconds={seconds}"))
             .unwrap_or_default();
@@ -1172,6 +1172,7 @@ mod tests {
         assert!(!sanitized.contains("Alice"));
         assert!(!sanitized.contains("AppData"));
         assert!(!sanitized.contains("Command ["));
+        assert!(!sanitized.contains("Command '["));
         assert!(sanitized.contains("stage=subprocess_timeout"));
         assert!(sanitized.contains("category=worker_timeout"));
         assert!(sanitized.contains("timeout_seconds=30"));
@@ -1181,6 +1182,17 @@ mod tests {
         );
         assert!(custom_timeout.contains("timeout_seconds=45"));
         assert!(!custom_timeout.contains("Alice"));
+
+        let quoted_python_timeout = sanitize_operator_diagnostic_line(
+            r#"subprocess.TimeoutExpired: Command '['C:\Users\Alice\python.exe', '-c', 'import llama_cpp']' timed out after 12 seconds"#,
+        );
+        assert_eq!(
+            quoted_python_timeout,
+            "desktop.llama_cpp_worker.init_failed stage=subprocess_timeout category=worker_timeout timeout_seconds=12"
+        );
+        assert!(!quoted_python_timeout.contains("Alice"));
+        assert!(!quoted_python_timeout.contains("Command '['"));
+        assert!(!quoted_python_timeout.contains("import llama_cpp"));
 
         let json = sanitize_operator_diagnostic_line(
             r#"{"path":"C:\\Users\\Alice\\AppData\\Local\\Programs\\Python\\Python311\\python.exe","stage":"llama_cpp_gpu_probe"}"#,
@@ -1208,6 +1220,7 @@ mod tests {
         assert!(!json_timeout.contains("Bob"));
         assert!(!json_timeout.contains("AppData"));
         assert!(!json_timeout.contains("Command ["));
+        assert!(!json_timeout.contains("Command '["));
         assert!(!json_timeout.contains("import llama_cpp"));
 
         let drive = sanitize_operator_diagnostic_line(

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -208,16 +208,20 @@ pub fn sanitize_operator_diagnostic_line(line: &str) -> String {
                 .unwrap_or_else(|_| r#"{"type":"operator_log_json_sanitize_error"}"#.to_string());
         }
     }
-    if line.contains("TimeoutExpired") && line.contains("Command [") {
-        let timeout_seconds = parse_timeout_expired_seconds(&line)
+    sanitize_operator_diagnostic_text(&line)
+}
+
+fn sanitize_operator_diagnostic_text(text: &str) -> String {
+    if text.contains("TimeoutExpired") && text.contains("Command [") {
+        let timeout_seconds = parse_timeout_expired_seconds(text)
             .map(|seconds| format!(" timeout_seconds={seconds}"))
             .unwrap_or_default();
-        let stage = parse_timeout_expired_stage(&line).unwrap_or("subprocess_timeout");
+        let stage = parse_timeout_expired_stage(text).unwrap_or("subprocess_timeout");
         return format!(
             "desktop.llama_cpp_worker.init_failed stage={stage} category=worker_timeout{timeout_seconds}"
         );
     }
-    line.split_whitespace()
+    text.split_whitespace()
         .map(sanitize_operator_diagnostic_token)
         .collect::<Vec<_>>()
         .join(" ")
@@ -292,7 +296,7 @@ fn sanitize_operator_json_value(value: &serde_json::Value) -> serde_json::Value 
                 .collect(),
         ),
         serde_json::Value::String(text) => {
-            serde_json::Value::String(sanitize_operator_diagnostic_token(text))
+            serde_json::Value::String(sanitize_operator_diagnostic_text(text))
         }
         _ => value.clone(),
     }
@@ -1185,6 +1189,26 @@ mod tests {
         assert_eq!(parsed["path"], "<path:python.exe>");
         assert!(!json.contains("Alice"));
         assert!(!json.contains("AppData"));
+
+        let json_timeout = sanitize_operator_diagnostic_line(
+            r#"{"message":"TimeoutExpired: Command ['C:\\Users\\Alice\\AppData\\Local\\Programs\\Python\\Python311\\python.exe', '-c', 'import llama_cpp'] timed out after 45 seconds","stderr":"prefix TimeoutExpired: Command ['D:\\Users\\Bob\\AppData\\Local\\app.exe'] timed out after 9 seconds","safe":"ok"}"#,
+        );
+        let parsed_timeout: serde_json::Value =
+            serde_json::from_str(&json_timeout).expect("timeout json remains parseable");
+        assert_eq!(
+            parsed_timeout["message"],
+            "desktop.llama_cpp_worker.init_failed stage=subprocess_timeout category=worker_timeout timeout_seconds=45"
+        );
+        assert_eq!(
+            parsed_timeout["stderr"],
+            "desktop.llama_cpp_worker.init_failed stage=subprocess_timeout category=worker_timeout timeout_seconds=9"
+        );
+        assert_eq!(parsed_timeout["safe"], "ok");
+        assert!(!json_timeout.contains("Alice"));
+        assert!(!json_timeout.contains("Bob"));
+        assert!(!json_timeout.contains("AppData"));
+        assert!(!json_timeout.contains("Command ["));
+        assert!(!json_timeout.contains("import llama_cpp"));
 
         let drive = sanitize_operator_diagnostic_line(
             r#"python=C:\Users\Alice\AppData\Local\Programs\Python\Python311\python.exe"#,

--- a/desktop-tauri/src-tauri/src/operator_logs.rs
+++ b/desktop-tauri/src-tauri/src/operator_logs.rs
@@ -197,7 +197,10 @@ pub fn read_log_tail(log_path: &Path, max_bytes: usize) -> anyhow::Result<String
 
 pub fn sanitize_operator_diagnostic_line(line: &str) -> String {
     if line.contains("TimeoutExpired") && line.contains("Command [") {
-        return "desktop.llama_cpp_worker.init_failed stage=llama_cpp_gpu_probe category=worker_timeout timeout_seconds=30".to_string();
+        let timeout_seconds = parse_timeout_expired_seconds(line).unwrap_or(30);
+        return format!(
+            "desktop.llama_cpp_worker.init_failed stage=subprocess_command category=worker_timeout timeout_seconds={timeout_seconds}"
+        );
     }
     let line = sanitize_log_line(line);
     let trimmed = line.trim();
@@ -231,6 +234,10 @@ fn sanitize_operator_diagnostic_token(token: &str) -> String {
     }
     if token.starts_with("http://") || token.starts_with("https://") {
         return sanitize_url_display(token);
+    }
+
+    if is_windows_drive_path_like(token) || is_windows_extended_or_unc_path_like(token) {
+        return sanitize_path_display(token);
     }
 
     for separator in ['=', ':'] {
@@ -567,18 +574,52 @@ fn sanitize_url_display(value: &str) -> String {
 
 fn sanitize_path_display(value: &str) -> String {
     let trimmed = value.trim_matches(|ch: char| matches!(ch, '\'' | '"' | ',' | ';' | ')' | '('));
-    let path = Path::new(trimmed);
     if trimmed.starts_with('/') && trimmed.split('/').filter(|part| !part.is_empty()).count() <= 2 {
         return "<path>".into();
     }
+    let normalized = trimmed.replace("\\\\", "\\").replace('\\', "/");
+    let cross_platform_name = normalized
+        .rsplit('/')
+        .next()
+        .filter(|name| !name.is_empty());
+    let path = Path::new(trimmed);
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
-        .filter(|name| !name.is_empty());
+        .filter(|name| !name.is_empty())
+        .or(cross_platform_name);
     match file_name {
         Some(name) => format!("<path:{name}>"),
         None => "<path>".into(),
     }
+}
+
+fn parse_timeout_expired_seconds(line: &str) -> Option<u64> {
+    let marker = "timed out after ";
+    let rest = line.split(marker).nth(1)?;
+    let digits: String = rest
+        .chars()
+        .skip_while(|ch| ch.is_whitespace())
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect();
+    digits.parse::<u64>().ok()
+}
+
+fn is_windows_drive_path_like(value: &str) -> bool {
+    let trimmed =
+        value.trim_matches(|ch: char| matches!(ch, '\'' | '"' | ',' | ';' | ')' | '(' | '[' | ']'));
+    trimmed.len() > 2
+        && trimmed.as_bytes()[1] == b':'
+        && (trimmed.as_bytes()[2] == b'/' || trimmed.as_bytes()[2] == b'\\')
+        && trimmed.as_bytes()[0].is_ascii_alphabetic()
+}
+
+fn is_windows_extended_or_unc_path_like(value: &str) -> bool {
+    let trimmed =
+        value.trim_matches(|ch: char| matches!(ch, '\'' | '"' | ',' | ';' | ')' | '(' | '[' | ']'));
+    let normalized = trimmed.replace("\\\\", "\\").replace('\\', "/");
+    let lower = normalized.to_ascii_lowercase();
+    lower.starts_with("//?/c:/") || lower.starts_with("//?/unc/") || lower.starts_with("//")
 }
 
 fn is_path_like(value: &str) -> bool {
@@ -1079,9 +1120,15 @@ mod tests {
         assert!(!sanitized.contains("Alice"));
         assert!(!sanitized.contains("AppData"));
         assert!(!sanitized.contains("Command ["));
-        assert!(sanitized.contains("stage=llama_cpp_gpu_probe"));
+        assert!(sanitized.contains("stage=subprocess_command"));
         assert!(sanitized.contains("category=worker_timeout"));
         assert!(sanitized.contains("timeout_seconds=30"));
+
+        let custom_timeout = sanitize_operator_diagnostic_line(
+            r#"TimeoutExpired: Command ['C:\Users\Alice\python.exe'] timed out after 45 seconds"#,
+        );
+        assert!(custom_timeout.contains("timeout_seconds=45"));
+        assert!(!custom_timeout.contains("Alice"));
 
         let json = sanitize_operator_diagnostic_line(
             r#"{"path":"C:\\Users\\Alice\\AppData\\Local\\Programs\\Python\\Python311\\python.exe","stage":"llama_cpp_gpu_probe"}"#,
@@ -1090,5 +1137,14 @@ mod tests {
         assert_eq!(parsed["path"], "<path:python.exe>");
         assert!(!json.contains("Alice"));
         assert!(!json.contains("AppData"));
+
+        let drive = sanitize_operator_diagnostic_line(
+            r#"python=C:\Users\Alice\AppData\Local\Programs\Python\Python311\python.exe"#,
+        );
+        assert_eq!(drive, "python=<path:python.exe>");
+        let extended = sanitize_operator_diagnostic_line(
+            r#"\\?\C:\Users\Alice\AppData\Local\Programs\Python\Python311\python.exe"#,
+        );
+        assert_eq!(extended, "<path:python.exe>");
     }
 }

--- a/tests/unit/test_compute_node_runtime.py
+++ b/tests/unit/test_compute_node_runtime.py
@@ -23,6 +23,7 @@ from utils.compute_node_runtime import (
     _completion_smoke_reason_from_api_v1_error,
     _readiness_smoke_model_id,
     _safe_completion_smoke_worker_diagnostics,
+    _qwen_64k_readiness_profile_recoverable,
 )
 
 
@@ -3175,3 +3176,14 @@ def test_qwen_64k_profile_recovery_three_profile_exhaustion_fails_closed():
     assert model_manager.get_llm_instance.call_count == 3
     assert model_manager._qwen_64k_first_readiness_failure_category == "backend_graph_compute_failure"
     assert model_manager._qwen_64k_profile_recovery_count == 3
+
+
+def test_completion_smoke_cuda_oom_classification_is_qwen64k_recoverable():
+    category, reason, diagnostics = _classify_completion_smoke_exception(
+        RuntimeError('CUDA out of memory in cudaMalloc during completion smoke')
+    )
+
+    assert category == 'runtime_context_create_cuda_memory'
+    assert reason == 'runtime_completion_smoke_cuda_memory_allocation'
+    assert _qwen_64k_readiness_profile_recoverable(category) is True
+    assert diagnostics['exception_type'] == 'RuntimeError'

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -2109,3 +2109,26 @@ def test_probe_result_payload_preserves_native_capability_types():
     assert encoded['q4_kv_cache_type_value'] == 2
     assert encoded['f16_kv_cache_type_value'] == 1
     assert encoded['capability_source'] == 'desktop_runtime_setup_probe'
+
+
+def test_runtime_probe_payload_filters_unknown_constructor_kwarg_support(monkeypatch, tmp_path):
+    payload = {
+        'backend': 'cuda',
+        'gpu_offload_supported': True,
+        'detected_device': 'cuda',
+        'constructor_kwarg_support': {
+            'rope_scaling_type': True,
+            'unexpected_future_kwarg': True,
+        },
+    }
+
+    class Result:
+        returncode = 0
+        stdout = json.dumps(payload)
+        stderr = ''
+
+    monkeypatch.setattr(desktop_runtime_setup.subprocess, 'run', lambda *_, **__: Result())
+
+    probe = desktop_runtime_setup._probe_llama_runtime(runtime_root=tmp_path)
+
+    assert probe.constructor_kwarg_support == {'rope_scaling_type': True}

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -2069,3 +2069,43 @@ def test_qwen_64k_probe_only_fallback_reason_keeps_yarn_context(monkeypatch, tmp
 
     assert result['runtime_action'] == 'probe_only'
     assert 'Qwen 64K requires YaRN/RoPE support' in result['fallback_reason']
+
+
+def test_probe_result_payload_preserves_native_capability_types():
+    support = {name: True for name in desktop_runtime_setup.LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS}
+    probe = desktop_runtime_setup.RuntimeProbe(
+        backend='cuda',
+        gpu_offload_supported=True,
+        detected_device='cuda',
+        interpreter=sys.executable,
+        prefix=sys.prefix,
+        llama_module_path='C:/Python/Lib/site-packages/llama_cpp/__init__.py',
+        llama_cpp_python_version='0.3.32',
+        yarn_rope_supported=True,
+        yarn_resolver_source='numeric_fallback',
+        rope_scaling_type_supported=True,
+        yarn_ext_factor_supported=True,
+        rope_freq_scale_supported=True,
+        yarn_orig_ctx_supported=True,
+        constructor_kwarg_support=support,
+        constructor_has_var_kwargs=False,
+        constructor_signature_inspectable=True,
+        qwen_64k_yarn_support='supported',
+        yarn_enum_value=2,
+        q8_kv_cache_type_value=8,
+        q4_kv_cache_type_value=2,
+        f16_kv_cache_type_value=1,
+    )
+
+    payload = desktop_runtime_setup._probe_result_payload(probe)
+    encoded = json.loads(json.dumps(payload))
+
+    assert encoded['gpu_offload_supported'] is True
+    assert encoded['constructor_kwarg_support'] == support
+    assert encoded['constructor_signature_inspectable'] is True
+    assert encoded['qwen_64k_yarn_support'] == 'supported'
+    assert encoded['yarn_enum_value'] == 2
+    assert encoded['q8_kv_cache_type_value'] == 8
+    assert encoded['q4_kv_cache_type_value'] == 2
+    assert encoded['f16_kv_cache_type_value'] == 1
+    assert encoded['capability_source'] == 'desktop_runtime_setup_probe'

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -8727,7 +8727,7 @@ def test_desktop_probe_module_path_mismatch_fails_closed_without_reprobe(monkeyp
     assert diagnostics['child_probe_reprobe_attempted'] is False
 
 
-def test_legacy_flat_desktop_probe_synthesizes_mandated_yarn_bridge(monkeypatch):
+def test_legacy_flat_desktop_probe_reprobes_for_actual_yarn_enum(monkeypatch):
     from utils.llm import model_manager as model_manager_module
 
     support = {
@@ -8748,7 +8748,7 @@ def test_legacy_flat_desktop_probe_synthesizes_mandated_yarn_bridge(monkeypatch)
     )
     capabilities = model_manager_module._safe_constructor_capability_payload(facade)
     assert capabilities['capability_source'] == 'desktop_runtime_setup_probe_legacy'
-    assert capabilities['yarn_enum_value'] == 2
+    assert 'yarn_enum_value' not in capabilities
     assert capabilities['qwen_64k_yarn_support'] == 'supported'
     assert capabilities['constructor_signature_inspectable'] is True
 
@@ -8773,7 +8773,8 @@ def test_legacy_flat_desktop_probe_synthesizes_mandated_yarn_bridge(monkeypatch)
 
     diagnostics = model_manager_module._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
 
-    assert not probe_calls
+    assert probe_calls
     assert diagnostics['supported'] is True
-    assert diagnostics['yarn_enum_value'] == 2
-    assert diagnostics['capability_source'] == 'desktop_runtime_setup_probe_legacy'
+    assert diagnostics['yarn_enum_value'] == 7
+    assert diagnostics['capability_source'] == 'worker_probe'
+    assert diagnostics['child_probe_reprobe_attempted'] is True

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -6032,6 +6032,41 @@ def test_subprocess_worker_error_summary_keeps_safe_category_hint():
     assert summary == 'RuntimeError:metal_memory_allocation'
 
 
+@pytest.mark.parametrize(
+    'message',
+    [
+        'CUDA error: out of memory',
+        'cudaMalloc failed',
+        'CUBLAS_STATUS_ALLOC_FAILED',
+        'ggml_cuda: failed to allocate device buffer',
+    ],
+)
+def test_subprocess_worker_cuda_oom_classification_uses_safe_category(message):
+    from utils.llm import model_manager as model_manager_module
+
+    namespace = {}
+    worker_code = model_manager_module._LLAMA_CPP_RUNTIME_WORKER_CODE
+    exec(worker_code.split('def _metadata_value', 1)[0], namespace)
+
+    exc = RuntimeError(message)
+
+    assert namespace['_classify_generation_exception'](exc) == 'cuda_memory_allocation'
+    assert namespace['_sanitize_error_summary'](exc).endswith(':cuda_memory_allocation')
+
+
+def test_subprocess_worker_generic_cuda_text_is_not_allocation_failure():
+    from utils.llm import model_manager as model_manager_module
+
+    namespace = {}
+    worker_code = model_manager_module._LLAMA_CPP_RUNTIME_WORKER_CODE
+    exec(worker_code.split('def _metadata_value', 1)[0], namespace)
+
+    exc = RuntimeError('CUDA backend initialized')
+
+    assert namespace['_classify_generation_exception'](exc) != 'cuda_memory_allocation'
+    assert namespace['_sanitize_error_summary'](exc) != 'RuntimeError:cuda_memory_allocation'
+
+
 def test_subprocess_worker_plain_completion_helpers_cover_safe_shapes():
     from utils.llm import model_manager as model_manager_module
 
@@ -8799,3 +8834,43 @@ def test_legacy_flat_desktop_probe_uses_mandated_yarn_bridge_without_reprobe(mon
     assert 'n_batch' not in kwargs
     assert 'n_ubatch' not in kwargs
     assert manager.last_yarn_rope_diagnostics['child_probe_reprobe_attempted'] is False
+
+
+@pytest.mark.parametrize('resolver_source', ['top_level_enum', 'nested_enum', 'llama_class_enum', 'arbitrary'])
+def test_legacy_flat_desktop_probe_exported_enum_without_value_fails_closed(monkeypatch, resolver_source):
+    from utils.llm import model_manager as model_manager_module
+
+    module_path = '/site/llama_cpp/__init__.py'
+    flat_payload = {
+        'backend': 'cuda',
+        'gpu_offload_supported': 'true',
+        'runtime_action': 'already_supported',
+        'llama_module_path': module_path,
+        'yarn_rope_supported': 'true',
+        'yarn_resolver_source': resolver_source,
+        'rope_scaling_type_supported': 'true',
+        'rope_freq_scale_supported': 'true',
+        'yarn_orig_ctx_supported': 'true',
+    }
+    facade = model_manager_module._SubprocessLlamaCppModule(
+        module_path,
+        desktop_runtime_probe=flat_payload,
+    )
+    capabilities = model_manager_module._safe_constructor_capability_payload(facade)
+
+    assert capabilities['capability_source'] == 'desktop_runtime_setup_probe_legacy'
+    assert capabilities.get('yarn_enum_value') is None
+    assert capabilities.get('qwen_64k_yarn_support') != 'supported'
+
+    def fail_child_probe(**_kwargs):
+        raise AssertionError('incomplete legacy desktop probe must fail closed without child reprobe')
+
+    monkeypatch.setattr(model_manager_module, '_probe_llama_cpp_capabilities_in_subprocess', fail_child_probe)
+
+    diagnostics = model_manager_module._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
+
+    assert diagnostics['supported'] is False
+    assert diagnostics['missing_reason'] == 'runtime_desktop_capability_probe_incomplete'
+    assert 'yarn_enum_value' in diagnostics['missing_required_kwargs']
+    assert diagnostics['child_probe_reprobe_attempted'] is False
+    assert diagnostics['child_probe_reprobe_skipped_reason'] == 'desktop_probe_incomplete_fail_closed'

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -8694,3 +8694,53 @@ def test_complete_cuda_desktop_probe_is_authoritative_without_reprobe(monkeypatc
     assert profiles[0]['kwargs']['offload_kqv'] is True
     assert profiles[0]['kwargs']['n_batch'] == 256
     assert profiles[0]['kwargs']['n_ubatch'] == 128
+
+
+def test_legacy_flat_desktop_probe_reprobes_instead_of_inventing_yarn_enum(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    support = {
+        'rope_scaling_type': True,
+        'rope_freq_scale': True,
+        'yarn_orig_ctx': True,
+    }
+    facade = model_manager_module._SubprocessLlamaCppModule(
+        '/site/llama_cpp/__init__.py',
+        desktop_runtime_probe={
+            'backend': 'cuda',
+            'gpu_offload_supported': True,
+            'llama_module_path': '/site/llama_cpp/__init__.py',
+            'yarn_rope_supported': True,
+            'yarn_resolver_source': 'numeric_fallback',
+            'constructor_kwarg_support': support,
+        },
+    )
+    capabilities = model_manager_module._safe_constructor_capability_payload(facade)
+    assert capabilities['capability_source'] == 'desktop_runtime_setup_probe_legacy'
+    assert 'yarn_enum_value' not in capabilities
+
+    probe_calls = []
+
+    def fake_child_probe(**kwargs):
+        probe_calls.append(kwargs)
+        return {
+            'backend': 'cuda',
+            'gpu_offload_supported': True,
+            'llama_module_path': '/real/site/llama_cpp/__init__.py',
+            'constructor_kwarg_support': support,
+            'constructor_signature_inspectable': True,
+            'constructor_has_var_kwargs': False,
+            'qwen_64k_yarn_support': 'supported',
+            'yarn_resolver_source': 'top_level_enum',
+            'yarn_enum_value': 7,
+            'capability_source': 'worker_probe',
+        }
+
+    monkeypatch.setattr(model_manager_module, '_probe_llama_cpp_capabilities_in_subprocess', fake_child_probe)
+
+    diagnostics = model_manager_module._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
+
+    assert probe_calls
+    assert diagnostics['supported'] is True
+    assert diagnostics['yarn_enum_value'] == 7
+    assert diagnostics['capability_source'] == 'worker_probe'

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -8632,3 +8632,65 @@ def test_qwen_64k_recovery_exhaustion_and_lifecycle_edge_coverage(monkeypatch):
             raise RuntimeError("poll failed")
 
     assert manager._worker_exit_code(SimpleNamespace(_process=BadProcess())) is None
+
+
+def test_desktop_runtime_probe_strict_bool_coercion_rejects_truthy_strings():
+    from utils.llm import model_manager as model_manager_module
+
+    assert model_manager_module._coerce_strict_bool(False) is False
+    assert model_manager_module._coerce_strict_bool(0) is False
+    assert model_manager_module._coerce_strict_bool('false') is False
+    assert model_manager_module._coerce_strict_bool(True) is True
+    assert model_manager_module._coerce_strict_bool(1) is True
+    assert model_manager_module._coerce_strict_bool('true') is True
+    assert model_manager_module._coerce_strict_bool('yes') is None
+
+
+def test_complete_cuda_desktop_probe_is_authoritative_without_reprobe(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    support = {name: True for name in model_manager_module.LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS}
+    facade = model_manager_module._SubprocessLlamaCppModule(
+        'C:/Users/Alice/AppData/Local/Programs/Python/Python311/Lib/site-packages/llama_cpp/__init__.py',
+        desktop_runtime_probe={
+            'backend': 'cuda',
+            'gpu_offload_supported': True,
+            'runtime_action': 'already_supported',
+            'llama_module_path': 'C:/redacted/llama_cpp/__init__.py',
+            'constructor_kwarg_support': support,
+            'constructor_signature_inspectable': True,
+            'constructor_has_var_kwargs': False,
+            'qwen_64k_yarn_support': 'supported',
+            'yarn_enum_value': 2,
+            'q8_kv_cache_type_value': 8,
+            'q4_kv_cache_type_value': 2,
+            'f16_kv_cache_type_value': 1,
+            'capability_source': 'desktop_runtime_setup_probe',
+        },
+    )
+
+    def fail_probe(**_kwargs):
+        raise AssertionError('unexpected secondary probe')
+
+    monkeypatch.setattr(model_manager_module, '_probe_llama_cpp_capabilities_in_subprocess', fail_probe)
+    diagnostics = model_manager_module._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
+    profiles = model_manager_module._build_qwen_64k_runtime_profiles(
+        facade,
+        facade.Llama,
+        model_path=__file__,
+        n_ctx=65536,
+    )
+
+    assert diagnostics['supported'] is True
+    assert diagnostics['child_probe_reprobe_attempted'] is False
+    assert diagnostics['child_probe_reprobe_skipped_reason'] == 'desktop_probe_authoritative'
+    assert [profile['profile_id'] for profile in profiles] == [
+        model_manager_module.QWEN_64K_RUNTIME_PROFILE_DEFAULT,
+        model_manager_module.QWEN_64K_RUNTIME_PROFILE_Q8,
+        model_manager_module.QWEN_64K_RUNTIME_PROFILE_Q4,
+    ]
+    assert profiles[0]['diagnostics']['backend'] == 'cuda'
+    assert profiles[0]['kwargs']['flash_attn'] is True
+    assert profiles[0]['kwargs']['offload_kqv'] is True
+    assert profiles[0]['kwargs']['n_batch'] == 256
+    assert profiles[0]['kwargs']['n_ubatch'] == 128

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -8727,54 +8727,75 @@ def test_desktop_probe_module_path_mismatch_fails_closed_without_reprobe(monkeyp
     assert diagnostics['child_probe_reprobe_attempted'] is False
 
 
-def test_legacy_flat_desktop_probe_reprobes_for_actual_yarn_enum(monkeypatch):
+def test_legacy_flat_desktop_probe_uses_mandated_yarn_bridge_without_reprobe(monkeypatch, tmp_path):
+    from utils.context_profiles import apply_context_profile
     from utils.llm import model_manager as model_manager_module
 
-    support = {
-        'rope_scaling_type': True,
-        'rope_freq_scale': True,
-        'yarn_orig_ctx': True,
+    module_path = '/site/llama_cpp/__init__.py'
+    flat_payload = {
+        'backend': 'cuda',
+        'gpu_offload_supported': 'true',
+        'runtime_action': 'already_supported',
+        'llama_module_path': module_path,
+        'yarn_rope_supported': 'true',
+        'yarn_resolver_source': 'numeric_fallback',
+        'rope_scaling_type_supported': 'true',
+        'rope_freq_scale_supported': 'true',
+        'yarn_orig_ctx_supported': 'true',
     }
     facade = model_manager_module._SubprocessLlamaCppModule(
-        '/site/llama_cpp/__init__.py',
-        desktop_runtime_probe={
-            'backend': 'cuda',
-            'gpu_offload_supported': True,
-            'llama_module_path': '/site/llama_cpp/__init__.py',
-            'yarn_rope_supported': True,
-            'yarn_resolver_source': 'numeric_fallback',
-            'constructor_kwarg_support': support,
-        },
+        module_path,
+        desktop_runtime_probe=flat_payload,
     )
     capabilities = model_manager_module._safe_constructor_capability_payload(facade)
     assert capabilities['capability_source'] == 'desktop_runtime_setup_probe_legacy'
-    assert 'yarn_enum_value' not in capabilities
     assert capabilities['qwen_64k_yarn_support'] == 'supported'
+    assert capabilities['yarn_enum_value'] == 2
     assert capabilities['constructor_signature_inspectable'] is True
+    assert capabilities['constructor_kwarg_support']['rope_scaling_type'] is True
+    assert capabilities['constructor_kwarg_support']['rope_freq_scale'] is True
+    assert capabilities['constructor_kwarg_support']['yarn_orig_ctx'] is True
+    for unobserved in ('type_k', 'type_v', 'flash_attn', 'offload_kqv', 'n_batch', 'n_ubatch'):
+        assert unobserved not in capabilities['constructor_kwarg_support']
+        assert unobserved not in capabilities
 
-    probe_calls = []
+    def fail_child_probe(**_kwargs):
+        raise AssertionError('legacy desktop facade must not launch a child capability reprobe')
 
-    def fake_child_probe(**kwargs):
-        probe_calls.append(kwargs)
-        return {
-            'backend': 'cuda',
-            'gpu_offload_supported': True,
-            'llama_module_path': '/real/site/llama_cpp/__init__.py',
-            'constructor_kwarg_support': support,
-            'constructor_signature_inspectable': True,
-            'constructor_has_var_kwargs': False,
-            'qwen_64k_yarn_support': 'supported',
-            'yarn_resolver_source': 'top_level_enum',
-            'yarn_enum_value': 7,
-            'capability_source': 'worker_probe',
-        }
-
-    monkeypatch.setattr(model_manager_module, '_probe_llama_cpp_capabilities_in_subprocess', fake_child_probe)
+    monkeypatch.setattr(model_manager_module, '_probe_llama_cpp_capabilities_in_subprocess', fail_child_probe)
 
     diagnostics = model_manager_module._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
 
-    assert probe_calls
     assert diagnostics['supported'] is True
-    assert diagnostics['yarn_enum_value'] == 7
-    assert diagnostics['capability_source'] == 'worker_probe'
-    assert diagnostics['child_probe_reprobe_attempted'] is True
+    assert diagnostics['yarn_enum_value'] == 2
+    assert diagnostics['capability_source'] == 'desktop_runtime_setup_probe_legacy'
+    assert diagnostics['child_probe_reprobe_attempted'] is False
+    assert diagnostics['child_probe_reprobe_skipped_reason'] == 'desktop_probe_authoritative'
+
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': -1,
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    kwargs = manager._runtime_init_kwargs(facade.Llama, -1, facade)
+
+    assert kwargs['rope_scaling_type'] == 2
+    assert kwargs['rope_freq_scale'] == 0.5
+    assert kwargs['yarn_orig_ctx'] == 32768
+    assert 'type_k' not in kwargs
+    assert 'type_v' not in kwargs
+    assert 'flash_attn' not in kwargs
+    assert 'offload_kqv' not in kwargs
+    assert 'n_batch' not in kwargs
+    assert 'n_ubatch' not in kwargs
+    assert manager.last_yarn_rope_diagnostics['child_probe_reprobe_attempted'] is False

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -5806,7 +5806,7 @@ def test_qwen_64k_runtime_init_guard_rejects_supported_probe_without_yarn_value(
     )
 
 
-def test_desktop_runtime_probe_coerces_string_yarn_enum_value():
+def test_desktop_runtime_probe_rejects_string_yarn_enum_value():
     from utils.llm import model_manager as model_manager_module
 
     coerced = model_manager_module._coerce_desktop_runtime_probe({
@@ -5821,7 +5821,7 @@ def test_desktop_runtime_probe_coerces_string_yarn_enum_value():
         'yarn_enum_value': '2',
     })
 
-    assert coerced['yarn_enum_value'] == 2
+    assert 'yarn_enum_value' not in coerced
     assert coerced['llama_cpp_python_version'] == '0.3.32'
     assert coerced['constructor_has_var_kwargs'] is True
     assert coerced['constructor_signature_inspectable'] is False
@@ -8656,7 +8656,7 @@ def test_complete_cuda_desktop_probe_is_authoritative_without_reprobe(monkeypatc
             'backend': 'cuda',
             'gpu_offload_supported': True,
             'runtime_action': 'already_supported',
-            'llama_module_path': 'C:/redacted/llama_cpp/__init__.py',
+            'llama_module_path': 'C:/Users/Alice/AppData/Local/Programs/Python/Python311/Lib/site-packages/llama_cpp/__init__.py',
             'constructor_kwarg_support': support,
             'constructor_signature_inspectable': True,
             'constructor_has_var_kwargs': False,
@@ -8696,7 +8696,38 @@ def test_complete_cuda_desktop_probe_is_authoritative_without_reprobe(monkeypatc
     assert profiles[0]['kwargs']['n_ubatch'] == 128
 
 
-def test_legacy_flat_desktop_probe_reprobes_instead_of_inventing_yarn_enum(monkeypatch):
+def test_desktop_probe_module_path_mismatch_fails_closed_without_reprobe(monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    support = {name: True for name in model_manager_module.LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS}
+    facade = model_manager_module._SubprocessLlamaCppModule(
+        '/runtime/actual/llama_cpp/__init__.py',
+        desktop_runtime_probe={
+            'backend': 'cuda',
+            'gpu_offload_supported': True,
+            'llama_module_path': '/runtime/other/llama_cpp/__init__.py',
+            'constructor_kwarg_support': support,
+            'constructor_signature_inspectable': True,
+            'qwen_64k_yarn_support': 'supported',
+            'yarn_enum_value': 2,
+            'capability_source': 'desktop_runtime_setup_probe',
+        },
+    )
+
+    def fail_probe(**_kwargs):
+        raise AssertionError('unexpected secondary probe')
+
+    monkeypatch.setattr(model_manager_module, '_probe_llama_cpp_capabilities_in_subprocess', fail_probe)
+
+    diagnostics = model_manager_module._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
+
+    assert diagnostics['supported'] is False
+    assert diagnostics['missing_reason'] == 'runtime_desktop_capability_probe_incomplete'
+    assert 'llama_module_path' in diagnostics['missing_required_kwargs']
+    assert diagnostics['child_probe_reprobe_attempted'] is False
+
+
+def test_legacy_flat_desktop_probe_synthesizes_mandated_yarn_bridge(monkeypatch):
     from utils.llm import model_manager as model_manager_module
 
     support = {
@@ -8717,7 +8748,9 @@ def test_legacy_flat_desktop_probe_reprobes_instead_of_inventing_yarn_enum(monke
     )
     capabilities = model_manager_module._safe_constructor_capability_payload(facade)
     assert capabilities['capability_source'] == 'desktop_runtime_setup_probe_legacy'
-    assert 'yarn_enum_value' not in capabilities
+    assert capabilities['yarn_enum_value'] == 2
+    assert capabilities['qwen_64k_yarn_support'] == 'supported'
+    assert capabilities['constructor_signature_inspectable'] is True
 
     probe_calls = []
 
@@ -8740,7 +8773,7 @@ def test_legacy_flat_desktop_probe_reprobes_instead_of_inventing_yarn_enum(monke
 
     diagnostics = model_manager_module._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
 
-    assert probe_calls
+    assert not probe_calls
     assert diagnostics['supported'] is True
-    assert diagnostics['yarn_enum_value'] == 7
-    assert diagnostics['capability_source'] == 'worker_probe'
+    assert diagnostics['yarn_enum_value'] == 2
+    assert diagnostics['capability_source'] == 'desktop_runtime_setup_probe_legacy'

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -832,7 +832,7 @@ class ComputeNodeRuntime:
                     llm_runtime = get_llm_instance()
             except Exception as exc:
                 setattr(self.model_manager, 'last_runtime_init_error', str(exc))
-                _log_error("Failed to initialize API v1 runtime for compute node", exc_info=True)
+                _log_error(f"Failed to initialize API v1 runtime for compute node: {type(exc).__name__}", exc_info=False)
                 return False
 
             if llm_runtime is None:
@@ -963,6 +963,13 @@ class ComputeNodeRuntime:
                 "api_v1_readiness_kv_cache_mode": diagnostics.get("kv_cache_mode"),
                 "api_v1_readiness_llama_cpp_python_version": yarn_diagnostics.get("llama_cpp_python_version"),
                 "api_v1_readiness_backend_used": diagnostics.get("backend_used"),
+                "llama_cpp_capability_source": yarn_diagnostics.get("capability_source"),
+                "llama_cpp_desktop_probe_authoritative": yarn_diagnostics.get("desktop_probe_authoritative"),
+                "llama_cpp_child_capability_reprobe_attempted": yarn_diagnostics.get("child_probe_reprobe_attempted"),
+                "llama_cpp_child_capability_reprobe_skipped_reason": yarn_diagnostics.get("child_probe_reprobe_skipped_reason"),
+                "llama_cpp_constructor_signature_inspectable": yarn_diagnostics.get("constructor_signature_inspectable"),
+                "llama_cpp_qwen_64k_yarn_support": yarn_diagnostics.get("support_classification"),
+                "llama_cpp_runtime_profile_backend": diagnostics.get("llama_cpp_runtime_profile_backend"),
             })
             for _key in (
                 "qwen_64k_runtime_profile_id",
@@ -1541,5 +1548,5 @@ class ComputeNodeRuntime:
         except Exception:
             _log_warning(
                 "Relay unregister request raised during shutdown; continuing stop",
-                exc_info=True,
+                exc_info=False,
             )

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -48,6 +48,9 @@ def _log_warning(message: str, *, exc_info: bool = False) -> None:
 
 _COMPLETION_SMOKE_REASON_BY_CATEGORY = {
     "metal_memory_allocation": "runtime_completion_smoke_metal_memory_allocation",
+    "cuda_memory_allocation": "runtime_completion_smoke_cuda_memory_allocation",
+    "runtime_context_create_cuda_memory": "runtime_completion_smoke_cuda_memory_allocation",
+    "runtime_context_create_cuda_buffer_limit": "runtime_completion_smoke_cuda_buffer_limit",
     "kv_cache_allocation": "runtime_completion_smoke_kv_cache_allocation",
     "rope_yarn_eval_failure": "runtime_completion_smoke_rope_yarn_eval_failure",
     "unsupported_render_kwarg": "runtime_completion_smoke_render_template_unexpected_kwarg",
@@ -370,6 +373,8 @@ def _classify_completion_smoke_exception(exc: BaseException) -> Tuple[str, str, 
         category = "worker_dead"
     elif "metal" in text and any(token in text for token in ("alloc", "memory", "out of memory", "oom")):
         category = "metal_memory_allocation"
+    elif "cuda" in text and any(token in text for token in ("alloc", "memory", "out of memory", "oom", "cudamalloc", "cublas")):
+        category = "cuda_memory_allocation"
     elif "kv" in text and any(token in text for token in ("alloc", "cache", "memory", "out of memory", "oom")):
         category = "kv_cache_allocation"
     elif "yarn" in text or ("rope" in text and any(token in text for token in ("eval", "scal", "freq"))):
@@ -978,6 +983,7 @@ class ComputeNodeRuntime:
                 "qwen_64k_first_readiness_failure_backend_state_sticky",
                 "qwen_64k_first_readiness_failure_backend_recreation_required",
                 "qwen_64k_first_readiness_failure_metal_command_buffer_status",
+                "qwen_64k_first_readiness_failure_cuda_error_category",
                 "qwen_64k_first_readiness_failure_eval_return_code",
             ):
                 if _key in diagnostics:

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -179,6 +179,7 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
     },
     "generation_exception_category": {
         "metal_memory_allocation",
+        "cuda_memory_allocation",
         "kv_cache_allocation",
         "rope_yarn_eval_failure",
         "unsupported_generation_kwarg",
@@ -257,7 +258,7 @@ _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
 _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_.:/@+-]{1,128}$")
 _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_CLASS_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]{0,127}$")
 _SAFE_COMPLETION_SMOKE_WORKER_DIAGNOSTIC_REDACTED_SUMMARY_RE = re.compile(
-    r"^[A-Za-z_][A-Za-z0-9_.]{0,127}:(?:redacted|metal_memory_allocation|kv_cache_allocation|"
+    r"^[A-Za-z_][A-Za-z0-9_.]{0,127}:(?:redacted|metal_memory_allocation|cuda_memory_allocation|kv_cache_allocation|"
     r"rope_yarn_eval_failure|unsupported_kwarg|prompt_tokenization_failure|prompt_eval_failure|"
     r"prompt_eval_decode_failure|prompt_eval_backend_failure|prompt_eval_invalid_token_failure|"
     r"prompt_eval_state_failure|prompt_eval_context_failure|sampling_failure)$"

--- a/utils/compute_node_runtime.py
+++ b/utils/compute_node_runtime.py
@@ -374,7 +374,7 @@ def _classify_completion_smoke_exception(exc: BaseException) -> Tuple[str, str, 
     elif "metal" in text and any(token in text for token in ("alloc", "memory", "out of memory", "oom")):
         category = "metal_memory_allocation"
     elif "cuda" in text and any(token in text for token in ("alloc", "memory", "out of memory", "oom", "cudamalloc", "cublas")):
-        category = "cuda_memory_allocation"
+        category = "runtime_context_create_cuda_memory"
     elif "kv" in text and any(token in text for token in ("alloc", "cache", "memory", "out of memory", "oom")):
         category = "kv_cache_allocation"
     elif "yarn" in text or ("rope" in text and any(token in text for token in ("eval", "scal", "freq"))):

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -535,6 +535,7 @@ def safe_plain_completion_decode_failure_category_and_code(exc: Any) -> Tuple[Op
 _FATAL_CURRENT_WORKER_GENERATION_CATEGORIES = {
     'backend_allocation_failure',
     'backend_graph_compute_failure',
+    'cuda_memory_allocation',
     'metal_graph_compute_failure',
     'kv_slot_unavailable',
     'decode_aborted',
@@ -563,6 +564,7 @@ _QWEN_64K_PROFILE_RECOVERABLE_FAILURE_CATEGORIES = {
     'unknown_metal_backend_failure',
     'runtime_context_create_cuda_memory',
     'runtime_context_create_cuda_buffer_limit',
+    'cuda_memory_allocation',
 }
 
 
@@ -2097,8 +2099,23 @@ def _extract_unsupported_generation_kwarg(message, attempted=None):
 
 def _sanitize_error_summary(message):
     text = str(message or '').lower()
+    cuda_allocation_markers = (
+        'cuda out of memory',
+        'cuda error: out of memory',
+        'cudamalloc',
+        'cuda malloc',
+        'cublas_status_alloc_failed',
+        'cublas alloc',
+    )
+    cuda_generic_allocation_markers = ('allocation failed', 'failed to allocate')
     if 'metal' in text and any(term in text for term in ('alloc', 'memory', 'out of memory', 'oom')):
         return type(message).__name__ + ':metal_memory_allocation'
+    if (
+        any(marker in text for marker in cuda_allocation_markers)
+        or ('cuda' in text and any(marker in text for marker in cuda_generic_allocation_markers))
+        or ('ggml_cuda' in text and any(term in text for term in ('alloc', 'memory', 'oom')))
+    ):
+        return type(message).__name__ + ':cuda_memory_allocation'
     if 'kv' in text and any(term in text for term in ('alloc', 'cache', 'memory', 'out of memory', 'oom')):
         return type(message).__name__ + ':kv_cache_allocation'
     if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'eval'))):
@@ -2145,8 +2162,23 @@ def _classify_generation_exception(exc):
     if decode_category is not None:
         return decode_category
     text = str(exc or '').lower()
+    cuda_allocation_markers = (
+        'cuda out of memory',
+        'cuda error: out of memory',
+        'cudamalloc',
+        'cuda malloc',
+        'cublas_status_alloc_failed',
+        'cublas alloc',
+    )
+    cuda_generic_allocation_markers = ('allocation failed', 'failed to allocate')
     if 'metal' in text and any(term in text for term in ('alloc', 'memory', 'out of memory', 'oom')):
         return 'metal_memory_allocation'
+    if (
+        any(marker in text for marker in cuda_allocation_markers)
+        or ('cuda' in text and any(marker in text for marker in cuda_generic_allocation_markers))
+        or ('ggml_cuda' in text and any(term in text for term in ('alloc', 'memory', 'oom')))
+    ):
+        return 'cuda_memory_allocation'
     if 'kv' in text and any(term in text for term in ('alloc', 'cache', 'memory', 'out of memory', 'oom')):
         return 'kv_cache_allocation'
     if 'yarn' in text or ('rope' in text and any(term in text for term in ('scal', 'freq', 'eval'))):
@@ -3131,6 +3163,7 @@ for line in sys.stdin:
             fatal_plain_completion_categories = {
                 'backend_allocation_failure',
                 'backend_graph_compute_failure',
+                'cuda_memory_allocation',
                 'metal_graph_compute_failure',
                 'kv_slot_unavailable',
                 'decode_aborted',
@@ -3185,6 +3218,9 @@ for line in sys.stdin:
                         plain_capabilities['plain_completion_backend_state_sticky'] = True
                         plain_capabilities['plain_completion_backend_recreation_required'] = True
                     if category == 'backend_allocation_failure':
+                        plain_capabilities['plain_completion_backend_recreation_required'] = True
+                    if category == 'cuda_memory_allocation':
+                        plain_capabilities['plain_completion_backend_failure_category'] = 'cuda_memory_allocation'
                         plain_capabilities['plain_completion_backend_recreation_required'] = True
                     if category not in fatal_plain_completion_categories and _reset_plain_completion_state(llama):
                         plain_capabilities['plain_completion_reset_after_failure_count'] += 1
@@ -3827,22 +3863,34 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
         coerced['capability_source'] = source
 
     # Compatibility bridge for deployed flat desktop probes. Do not invent
-    # unobserved performance/KV kwargs. The pinned llama-cpp-python==0.3.32
-    # path has a verified numeric YaRN enum value of 2; launching another
-    # native import here would recreate the Windows timeout failure this
-    # desktop facade is designed to avoid.
+    # unobserved performance/KV kwargs or assume exported enum sources map to
+    # value 2. Only the old probe's explicit verified numeric-fallback path is
+    # accepted here; launching another native import would recreate the Windows
+    # timeout failure this desktop facade is designed to avoid.
     legacy_yarn = _coerce_strict_bool(probe.get('yarn_rope_supported'))
     required_supported = all(support.get(name) is True for name in ('rope_scaling_type', 'rope_freq_scale', 'yarn_orig_ctx'))
+    legacy_resolver = str(probe.get('yarn_resolver_source') or '').strip().lower()
     if (
         coerced.get('qwen_64k_yarn_support') is None
+        and coerced.get('yarn_enum_value') is None
         and legacy_yarn is True
         and required_supported
-        and str(probe.get('yarn_resolver_source') or '').lower() != 'unsupported'
+        and legacy_resolver == 'numeric_fallback'
+        and probe.get('yarn_enum_value') is None
     ):
         coerced['qwen_64k_yarn_support'] = 'supported'
         coerced['yarn_enum_value'] = 2
-        coerced['yarn_resolver_source'] = str(probe.get('yarn_resolver_source') or 'legacy_numeric_yarn')
+        coerced['yarn_resolver_source'] = 'numeric_fallback'
         coerced['constructor_signature_inspectable'] = True
+        coerced['capability_source'] = 'desktop_runtime_setup_probe_legacy'
+    elif (
+        coerced.get('capability_source') is None
+        and (
+            legacy_yarn is not None
+            or probe.get('yarn_resolver_source') is not None
+            or any(probe.get(f'{name}_supported') is not None for name in ('rope_scaling_type', 'rope_freq_scale', 'yarn_orig_ctx'))
+        )
+    ):
         coerced['capability_source'] = 'desktop_runtime_setup_probe_legacy'
     return coerced
 

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -138,11 +138,14 @@ def _safe_constructor_capability_payload(llama_cpp_module: Any) -> Dict[str, Any
     payload: Dict[str, Any] = {}
     support = capabilities.get('constructor_kwarg_support')
     if isinstance(support, dict):
-        payload['constructor_kwarg_support'] = {
-            str(name): bool(value)
-            for name, value in support.items()
-            if isinstance(name, str) and name in LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS
-        }
+        payload_support: Dict[str, bool] = {}
+        for name, value in support.items():
+            if not isinstance(name, str) or name not in LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS:
+                continue
+            coerced = _coerce_strict_bool(value)
+            if coerced is not None:
+                payload_support[name] = coerced
+        payload['constructor_kwarg_support'] = payload_support
     for key in ('q8_kv_cache_type_value', 'q4_kv_cache_type_value', 'f16_kv_cache_type_value'):
         value = capabilities.get(key)
         if isinstance(value, int) and not isinstance(value, bool):
@@ -771,16 +774,26 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
         required = ('rope_scaling_type', 'rope_freq_scale', 'yarn_orig_ctx')
         required_supported = isinstance(kwarg_support, dict) and all(kwarg_support.get(name) is True for name in required)
         authoritative_backend = str(capabilities.get('backend') or '').lower() in {'cuda', 'metal'}
+        capability_module_path = capabilities.get('llama_module_path')
+        facade_module_path = getattr(llama_cpp_module, '__file__', None)
+        module_paths_match = (
+            bool(capability_module_path)
+            and bool(facade_module_path)
+            and _canonical_path_for_compare(capability_module_path)
+            == _canonical_path_for_compare(facade_module_path)
+        )
         authoritative = (
-            source == 'desktop_runtime_setup_probe'
+            source in {'desktop_runtime_setup_probe', 'desktop_runtime_setup_probe_legacy'}
             and authoritative_backend
             and capabilities.get('gpu_offload_supported') is True
-            and bool(capabilities.get('llama_module_path') or getattr(llama_cpp_module, '__file__', None))
+            and module_paths_match
         )
         complete = (
             capabilities.get('qwen_64k_yarn_support') == 'supported'
             and required_supported
             and capabilities.get('yarn_enum_value') is not None
+            and capabilities.get('constructor_signature_inspectable') is True
+            and module_paths_match
         )
         if authoritative and complete:
             diagnostics = _qwen_64k_rope_support_diagnostics(llama_cpp_module, llama_cls)
@@ -788,7 +801,7 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
             diagnostics['child_probe_reprobe_skipped_reason'] = 'desktop_probe_authoritative'
             diagnostics['desktop_probe_authoritative'] = True
             return diagnostics
-        if source == 'desktop_runtime_setup_probe' and not complete:
+        if source in {'desktop_runtime_setup_probe', 'desktop_runtime_setup_probe_legacy'} and not complete:
             missing = []
             if capabilities.get('qwen_64k_yarn_support') != 'supported':
                 missing.append('qwen_64k_yarn_support')
@@ -796,6 +809,14 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
                 missing.extend([name for name in required if not (isinstance(kwarg_support, dict) and kwarg_support.get(name) is True)])
             if capabilities.get('yarn_enum_value') is None:
                 missing.append('yarn_enum_value')
+            if capabilities.get('constructor_signature_inspectable') is not True:
+                missing.append('constructor_signature_inspectable')
+            if not module_paths_match:
+                missing.append('llama_module_path')
+            if not authoritative_backend:
+                missing.append('backend')
+            if capabilities.get('gpu_offload_supported') is not True:
+                missing.append('gpu_offload_supported')
             diagnostics = _qwen_64k_rope_support_diagnostics(llama_cpp_module, llama_cls)
             diagnostics.update({
                 'supported': False,
@@ -3777,8 +3798,13 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
     if support:
         coerced['constructor_kwarg_support'] = support
 
+    def _coerce_bounded_schema_int(value: Any) -> Optional[int]:
+        if isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= 2**31 - 1:
+            return value
+        return None
+
     for field in ('q8_kv_cache_type_value', 'q4_kv_cache_type_value', 'f16_kv_cache_type_value'):
-        value = _coerce_optional_int_enum(probe.get(field))
+        value = _coerce_bounded_schema_int(probe.get(field))
         if value is not None and 0 <= value <= 2**31 - 1:
             coerced[field] = value
     if probe.get('llama_cpp_python_version'):
@@ -3792,7 +3818,7 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
         coerced['qwen_64k_yarn_support'] = str(yarn_support)
     if probe.get('yarn_resolver_source'):
         coerced['yarn_resolver_source'] = str(probe.get('yarn_resolver_source'))
-    yarn_enum_value = _coerce_optional_int_enum(probe.get('yarn_enum_value'))
+    yarn_enum_value = _coerce_bounded_schema_int(probe.get('yarn_enum_value'))
     if yarn_enum_value is not None and 0 <= yarn_enum_value <= 2**31 - 1:
         coerced['yarn_enum_value'] = yarn_enum_value
 
@@ -3811,6 +3837,8 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
         and str(probe.get('yarn_resolver_source') or '').lower() != 'unsupported'
     ):
         coerced['qwen_64k_yarn_support'] = 'supported'
+        coerced['yarn_enum_value'] = LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK
+        coerced['yarn_resolver_source'] = 'numeric_fallback'
         coerced['constructor_signature_inspectable'] = True
         coerced['capability_source'] = 'desktop_runtime_setup_probe_legacy'
     return coerced

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -199,9 +199,13 @@ def _resolve_yarn_rope_scaling_type(llama_cpp_module: Any, llama_cls: Any = None
             return value, source
 
     worker_capabilities = _safe_constructor_capability_payload(llama_cpp_module)
-    if worker_capabilities.get('yarn_resolver_source') == 'numeric_fallback':
+    worker_yarn_value = worker_capabilities.get('yarn_enum_value')
+    worker_yarn_source = worker_capabilities.get('yarn_resolver_source')
+    if worker_yarn_value is not None and worker_yarn_source in {'top_level_enum', 'nested_enum', 'llama_class_enum', 'numeric_fallback'}:
+        return worker_yarn_value, str(worker_yarn_source)
+    if worker_yarn_source == 'numeric_fallback':
         return (
-            worker_capabilities.get('yarn_enum_value', LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK),
+            LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK,
             'numeric_fallback',
         )
     worker_kwarg_support = worker_capabilities.get('constructor_kwarg_support')
@@ -768,7 +772,7 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
         required_supported = isinstance(kwarg_support, dict) and all(kwarg_support.get(name) is True for name in required)
         authoritative_backend = str(capabilities.get('backend') or '').lower() in {'cuda', 'metal'}
         authoritative = (
-            source in {'desktop_runtime_setup_probe', 'desktop_runtime_setup_probe_legacy'}
+            source == 'desktop_runtime_setup_probe'
             and authoritative_backend
             and capabilities.get('gpu_offload_supported') is True
             and bool(capabilities.get('llama_module_path') or getattr(llama_cpp_module, '__file__', None))
@@ -3807,7 +3811,6 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
         and str(probe.get('yarn_resolver_source') or '').lower() != 'unsupported'
     ):
         coerced['qwen_64k_yarn_support'] = 'supported'
-        coerced['yarn_enum_value'] = 2
         coerced['constructor_signature_inspectable'] = True
         coerced['capability_source'] = 'desktop_runtime_setup_probe_legacy'
     return coerced

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -783,7 +783,7 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
             == _canonical_path_for_compare(facade_module_path)
         )
         authoritative = (
-            source in {'desktop_runtime_setup_probe', 'desktop_runtime_setup_probe_legacy'}
+            source == 'desktop_runtime_setup_probe'
             and authoritative_backend
             and capabilities.get('gpu_offload_supported') is True
             and module_paths_match
@@ -801,7 +801,7 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
             diagnostics['child_probe_reprobe_skipped_reason'] = 'desktop_probe_authoritative'
             diagnostics['desktop_probe_authoritative'] = True
             return diagnostics
-        if source in {'desktop_runtime_setup_probe', 'desktop_runtime_setup_probe_legacy'} and not complete:
+        if source == 'desktop_runtime_setup_probe' and not complete:
             missing = []
             if capabilities.get('qwen_64k_yarn_support') != 'supported':
                 missing.append('qwen_64k_yarn_support')
@@ -3837,8 +3837,7 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
         and str(probe.get('yarn_resolver_source') or '').lower() != 'unsupported'
     ):
         coerced['qwen_64k_yarn_support'] = 'supported'
-        coerced['yarn_enum_value'] = LLAMA_ROPE_SCALING_TYPE_YARN_NUMERIC_FALLBACK
-        coerced['yarn_resolver_source'] = 'numeric_fallback'
+        coerced['yarn_resolver_source'] = 'legacy_requires_child_probe'
         coerced['constructor_signature_inspectable'] = True
         coerced['capability_source'] = 'desktop_runtime_setup_probe_legacy'
     return coerced

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -48,6 +48,12 @@ QWEN_64K_UBATCH_TOKENS = 128
 QWEN_64K_RUNTIME_PROFILE_DEFAULT = 'qwen64k_f16_fa_small_batch'
 QWEN_64K_RUNTIME_PROFILE_Q8 = 'qwen64k_kv_q8_fa_small_batch'
 QWEN_64K_RUNTIME_PROFILE_Q4 = 'qwen64k_kv_q4_fa_small_batch'
+
+LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS = (
+    'type_k', 'type_v', 'flash_attn', 'offload_kqv', 'n_batch', 'n_ubatch',
+    'rope_scaling_type', 'yarn_ext_factor', 'yarn_attn_factor', 'yarn_beta_fast',
+    'yarn_beta_slow', 'yarn_orig_ctx', 'rope_freq_base', 'rope_freq_scale',
+)
 # Only retry context-create failures backed by safe Metal/KV/cache/buffer
 # evidence. A bare ``Failed to create llama_context`` remains classified as
 # ``runtime_context_create_failed`` but is intentionally non-retryable so corrupt
@@ -58,6 +64,8 @@ QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES = {
     'runtime_context_create_metal_memory',
     'runtime_context_create_kv_cache_allocation',
     'runtime_context_create_metal_buffer_limit',
+    'runtime_context_create_cuda_memory',
+    'runtime_context_create_cuda_buffer_limit',
 }
 
 CRITICAL_STDLIB_IMPORT_MODULES = (
@@ -109,6 +117,20 @@ def _coerce_optional_int_enum(value: Any) -> Optional[int]:
     return None
 
 
+def _coerce_strict_bool(value: Any) -> Optional[bool]:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered == 'true':
+            return True
+        if lowered == 'false':
+            return False
+    return None
+
+
 def _safe_constructor_capability_payload(llama_cpp_module: Any) -> Dict[str, Any]:
     capabilities = getattr(llama_cpp_module, '__token_place_worker_capabilities__', None)
     if not isinstance(capabilities, dict):
@@ -117,7 +139,9 @@ def _safe_constructor_capability_payload(llama_cpp_module: Any) -> Dict[str, Any
     support = capabilities.get('constructor_kwarg_support')
     if isinstance(support, dict):
         payload['constructor_kwarg_support'] = {
-            str(name): bool(value) for name, value in support.items() if isinstance(name, str)
+            str(name): bool(value)
+            for name, value in support.items()
+            if isinstance(name, str) and name in LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS
         }
     for key in ('q8_kv_cache_type_value', 'q4_kv_cache_type_value', 'f16_kv_cache_type_value'):
         value = capabilities.get(key)
@@ -133,6 +157,8 @@ def _safe_constructor_capability_payload(llama_cpp_module: Any) -> Dict[str, Any
         'qwen_64k_yarn_support',
         'yarn_resolver_source',
         'llama_module_path',
+        'child_probe_reprobe_attempted',
+        'child_probe_reprobe_skipped_reason',
     ):
         if field in capabilities:
             payload[field] = capabilities.get(field)
@@ -392,6 +418,10 @@ def _classify_runtime_context_create_error(error: Any, child_stderr: str = '') -
         return 'runtime_context_create_metal_buffer_limit'
     if 'metal' in text and any(term in text for term in ('alloc', 'memory', 'oom', 'out of memory', 'failed to create llama_context')):
         return 'runtime_context_create_metal_memory'
+    if 'cuda' in text and any(term in text for term in ('out of memory', 'oom', 'cudamalloc', 'alloc failed', 'allocation failed', 'cublas')):
+        return 'runtime_context_create_cuda_memory'
+    if 'cuda' in text and any(term in text for term in ('buffer', 'resource', 'allocation')):
+        return 'runtime_context_create_cuda_buffer_limit'
     if 'failed to create llama_context' in text or 'llamacontext' in text:
         return 'runtime_context_create_failed'
     return 'runtime_init_unclassified'
@@ -524,6 +554,8 @@ _QWEN_64K_PROFILE_RECOVERABLE_FAILURE_CATEGORIES = {
     'memory_context_apply_failed',
     'graph_initialization_failed',
     'unknown_metal_backend_failure',
+    'runtime_context_create_cuda_memory',
+    'runtime_context_create_cuda_buffer_limit',
 }
 
 
@@ -728,33 +760,56 @@ def _qwen_64k_rope_support_diagnostics(llama_cpp_module: Any, llama_cls: Any) ->
 
 
 def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> Dict[str, Any]:
-    reprobe_attempted = False
     if getattr(llama_cpp_module, '__token_place_subprocess_facade__', False):
         capabilities = _safe_constructor_capability_payload(llama_cpp_module)
-        existing_support = capabilities.get('qwen_64k_yarn_support')
+        source = capabilities.get('capability_source')
         kwarg_support = capabilities.get('constructor_kwarg_support')
-        required_supported = (
-            isinstance(kwarg_support, dict)
-            and all(bool(kwarg_support.get(name)) for name in ('rope_scaling_type', 'rope_freq_scale', 'yarn_orig_ctx'))
+        required = ('rope_scaling_type', 'rope_freq_scale', 'yarn_orig_ctx')
+        required_supported = isinstance(kwarg_support, dict) and all(kwarg_support.get(name) is True for name in required)
+        authoritative_backend = str(capabilities.get('backend') or '').lower() in {'cuda', 'metal'}
+        authoritative = (
+            source in {'desktop_runtime_setup_probe', 'desktop_runtime_setup_probe_legacy'}
+            and authoritative_backend
+            and capabilities.get('gpu_offload_supported') is True
+            and bool(capabilities.get('llama_module_path') or getattr(llama_cpp_module, '__file__', None))
         )
-        has_concrete_yarn_value = capabilities.get('yarn_enum_value') is not None
-        facade_capabilities_complete = (
-            existing_support == 'supported'
+        complete = (
+            capabilities.get('qwen_64k_yarn_support') == 'supported'
             and required_supported
-            and has_concrete_yarn_value
+            and capabilities.get('yarn_enum_value') is not None
         )
-        if not facade_capabilities_complete:
-            reprobe_attempted = True
-            probe = _probe_llama_cpp_capabilities_in_subprocess(
-                timeout_seconds=getattr(llama_cpp_module, '_timeout_seconds', None)
-            )
-            if isinstance(probe, dict):
-                probe = dict(probe)
-                probe['child_probe_reprobe_attempted'] = True
-                llama_cpp_module.__token_place_worker_capabilities__ = probe
+        if authoritative and complete:
+            diagnostics = _qwen_64k_rope_support_diagnostics(llama_cpp_module, llama_cls)
+            diagnostics['child_probe_reprobe_attempted'] = False
+            diagnostics['child_probe_reprobe_skipped_reason'] = 'desktop_probe_authoritative'
+            diagnostics['desktop_probe_authoritative'] = True
+            return diagnostics
+        if source == 'desktop_runtime_setup_probe' and not complete:
+            missing = []
+            if capabilities.get('qwen_64k_yarn_support') != 'supported':
+                missing.append('qwen_64k_yarn_support')
+            if not required_supported:
+                missing.extend([name for name in required if not (isinstance(kwarg_support, dict) and kwarg_support.get(name) is True)])
+            if capabilities.get('yarn_enum_value') is None:
+                missing.append('yarn_enum_value')
+            diagnostics = _qwen_64k_rope_support_diagnostics(llama_cpp_module, llama_cls)
+            diagnostics.update({
+                'supported': False,
+                'missing_reason': 'runtime_desktop_capability_probe_incomplete',
+                'missing_required_kwargs': sorted(set(missing)),
+                'child_probe_reprobe_attempted': False,
+                'child_probe_reprobe_skipped_reason': 'desktop_probe_incomplete_fail_closed',
+                'desktop_probe_authoritative': False,
+            })
+            return diagnostics
+        probe = _probe_llama_cpp_capabilities_in_subprocess(timeout_seconds=getattr(llama_cpp_module, '_timeout_seconds', None))
+        if isinstance(probe, dict):
+            probe = dict(probe)
+            probe['child_probe_reprobe_attempted'] = True
+            llama_cpp_module.__token_place_worker_capabilities__ = probe
     diagnostics = _qwen_64k_rope_support_diagnostics(llama_cpp_module, llama_cls)
-    if reprobe_attempted:
-        diagnostics['child_probe_reprobe_attempted'] = True
+    if diagnostics.get('child_probe_reprobe_attempted') is not True:
+        diagnostics.setdefault('child_probe_reprobe_attempted', False)
     return diagnostics
 
 def _is_site_packages_path(path_text: Any) -> bool:
@@ -1929,16 +1984,26 @@ class _SubprocessLlamaCppModule:
         self._timeout_seconds = timeout_seconds
         self.__token_place_subprocess_facade__ = True
         self.LLAMA_TYPE_Q8_0 = 8
+        self.GGML_TYPE_Q8_0 = 8
         probe = _coerce_desktop_runtime_probe(desktop_runtime_probe)
         self.__token_place_worker_capabilities__ = dict(probe or {})
-        if 'constructor_kwarg_support' in self.__token_place_worker_capabilities__:
-            self.__token_place_worker_capabilities__['capability_source'] = 'worker_probe'
         backend = str((probe or {}).get('backend') or '').lower()
         self.GGML_USE_CUDA = backend == 'cuda'
         self.GGML_USE_METAL = backend == 'metal'
-        q8_value = self.__token_place_worker_capabilities__.get('q8_kv_cache_type_value')
-        if isinstance(q8_value, int):
-            self.LLAMA_TYPE_Q8_0 = q8_value
+        for attr, key in (
+            ('LLAMA_TYPE_Q8_0', 'q8_kv_cache_type_value'),
+            ('GGML_TYPE_Q8_0', 'q8_kv_cache_type_value'),
+            ('LLAMA_TYPE_Q4_0', 'q4_kv_cache_type_value'),
+            ('GGML_TYPE_Q4_0', 'q4_kv_cache_type_value'),
+            ('LLAMA_TYPE_F16', 'f16_kv_cache_type_value'),
+            ('GGML_TYPE_F16', 'f16_kv_cache_type_value'),
+        ):
+            value = self.__token_place_worker_capabilities__.get(key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                setattr(self, attr, value)
+        yarn_value = self.__token_place_worker_capabilities__.get('yarn_enum_value')
+        if isinstance(yarn_value, int) and not isinstance(yarn_value, bool):
+            self.LLAMA_ROPE_SCALING_TYPE_YARN = yarn_value
 
     def llama_supports_gpu_offload(self) -> bool:
         return bool(self.GGML_USE_CUDA or self.GGML_USE_METAL)
@@ -3460,7 +3525,7 @@ def _import_llama_cpp_runtime(
     path_diagnostics = _sanitize_llama_cpp_import_paths()
     logger.info(
         "llama_cpp import path sanitized import_root=%s deprioritized_entries=%s sys_path_count=%s",
-        path_diagnostics.get('import_root'),
+        _redact_paths_from_text(path_diagnostics.get('import_root')),
         len(path_diagnostics.get('deprioritized_entries', [])),
         path_diagnostics.get('sys_path_count'),
     )
@@ -3471,16 +3536,16 @@ def _import_llama_cpp_runtime(
         llama_module_path = expected_module_path
         logger.info(
             "llama_cpp runtime discovery reused desktop probe module_path=%s interpreter=%s",
-            llama_module_path,
-            sys.executable,
+            _redact_paths_from_text(llama_module_path),
+            _redact_paths_from_text(sys.executable),
         )
     else:
         spec_diagnostics = _find_llama_cpp_spec_in_subprocess(timeout_seconds=timeout_seconds)
         llama_module_path = spec_diagnostics.get('module_path')
         logger.info(
             "llama_cpp runtime discovery complete module_path=%s interpreter=%s",
-            llama_module_path or 'missing',
-            sys.executable,
+            _redact_paths_from_text(llama_module_path or 'missing'),
+            _redact_paths_from_text(sys.executable),
         )
 
     if require_real_runtime and _is_repo_llama_cpp_shim(llama_module_path):
@@ -3495,8 +3560,8 @@ def _import_llama_cpp_runtime(
 
     logger.info(
         "llama_cpp direct import start module_path_hint=%s interpreter=%s",
-        llama_module_path or 'unknown',
-        sys.executable,
+        _redact_paths_from_text(llama_module_path or 'unknown'),
+        _redact_paths_from_text(sys.executable),
     )
     llama_cpp = _import_llama_cpp_in_parent_with_timeout(
         timeout_seconds=timeout_seconds,
@@ -3519,8 +3584,8 @@ def _import_llama_cpp_runtime(
     llama_module_path = imported_module_path
     logger.info(
         "llama_cpp import complete module_path=%s interpreter=%s",
-        llama_module_path or 'unknown',
-        sys.executable,
+        _redact_paths_from_text(llama_module_path or 'unknown'),
+        _redact_paths_from_text(sys.executable),
     )
 
     if require_real_runtime and _is_repo_llama_cpp_shim(llama_module_path):
@@ -3669,7 +3734,8 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
     error = str(probe.get('error') or probe.get('fallback_reason') or '').strip()
     action = str(probe.get('runtime_action') or probe.get('action') or '').strip().lower()
     backend = str(probe.get('selected_backend') or probe.get('backend') or '').strip().lower()
-    gpu_supported = bool(probe.get('gpu_offload_supported', backend in {'cuda', 'metal'}))
+    gpu_bool = _coerce_strict_bool(probe.get('gpu_offload_supported', True if backend in {'cuda', 'metal'} else False))
+    gpu_supported = bool(gpu_bool)
     module_path = str(probe.get('llama_module_path') or '').strip()
     if not backend or backend == 'missing' or action in {'failed', 'unavailable', 'shadowed_repo_llama_cpp'}:
         return None
@@ -3685,29 +3751,65 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
         'error': None,
         'runtime_action': action or 'unknown',
     }
-    support = probe.get('constructor_kwarg_support')
-    if isinstance(support, dict):
-        coerced['constructor_kwarg_support'] = {
-            str(name): bool(value) for name, value in support.items() if isinstance(name, str)
-        }
-    q8_value = probe.get('q8_kv_cache_type_value')
-    if isinstance(q8_value, int):
-        coerced['q8_kv_cache_type_value'] = q8_value
-    if probe.get('capability_source'):
-        coerced['capability_source'] = str(probe.get('capability_source'))
+    support: Dict[str, bool] = {}
+    raw_support = probe.get('constructor_kwarg_support')
+    if isinstance(raw_support, dict):
+        for name in LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS:
+            if name in raw_support:
+                value = _coerce_strict_bool(raw_support.get(name))
+                if value is not None:
+                    support[name] = value
+    legacy_map = {
+        'rope_scaling_type': 'rope_scaling_type_supported',
+        'yarn_ext_factor': 'yarn_ext_factor_supported',
+        'rope_freq_scale': 'rope_freq_scale_supported',
+        'yarn_orig_ctx': 'yarn_orig_ctx_supported',
+    }
+    for kwarg, field in legacy_map.items():
+        if kwarg not in support and field in probe:
+            value = _coerce_strict_bool(probe.get(field))
+            if value is not None:
+                support[kwarg] = value
+    if support:
+        coerced['constructor_kwarg_support'] = support
+
+    for field in ('q8_kv_cache_type_value', 'q4_kv_cache_type_value', 'f16_kv_cache_type_value'):
+        value = _coerce_optional_int_enum(probe.get(field))
+        if value is not None and 0 <= value <= 2**31 - 1:
+            coerced[field] = value
     if probe.get('llama_cpp_python_version'):
         coerced['llama_cpp_python_version'] = str(probe.get('llama_cpp_python_version'))
-    if probe.get('constructor_has_var_kwargs') is not None:
-        coerced['constructor_has_var_kwargs'] = bool(probe.get('constructor_has_var_kwargs'))
-    if probe.get('constructor_signature_inspectable') is not None:
-        coerced['constructor_signature_inspectable'] = bool(probe.get('constructor_signature_inspectable'))
-    if probe.get('qwen_64k_yarn_support') in {'supported', 'unknown', 'unsupported'}:
-        coerced['qwen_64k_yarn_support'] = str(probe.get('qwen_64k_yarn_support'))
+    for field in ('constructor_has_var_kwargs', 'constructor_signature_inspectable'):
+        value = _coerce_strict_bool(probe.get(field))
+        if value is not None:
+            coerced[field] = value
+    yarn_support = probe.get('qwen_64k_yarn_support')
+    if yarn_support in {'supported', 'unknown', 'unsupported'}:
+        coerced['qwen_64k_yarn_support'] = str(yarn_support)
     if probe.get('yarn_resolver_source'):
         coerced['yarn_resolver_source'] = str(probe.get('yarn_resolver_source'))
     yarn_enum_value = _coerce_optional_int_enum(probe.get('yarn_enum_value'))
-    if yarn_enum_value is not None:
+    if yarn_enum_value is not None and 0 <= yarn_enum_value <= 2**31 - 1:
         coerced['yarn_enum_value'] = yarn_enum_value
+
+    source = str(probe.get('capability_source') or '').strip()
+    if source in {'desktop_runtime_setup_probe', 'desktop_runtime_setup_probe_legacy', 'worker_probe'}:
+        coerced['capability_source'] = source
+
+    # Compatibility bridge for deployed flat desktop probes. Do not invent
+    # unobserved performance/KV kwargs.
+    legacy_yarn = _coerce_strict_bool(probe.get('yarn_rope_supported'))
+    required_supported = all(support.get(name) is True for name in ('rope_scaling_type', 'rope_freq_scale', 'yarn_orig_ctx'))
+    if (
+        coerced.get('qwen_64k_yarn_support') is None
+        and legacy_yarn is True
+        and required_supported
+        and str(probe.get('yarn_resolver_source') or '').lower() != 'unsupported'
+    ):
+        coerced['qwen_64k_yarn_support'] = 'supported'
+        coerced['yarn_enum_value'] = 2
+        coerced['constructor_signature_inspectable'] = True
+        coerced['capability_source'] = 'desktop_runtime_setup_probe_legacy'
     return coerced
 
 
@@ -4541,7 +4643,7 @@ class ModelManager:
                             if is_qwen_64k:
                                 _runtime_supports_qwen_yarn_rope(llama_cpp, Llama)
                                 Llama = llama_cpp.Llama
-                                if str(compute_plan.get('backend_used') or '').lower() == 'metal':
+                                if str(compute_plan.get('backend_used') or '').lower() in {'metal', 'cuda'}:
                                     runtime_profiles = _build_qwen_64k_runtime_profiles(
                                         llama_cpp,
                                         Llama,
@@ -4735,10 +4837,17 @@ class ModelManager:
                                 self.last_runtime_init_error = _format_runtime_stage_timeout(e)
                             self.worker_state = 'failed'
                             self.last_worker_error_code = _safe_worker_error_code(e)
-                            self.log_error(
-                                f"Failed to initialize Llama model: {self.last_runtime_init_error}",
-                                exc_info=True,
-                            )
+                            if isinstance(e, LlamaCppRuntimeStageTimeout):
+                                self.log_error(
+                                    "desktop.llama_cpp_worker.init_failed "
+                                    f"stage={e.stage} category=worker_timeout timeout_seconds={e.timeout_seconds:g}",
+                                    exc_info=False,
+                                )
+                            else:
+                                self.log_error(
+                                    f"Failed to initialize Llama model: {self.last_runtime_init_error}",
+                                    exc_info=True,
+                                )
                             return None
 
         return self.llm
@@ -4788,7 +4897,7 @@ class ModelManager:
             None,
         )
         active_diagnostics = active_profile.get('diagnostics') if isinstance(active_profile, dict) else {}
-        if str((active_diagnostics or {}).get('backend') or '').lower() != 'metal':
+        if str((active_diagnostics or {}).get('backend') or '').lower() not in {'metal', 'cuda'}:
             return None
         with self.llm_lock:
             if self.llm is not failed_runtime:
@@ -4815,6 +4924,7 @@ class ModelManager:
                         'backend_state_sticky',
                         'backend_recreation_required',
                         'metal_command_buffer_status',
+                        'cuda_error_category',
                         'eval_return_code',
                     }
                     and value is not None
@@ -4861,6 +4971,7 @@ class ModelManager:
                         'backend_state_sticky',
                         'backend_recreation_required',
                         'metal_command_buffer_status',
+                        'cuda_error_category',
                         'eval_return_code',
                     }
                     and value is not None

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -165,8 +165,8 @@ def _safe_constructor_capability_payload(llama_cpp_module: Any) -> Dict[str, Any
     ):
         if field in capabilities:
             payload[field] = capabilities.get(field)
-    yarn_enum_value = _coerce_optional_int_enum(capabilities.get('yarn_enum_value'))
-    if yarn_enum_value is not None:
+    yarn_enum_value = capabilities.get('yarn_enum_value')
+    if isinstance(yarn_enum_value, int) and not isinstance(yarn_enum_value, bool):
         payload['yarn_enum_value'] = yarn_enum_value
     return payload
 
@@ -4823,6 +4823,7 @@ class ModelManager:
                                     'qwen_64k_runtime_profile_n_batch': applied_memory.get('n_batch'),
                                     'qwen_64k_runtime_profile_n_ubatch': applied_memory.get('n_ubatch'),
                                     'qwen_64k_runtime_profile_result': 'constructed',
+                                    'llama_cpp_runtime_profile_backend': memory_profile.get('backend'),
                                 })
                                 first_failure = getattr(self, '_qwen_64k_first_readiness_failure_diagnostics', {})
                                 if isinstance(first_failure, dict):
@@ -4833,6 +4834,12 @@ class ModelManager:
                                 compute_plan['yarn_rope_diagnostics'] = dict(yarn_diagnostics)
                                 compute_plan['yarn_rope_enum_location'] = yarn_diagnostics.get('yarn_enum_location')
                                 compute_plan['yarn_rope_accepted_constructor_kwargs'] = yarn_diagnostics.get('accepted_constructor_kwargs')
+                                compute_plan['llama_cpp_capability_source'] = yarn_diagnostics.get('capability_source')
+                                compute_plan['llama_cpp_desktop_probe_authoritative'] = yarn_diagnostics.get('desktop_probe_authoritative')
+                                compute_plan['llama_cpp_child_capability_reprobe_attempted'] = yarn_diagnostics.get('child_probe_reprobe_attempted')
+                                compute_plan['llama_cpp_child_capability_reprobe_skipped_reason'] = yarn_diagnostics.get('child_probe_reprobe_skipped_reason')
+                                compute_plan['llama_cpp_constructor_signature_inspectable'] = yarn_diagnostics.get('constructor_signature_inspectable')
+                                compute_plan['llama_cpp_qwen_64k_yarn_support'] = yarn_diagnostics.get('support_classification')
                             self.last_compute_diagnostics = compute_plan
                             if compute_plan['requested_mode'] == 'cpu':
                                 runtime_identity = {
@@ -4877,7 +4884,7 @@ class ModelManager:
                             else:
                                 self.log_error(
                                     f"Failed to initialize Llama model: {self.last_runtime_init_error}",
-                                    exc_info=True,
+                                    exc_info=False,
                                 )
                             return None
 

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -783,7 +783,7 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
             == _canonical_path_for_compare(facade_module_path)
         )
         authoritative = (
-            source == 'desktop_runtime_setup_probe'
+            source in {'desktop_runtime_setup_probe', 'desktop_runtime_setup_probe_legacy'}
             and authoritative_backend
             and capabilities.get('gpu_offload_supported') is True
             and module_paths_match
@@ -801,7 +801,7 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
             diagnostics['child_probe_reprobe_skipped_reason'] = 'desktop_probe_authoritative'
             diagnostics['desktop_probe_authoritative'] = True
             return diagnostics
-        if source == 'desktop_runtime_setup_probe' and not complete:
+        if source in {'desktop_runtime_setup_probe', 'desktop_runtime_setup_probe_legacy'} and not complete:
             missing = []
             if capabilities.get('qwen_64k_yarn_support') != 'supported':
                 missing.append('qwen_64k_yarn_support')
@@ -3827,7 +3827,10 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
         coerced['capability_source'] = source
 
     # Compatibility bridge for deployed flat desktop probes. Do not invent
-    # unobserved performance/KV kwargs.
+    # unobserved performance/KV kwargs. The pinned llama-cpp-python==0.3.32
+    # path has a verified numeric YaRN enum value of 2; launching another
+    # native import here would recreate the Windows timeout failure this
+    # desktop facade is designed to avoid.
     legacy_yarn = _coerce_strict_bool(probe.get('yarn_rope_supported'))
     required_supported = all(support.get(name) is True for name in ('rope_scaling_type', 'rope_freq_scale', 'yarn_orig_ctx'))
     if (
@@ -3837,7 +3840,8 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
         and str(probe.get('yarn_resolver_source') or '').lower() != 'unsupported'
     ):
         coerced['qwen_64k_yarn_support'] = 'supported'
-        coerced['yarn_resolver_source'] = 'legacy_requires_child_probe'
+        coerced['yarn_enum_value'] = 2
+        coerced['yarn_resolver_source'] = str(probe.get('yarn_resolver_source') or 'legacy_numeric_yarn')
         coerced['constructor_signature_inspectable'] = True
         coerced['capability_source'] = 'desktop_runtime_setup_probe_legacy'
     return coerced

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -97,6 +97,21 @@ def _classify_safe_generation_exception(exc: BaseException) -> str:
     text = f"{type(exc).__name__} {exc}".lower()
     if "metal" in text and any(term in text for term in ("alloc", "memory", "out of memory", "oom")):
         return "metal_memory_allocation"
+    cuda_markers = (
+        "cuda out of memory",
+        "cuda error: out of memory",
+        "cudamalloc",
+        "cuda malloc",
+        "cublas_status_alloc_failed",
+        "cublas alloc",
+    )
+    cuda_generic_allocation_markers = ("allocation failed", "failed to allocate")
+    if (
+        any(marker in text for marker in cuda_markers)
+        or ("cuda" in text and any(marker in text for marker in cuda_generic_allocation_markers))
+        or ("ggml_cuda" in text and any(term in text for term in ("alloc", "memory", "oom")))
+    ):
+        return "cuda_memory_allocation"
     if "kv" in text and any(term in text for term in ("alloc", "cache", "memory", "out of memory", "oom")):
         return "kv_cache_allocation"
     if "yarn" in text or ("rope" in text and any(term in text for term in ("scal", "freq", "eval"))):
@@ -204,6 +219,7 @@ _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
     },
     "generation_exception_category": {
         "metal_memory_allocation",
+        "cuda_memory_allocation",
         "kv_cache_allocation",
         "rope_yarn_eval_failure",
         "unsupported_generation_kwarg",
@@ -282,7 +298,7 @@ _SAFE_WORKER_DIAGNOSTIC_ENUM_VALUES = {
 _SAFE_WORKER_DIAGNOSTIC_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9_.:/@+-]{1,128}$")
 _SAFE_WORKER_DIAGNOSTIC_CLASS_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]{0,127}$")
 _SAFE_WORKER_DIAGNOSTIC_REDACTED_SUMMARY_RE = re.compile(
-    r"^[A-Za-z_][A-Za-z0-9_.]{0,127}:(?:redacted|metal_memory_allocation|kv_cache_allocation|"
+    r"^[A-Za-z_][A-Za-z0-9_.]{0,127}:(?:redacted|metal_memory_allocation|cuda_memory_allocation|kv_cache_allocation|"
     r"rope_yarn_eval_failure|unsupported_kwarg|prompt_tokenization_failure|prompt_eval_failure|"
     r"prompt_eval_decode_failure|prompt_eval_backend_failure|prompt_eval_invalid_token_failure|"
     r"prompt_eval_state_failure|prompt_eval_context_failure|sampling_failure)$"


### PR DESCRIPTION
### Motivation
- Prevent redundant native `llama_cpp_gpu_probe` on Windows by making the desktop-side probe authoritative and carrying full typed capability fields into the subprocess facade. 
- Enable the bounded Qwen 64K profile lifecycle (F16 → Q8 → Q4) for CUDA as well as Metal and avoid spurious profile/reprobe failures.
- Stop leaking local Windows paths and full subprocess commands into operator logs by sanitizing timeouts/commands and hardening path redaction.

### Description
- Define a single, complete desktop capability schema and constructor-kwarg list in `desktop_runtime_setup.py` and extend `RuntimeProbe` with typed fields including `constructor_kwarg_support`, `constructor_has_var_kwargs`, `constructor_signature_inspectable`, `qwen_64k_yarn_support`, `yarn_enum_value`, Q8/Q4/F16 values, and `capability_source`.
- Update the in-subprocess probe snippet to inspect `Llama.__init__` once, report constructor-kwarg support, resolve YaRN enum/value and KV constants, set `qwen_64k_yarn_support` classification, and mark `capability_source="desktop_runtime_setup_probe"` while preserving native booleans/ints in `TOKEN_PLACE_DESKTOP_RUNTIME_PROBE_JSON`.
- Change `_probe_result_payload(...)` to return `Dict[str, Any]` (preserving native types) and keep legacy flat boolean/text fields for compatibility while emitting the structured payload.
- Add strict boolean coercion and robust normalization in `_coerce_desktop_runtime_probe(...)` (accept only bool, 0/1, "true"/"false" strings), validate and retain only known constructor kwargs, accept only bounded integer enums/constants and a small `capability_source` enum, and synthesize legacy-compatible fields when safe.
- Refactor `_runtime_supports_qwen_yarn_rope(...)` to treat a complete desktop probe as authoritative (skip secondary reprobe), fail closed with a safe diagnostic when an explicitly-marked desktop probe is incomplete, and only fall back to subprocess reprobe for non-authoritative cases.
- Initialize `_SubprocessLlamaCppModule` from the validated probe: expose observed KV constants (Q8/Q4/F16), YaRN enum/value, backend flags, and populate `__token_place_supported_constructor_kwargs__` from the probe so subprocess facades no longer require a secondary native import.
- Enable building the Qwen 64K profile list for CUDA as well as Metal, preserving exact profile order (F16, Q8, Q4) and profile kwargs, and add CUDA-safe allocation/diagnostic categories and bounded profile-retry hooks equal to Metal behavior.
- Harden initialization error logging to avoid leaking `python -c` commands, raw env, and explicit paths; produce a safe one-line timeout message for `LlamaCppRuntimeStageTimeout` events; sanitize reported import roots.
- Extend Rust operator log sanitizer to better detect and redact Windows extended, UNC, and doubled-backslash path forms, and to special-case `TimeoutExpired`/`Command [...]` lines into a safe summary.
- Add unit/integration regressions that assert: structured probe preserves native types; strict bool coercion behavior; authoritative desktop CUDA probe avoids secondary reprobe and proceeds to model construction; legacy flat probes are compatibly normalized; CUDA profile ordering and profile-recovery flows work; and Windows path/timeouts are redacted.
- Add a Windows-focused step to `.github/workflows/desktop-operator-e2e.yml` to run the fake-based regressions (no physical CUDA required).

Files changed (key):
- desktop-tauri/src-tauri/python/desktop_runtime_setup.py (probe schema, typed payload, timeout handling)
- utils/llm/model_manager.py (probe coercion, authoritative reuse, subprocess facade initialization, Qwen64k profile/CUDA changes, logging redaction)
- utils/compute_node_runtime.py (CUDA-safe profile/recovery categories)
- desktop-tauri/src-tauri/src/operator_logs.rs (Windows path/timeoute redaction tests and sanitizer)
- tests/unit & tests/integration (new/extended tests covering the fix and regressions)
- .github/workflows/desktop-operator-e2e.yml (added targeted Windows fake regression step)

### Testing
- Ran unit and integration Python test suites locally (fakes/mocks):
  - `python -m pytest tests/unit/test_desktop_runtime_setup.py -q` — passed.
  - `python -m pytest tests/unit/test_model_manager.py -q` — passed.
  - `python -m pytest tests/unit/test_compute_node_runtime.py -q` — passed.
  - `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -q` — passed.
  - `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q` — passed.
- Ran Rust formatting and project checks: `cargo fmt --manifest-path desktop-tauri/src-tauri/Cargo.toml -- --check` — passed.
- Ran `pre-commit run --all-files` and `git diff --check` — passed.
- Note: `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml operator_logs` and the full `compute_node` cargo tests require system `glib-2.0` pkg-config files and were blocked in this container (missing `glib-2.0.pc` / `PKG_CONFIG_PATH`); the new Rust unit test for Windows path redaction was added and is exercised by CI where system deps are available.

Residual notes and follow-ups
- The change preserves all API v1 invariants (non-reasoning, enable_thinking never injected) and does not alter pinned `llama-cpp-python` dependency.
- CI should run the added Windows fake regressions on the Windows runner (workflow entry included). If CI reports Rust build failures on hosted runners, ensure `pkg-config`/`glib-2.0` are available or limit `cargo test` targets as intended for fakes.
- If any additional runtime probe variants are observed in the field, expand the capability-schema whitelist before synthesis to avoid accidental acceptance of unknown fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a535243f8ac832f97add9d9cf040fe9)