### PR TITLE
Add opt-in authenticated ServiceMonitor to charts/tokenplace

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -167,6 +167,44 @@ jobs:
           assert secret["valueFrom"]["secretKeyRef"]["key"] == "token"
           PY
 
+      - name: Template metrics ServiceMonitor render check
+        run: |
+          helm template tokenplace charts/tokenplace \
+            --namespace tokenplace \
+            --set metrics.enabled=true \
+            --set metrics.auth.existingSecret=tokenplace-metrics \
+            --set serviceMonitor.enabled=true \
+            --set serviceMonitor.relabelings.environment=staging > /tmp/tokenplace-render-metrics.yaml
+
+          grep -n "kind: ServiceMonitor" /tmp/tokenplace-render-metrics.yaml
+          grep -n "release: kube-prometheus-stack" /tmp/tokenplace-render-metrics.yaml
+          grep -n "name: TOKENPLACE_METRICS_TOKEN" -A5 /tmp/tokenplace-render-metrics.yaml
+          grep -n "authorization:" -A5 /tmp/tokenplace-render-metrics.yaml
+          grep -n "targetLabel: environment" -A1 /tmp/tokenplace-render-metrics.yaml | grep -n 'replacement: "staging"'
+          ! grep -n "path: /metrics" /tmp/tokenplace-render.yaml
+
+          python3 - <<'PY'
+          import yaml
+
+          docs = list(yaml.safe_load_all(open("/tmp/tokenplace-render-metrics.yaml", encoding="utf-8")))
+          docs = [doc for doc in docs if doc]
+          service = next(d for d in docs if d.get("kind") == "Service")
+          monitor = next(d for d in docs if d.get("kind") == "ServiceMonitor")
+          deploy = next(d for d in docs if d.get("kind") == "Deployment")
+          endpoint = monitor["spec"]["endpoints"][0]
+          assert monitor["spec"]["selector"]["matchLabels"] == service["spec"]["selector"]
+          assert endpoint["port"] == "http"
+          assert endpoint["authorization"]["credentials"] == {"name": "tokenplace-metrics", "key": "token"}
+          relabels = {item["targetLabel"]: item["replacement"] for item in endpoint["relabelings"]}
+          assert set(relabels) == {"app", "environment", "release", "cluster"}
+          assert deploy["spec"]["replicas"] == 1
+          assert deploy["spec"]["strategy"]["type"] == "Recreate"
+          env = {item["name"]: item for item in deploy["spec"]["template"]["spec"]["containers"][0]["env"]}
+          assert env["RELAY_WORKERS"]["value"] == "1"
+          assert env["TOKENPLACE_METRICS_TOKEN"]["valueFrom"]["secretKeyRef"] == {"name": "tokenplace-metrics", "key": "token"}
+          assert not any(doc.get("kind") == "Ingress" and "/metrics" in str(doc) for doc in docs)
+          PY
+
       - name: Template strategy-empty fallback smoke render
         run: |
 

--- a/charts/tokenplace/README.md
+++ b/charts/tokenplace/README.md
@@ -1,0 +1,68 @@
+# token.place Helm chart
+
+Canonical Sugarkube/GHCR chart for the token.place relay, published as
+`oci://ghcr.io/futuroptimist/charts/tokenplace`.
+
+## Metrics and ServiceMonitor
+
+Metrics scraping is opt-in and authenticated. Defaults render no metrics token
+environment variable and no `ServiceMonitor`.
+
+Create the token secret in the same namespace as the token.place release and the
+`ServiceMonitor`:
+
+```bash
+kubectl -n tokenplace create secret generic tokenplace-metrics \
+  --from-literal=token='REPLACE_WITH_RANDOM_TOKEN'
+```
+
+Enable the internal scrape contract without publishing `/metrics` through
+Ingress:
+
+```yaml
+metrics:
+  enabled: true
+  path: /metrics
+  auth:
+    existingSecret: tokenplace-metrics
+    secretKey: token
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    release: kube-prometheus-stack
+  relabelings:
+    app: tokenplace
+    environment: staging
+    release: tokenplace
+    cluster: sugarkube
+```
+
+The chart injects `TOKENPLACE_METRICS_TOKEN` from the existing Secret into the
+relay pod and configures Prometheus Operator `authorization.credentials` so
+Prometheus sends the same bearer token when scraping the named `http` Service
+port. Do not put plaintext token values in values files or Git.
+
+Verification commands:
+
+```bash
+helm template tokenplace charts/tokenplace --namespace tokenplace \
+  --set metrics.enabled=true \
+  --set metrics.auth.existingSecret=tokenplace-metrics \
+  --set serviceMonitor.enabled=true > /tmp/tokenplace-metrics.yaml
+kubectl -n tokenplace get servicemonitor tokenplace -o jsonpath='{.metadata.labels.release}{"\n"}'
+kubectl -n tokenplace get endpoints tokenplace
+kubectl -n monitoring exec statefulset/prometheus-kube-prometheus-stack-prometheus -c prometheus -- \
+  wget -qO- --header="Authorization: Bearer $(kubectl -n tokenplace get secret tokenplace-metrics -o jsonpath='{.data.token}' | base64 -d)" \
+  http://tokenplace.tokenplace.svc/metrics | head
+curl -fsS -o /dev/null -w '%{http_code}\n' https://staging.token.place/metrics
+kubectl -n tokenplace get ingress tokenplace -o yaml | grep -n '/metrics' || true
+```
+
+Expected results: the release label is `kube-prometheus-stack`, endpoints point
+at the token.place Service, the internal scrape returns Prometheus text, the
+public request is denied by the application when staging/production metrics are
+enabled, and the Ingress contains no dedicated `/metrics` path.
+
+The chart intentionally preserves one replica, one relay worker, `Recreate`
+rollouts, and in-memory relay state. Observability must not change that relay
+architecture.

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -122,6 +122,10 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
+          {{- if .Values.metrics.enabled }}
+          {{- $metricsSecret := required "metrics.auth.existingSecret is required when metrics.enabled=true" .Values.metrics.auth.existingSecret }}
+          {{- $_ := set $mergedEnv "TOKENPLACE_METRICS_TOKEN" (dict "name" "TOKENPLACE_METRICS_TOKEN" "valueFrom" (dict "secretKeyRef" (dict "name" $metricsSecret "key" .Values.metrics.auth.secretKey))) }}
+          {{- end }}
           image: {{ include "tokenplace.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/tokenplace/templates/servicemonitor.yaml
+++ b/charts/tokenplace/templates/servicemonitor.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.serviceMonitor.enabled }}
+{{- $secretName := required "metrics.auth.existingSecret is required when serviceMonitor.enabled=true" .Values.metrics.auth.existingSecret }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "tokenplace.fullname" . }}
+  labels:
+    {{- include "tokenplace.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      {{- include "tokenplace.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.metrics.path | quote }}
+      interval: {{ .Values.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | quote }}
+      authorization:
+        type: Bearer
+        credentials:
+          name: {{ $secretName | quote }}
+          key: {{ .Values.metrics.auth.secretKey | quote }}
+      relabelings:
+        - action: replace
+          targetLabel: app
+          replacement: {{ .Values.serviceMonitor.relabelings.app | quote }}
+        - action: replace
+          targetLabel: environment
+          replacement: {{ .Values.serviceMonitor.relabelings.environment | quote }}
+        - action: replace
+          targetLabel: release
+          replacement: {{ .Values.serviceMonitor.relabelings.release | quote }}
+        - action: replace
+          targetLabel: cluster
+          replacement: {{ .Values.serviceMonitor.relabelings.cluster | quote }}
+{{- end }}

--- a/charts/tokenplace/values.schema.json
+++ b/charts/tokenplace/values.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": { "type": "integer", "default": 1 },
+    "strategy": {
+      "type": "object",
+      "properties": { "type": { "type": "string", "enum": ["Recreate", "RollingUpdate"] } }
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "path": { "type": "string", "default": "/metrics", "pattern": "^/[^?#]*$" },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "existingSecret": { "type": "string", "default": "" },
+            "secretKey": { "type": "string", "default": "token", "minLength": 1 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "interval": { "type": "string", "default": "30s" },
+        "scrapeTimeout": { "type": "string", "default": "10s" },
+        "additionalLabels": { "type": "object", "additionalProperties": { "type": "string" } },
+        "relabelings": {
+          "type": "object",
+          "properties": {
+            "app": { "type": "string", "default": "tokenplace" },
+            "environment": { "type": "string", "default": "dev" },
+            "release": { "type": "string", "default": "tokenplace" },
+            "cluster": { "type": "string", "default": "sugarkube" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/charts/tokenplace/values.yaml
+++ b/charts/tokenplace/values.yaml
@@ -57,6 +57,26 @@ service:
   type: ClusterIP
   port: 80
 
+
+metrics:
+  enabled: false
+  path: /metrics
+  auth:
+    existingSecret: ""
+    secretKey: token
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels:
+    release: kube-prometheus-stack
+  relabelings:
+    app: tokenplace
+    environment: dev
+    release: tokenplace
+    cluster: sugarkube
+
 ingress:
   enabled: false
   className: ""

--- a/docs/releases/v0.1.2.md
+++ b/docs/releases/v0.1.2.md
@@ -361,3 +361,49 @@ histogram_quantile(0.95, sum by (le, route) (rate(tokenplace_http_request_durati
 - Staging Prometheus target discovery, in-cluster scrape success, Grafana panels,
   Alertmanager behavior, production scrape behavior, and Sugarkube chart wiring
   remain explicitly unverified in this source-only slice.
+
+## Canonical chart metrics scrape contract
+
+- [ ] `charts/tokenplace` keeps `metrics.enabled=false` and
+  `serviceMonitor.enabled=false` by default so existing Sugarkube deployments
+  render no metrics Secret reference and no `ServiceMonitor`.
+- [ ] Staging and production metrics use an existing Kubernetes Secret only:
+  `metrics.auth.existingSecret` plus `metrics.auth.secretKey` inject
+  `TOKENPLACE_METRICS_TOKEN` into the relay pod with `valueFrom.secretKeyRef`;
+  plaintext bearer tokens must never be committed to chart values, release docs,
+  or rendered examples.
+- [ ] The canonical ServiceMonitor is opt-in, carries configurable discovery
+  labels such as `release: kube-prometheus-stack`, selects the canonical
+  token.place Service labels, scrapes the named `http` port at `/metrics`, and
+  uses Prometheus Operator `authorization.credentials` rather than file-based
+  bearer tokens.
+- [ ] The only target-label relabeling hooks are bounded static replacements for
+  `app`, `environment`, `release`, and `cluster`; do not add user-, request-,
+  payload-, key-, or path-derived labels.
+- [ ] `/metrics` remains internal-only: the chart must not create a public
+  metrics Ingress path, and staging/production must prove unauthenticated public
+  requests are denied while Prometheus in the monitoring namespace can scrape
+  with the Secret-backed bearer token.
+- [ ] Observability does not change the accepted relay architecture: one
+  replica, one Gunicorn worker, `Recreate` rollouts, and in-memory relay state
+  remain the canonical Sugarkube constraints.
+
+Suggested proof commands for release QA:
+
+```bash
+helm template tokenplace charts/tokenplace --namespace tokenplace \
+  --set metrics.enabled=true \
+  --set metrics.auth.existingSecret=tokenplace-metrics \
+  --set serviceMonitor.enabled=true > /tmp/tokenplace-metrics.yaml
+grep -n "kind: ServiceMonitor" /tmp/tokenplace-metrics.yaml
+grep -n "release: kube-prometheus-stack" /tmp/tokenplace-metrics.yaml
+grep -n "name: TOKENPLACE_METRICS_TOKEN" -A5 /tmp/tokenplace-metrics.yaml
+grep -n "authorization:" -A5 /tmp/tokenplace-metrics.yaml
+kubectl -n tokenplace get servicemonitor tokenplace -o jsonpath='{.spec.selector.matchLabels}{"\n"}'
+kubectl -n tokenplace get svc tokenplace -o jsonpath='{.spec.selector}{"\n"}'
+kubectl -n monitoring exec statefulset/prometheus-kube-prometheus-stack-prometheus -c prometheus -- \
+  wget -qO- --header="Authorization: Bearer ${TOKENPLACE_METRICS_TOKEN}" \
+  http://tokenplace.tokenplace.svc/metrics | head
+curl -fsS -o /dev/null -w '%{http_code}\n' https://staging.token.place/metrics
+kubectl -n tokenplace get ingress tokenplace -o yaml | grep -n '/metrics' || true
+```

--- a/tests/test_tokenplace_chart_metrics.py
+++ b/tests/test_tokenplace_chart_metrics.py
@@ -1,0 +1,86 @@
+"""Regression tests for the canonical token.place Helm metrics contract."""
+
+import shutil
+import subprocess
+
+import pytest
+import yaml
+
+
+pytestmark = pytest.mark.skipif(shutil.which("helm") is None, reason="helm is not installed")
+
+
+def _render(*args: str) -> list[dict]:
+    command = ["helm", "template", "tokenplace", "charts/tokenplace", "--namespace", "tokenplace", *args]
+    rendered = subprocess.check_output(command, text=True)
+    return [doc for doc in yaml.safe_load_all(rendered) if doc]
+
+
+def _kind(docs: list[dict], kind: str) -> list[dict]:
+    return [doc for doc in docs if doc.get("kind") == kind]
+
+
+def _deploy(docs: list[dict]) -> dict:
+    return _kind(docs, "Deployment")[0]
+
+
+def _env(deploy: dict) -> dict:
+    env = deploy["spec"]["template"]["spec"]["containers"][0]["env"]
+    return {item["name"]: item for item in env}
+
+
+def test_default_metrics_and_servicemonitor_disabled() -> None:
+    docs = _render()
+    assert not _kind(docs, "ServiceMonitor")
+    assert "TOKENPLACE_METRICS_TOKEN" not in _env(_deploy(docs))
+    assert not any(doc.get("kind") == "Ingress" and "/metrics" in str(doc) for doc in docs)
+
+
+def test_enabled_servicemonitor_selects_service_and_uses_existing_secret() -> None:
+    docs = _render(
+        "--set", "metrics.enabled=true",
+        "--set", "metrics.auth.existingSecret=tokenplace-metrics",
+        "--set", "serviceMonitor.enabled=true",
+        "--set", "serviceMonitor.relabelings.environment=staging",
+    )
+    service = _kind(docs, "Service")[0]
+    monitor = _kind(docs, "ServiceMonitor")[0]
+    endpoint = monitor["spec"]["endpoints"][0]
+
+    assert monitor["metadata"]["labels"]["release"] == "kube-prometheus-stack"
+    assert monitor["spec"]["selector"]["matchLabels"] == service["spec"]["selector"]
+    assert endpoint["port"] == "http"
+    assert endpoint["path"] == "/metrics"
+    assert endpoint["authorization"]["type"] == "Bearer"
+    assert endpoint["authorization"]["credentials"] == {"name": "tokenplace-metrics", "key": "token"}
+
+    metrics_env = _env(_deploy(docs))["TOKENPLACE_METRICS_TOKEN"]
+    assert metrics_env["valueFrom"]["secretKeyRef"] == {"name": "tokenplace-metrics", "key": "token"}
+
+    relabels = {item["targetLabel"]: item["replacement"] for item in endpoint["relabelings"]}
+    assert relabels == {
+        "app": "tokenplace",
+        "environment": "staging",
+        "release": "tokenplace",
+        "cluster": "sugarkube",
+    }
+
+
+def test_no_public_metrics_ingress_and_relay_constraints_preserved() -> None:
+    docs = _render(
+        "--set", "ingress.enabled=true",
+        "--set", "ingress.host=staging.token.place",
+        "--set", "metrics.enabled=true",
+        "--set", "metrics.auth.existingSecret=tokenplace-metrics",
+        "--set", "serviceMonitor.enabled=true",
+    )
+    deploy = _deploy(docs)
+    container = deploy["spec"]["template"]["spec"]["containers"][0]
+    env = _env(deploy)
+
+    assert deploy["spec"]["replicas"] == 1
+    assert deploy["spec"]["strategy"]["type"] == "Recreate"
+    assert env["RELAY_WORKERS"]["value"] == "1"
+    assert env["RELAY_THREADS"]["value"] == "4"
+    assert not any(doc.get("kind") == "Ingress" and "/metrics" in str(doc) for doc in docs)
+    assert [port["name"] for port in container["ports"]] == ["http"]


### PR DESCRIPTION
### Motivation
- Provide a safe, opt-in Prometheus scrape contract for the canonical `charts/tokenplace` chart that preserves relay privacy and architecture invariants. 
- Avoid blindly porting legacy `deploy/charts/tokenplace-relay` monitoring scaffolding and use Prometheus Operator features supported by the pinned kube-prometheus-stack. 
- Ensure scrapes are authenticated via a Kubernetes Secret and prevent any public unauthenticated `/metrics` exposure.

### Description
- Add new, safe-disabled values and schema under `metrics` and `serviceMonitor` (defaults: `metrics.enabled=false`, `metrics.path=/metrics`, `metrics.auth.existingSecret=""`, `metrics.auth.secretKey=token`, `serviceMonitor.enabled=false`, `serviceMonitor.interval=30s`, `serviceMonitor.scrapeTimeout=10s`, `serviceMonitor.additionalLabels` and bounded `serviceMonitor.relabelings`). (files: `charts/tokenplace/values.yaml`, `charts/tokenplace/values.schema.json`)
- Inject `TOKENPLACE_METRICS_TOKEN` into the pod only when `metrics.enabled=true` using `valueFrom.secretKeyRef` (no plaintext token anywhere) and preserve existing one-replica, `Recreate`, one-worker relay constraints. (file: `charts/tokenplace/templates/deployment.yaml`)
- Render an opt-in `ServiceMonitor` only when `serviceMonitor.enabled=true`, select the canonical Service via selector labels, scrape the named `http` port at the configured path, and wire the bearer token using Prometheus Operator `authorization.credentials` (Secret name + key). Bounded relabelings for `app`, `environment`, `release`, and `cluster` are applied. (file: `charts/tokenplace/templates/servicemonitor.yaml`)
- Document usage and verification commands in `charts/tokenplace/README.md` and extend `docs/releases/v0.1.2.md` with the canonical scrape contract; add regression tests and a CI helm render check to validate the ServiceMonitor rendering. (files: `charts/tokenplace/README.md`, `docs/releases/v0.1.2.md`, `tests/test_tokenplace_chart_metrics.py`, `.github/workflows/ci-helm.yml`)

### Testing
- Ran `helm lint charts/tokenplace` which completed successfully. (pass)
- Rendered templates for disabled and enabled modes with `helm template tokenplace charts/tokenplace --namespace tokenplace` and `helm template ... --set metrics.enabled=true --set metrics.auth.existingSecret=tokenplace-metrics --set serviceMonitor.enabled=true` and verified the expected `ServiceMonitor`, `authorization.credentials`, selector, endpoints, and that no public `/metrics` ingress is added. (pass)
- Executed targeted pytest for the chart contract with `pytest -q tests/test_tokenplace_chart_metrics.py` and confirmed all tests passed (3 passed). (pass)
- Ran the repository unit test sweep and hooks with `pytest tests/unit -q --tb=short` and `pre-commit run --all-files` to verify no regressions; the test run completed successfully (full unit test suite passed in this environment) and pre-commit checks passed. (pass)

Files changed (not exhaustive): `charts/tokenplace/values.yaml`, `charts/tokenplace/values.schema.json`, `charts/tokenplace/templates/servicemonitor.yaml`, `charts/tokenplace/templates/deployment.yaml`, `charts/tokenplace/README.md`, `docs/releases/v0.1.2.md`, `tests/test_tokenplace_chart_metrics.py`, and a small CI helm workflow addition in `.github/workflows/ci-helm.yml`.

Notes and follow-ups: No plaintext tokens were added to the repo; the chart requires an existing Secret for Prometheus scraping in staging/production and documentation includes commands to verify internal scrape success and public denial. Recommend Sugarkube operators create the Secret in the release namespace and enable the toggle per environment when ready.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5448979eec832fa114399c80664884)