### PR TITLE
Add opt-in authenticated ServiceMonitor to canonical charts/tokenplace

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -185,6 +185,28 @@ jobs:
           grep -n 'else if and (eq $strategyType "Recreate") $existingHasRollingUpdate' charts/tokenplace/templates/deployment.yaml
           grep -n 'rollingUpdate: null' charts/tokenplace/templates/deployment.yaml
 
+      - name: Template authenticated metrics ServiceMonitor render check
+        run: |
+          helm template tokenplace charts/tokenplace \
+            --namespace tokenplace \
+            --set metrics.enabled=true \
+            --set metrics.auth.existingSecret=tokenplace-metrics \
+            --set serviceMonitor.enabled=true \
+            --set serviceMonitor.relabelings.environment=staging \
+            --set serviceMonitor.relabelings.release=v0.1.2 \
+            --set serviceMonitor.relabelings.cluster=sugarkube-staging > /tmp/tokenplace-render-metrics.yaml
+
+          grep -n "kind: ServiceMonitor" /tmp/tokenplace-render-metrics.yaml
+          grep -n "release: kube-prometheus-stack" /tmp/tokenplace-render-metrics.yaml
+          grep -n "port: http" /tmp/tokenplace-render-metrics.yaml
+          grep -n 'path: "/metrics"' /tmp/tokenplace-render-metrics.yaml
+          grep -n "bearerTokenSecret:" -A2 /tmp/tokenplace-render-metrics.yaml | grep -n 'name: "tokenplace-metrics"'
+          grep -n "name: TOKENPLACE_METRICS_TOKEN" -A5 /tmp/tokenplace-render-metrics.yaml | grep -n "secretKeyRef:"
+          ! grep -n "path: /metrics" /tmp/tokenplace-render-metrics.yaml
+          grep -n "replicas: 1" /tmp/tokenplace-render-metrics.yaml
+          grep -n "type: Recreate" /tmp/tokenplace-render-metrics.yaml
+          grep -n "name: RELAY_WORKERS" -A2 /tmp/tokenplace-render-metrics.yaml | grep -n 'value: "1"'
+
       - name: Capture chart metadata
         id: chart_meta
         run: |

--- a/charts/tokenplace/README.md
+++ b/charts/tokenplace/README.md
@@ -1,0 +1,82 @@
+# tokenplace Helm chart
+
+This is the canonical Sugarkube chart published by `.github/workflows/ci-helm.yml`
+as `oci://ghcr.io/futuroptimist/charts/tokenplace`.
+
+## Authenticated metrics scrape
+
+Metrics scraping is opt-in and internal-only by default. The chart does not create
+or route a public `/metrics` Ingress path. When metrics are enabled, the relay
+receives `TOKENPLACE_METRICS_TOKEN` from an existing Kubernetes Secret and denies
+unauthenticated `/metrics` requests.
+
+Create the token Secret in the token.place namespace:
+
+```sh
+kubectl -n tokenplace create secret generic tokenplace-metrics \
+  --from-literal=token='<random bearer token>'
+```
+
+Enable the scrape contract for the canonical Service and the Sugarkube
+kube-prometheus-stack discovery label:
+
+```sh
+helm upgrade --install tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace \
+  --namespace tokenplace --create-namespace \
+  --set metrics.enabled=true \
+  --set metrics.auth.existingSecret=tokenplace-metrics \
+  --set serviceMonitor.enabled=true \
+  --set serviceMonitor.additionalLabels.release=kube-prometheus-stack \
+  --set serviceMonitor.relabelings.environment=staging \
+  --set serviceMonitor.relabelings.release=v0.1.2 \
+  --set serviceMonitor.relabelings.cluster=sugarkube-staging
+```
+
+The ServiceMonitor selects the canonical `tokenplace` Service by its Helm selector
+labels and scrapes the named `http` port at `metrics.path` (`/metrics` by
+default). The bearer token is referenced with the Prometheus Operator
+`bearerTokenSecret` endpoint field so the token remains in a Kubernetes Secret;
+no plaintext token value belongs in chart values, rendered manifests, logs, or
+Git.
+
+### Verification commands
+
+Internal scrape success from the token.place namespace:
+
+```sh
+TOKEN="$(kubectl -n tokenplace get secret tokenplace-metrics -o jsonpath='{.data.token}' | base64 -d)"
+kubectl -n tokenplace run tokenplace-metrics-curl --rm -i --restart=Never \
+  --image=curlimages/curl:8.10.1 -- \
+  curl -fsS -H "Authorization: Bearer ${TOKEN}" \
+  http://tokenplace.tokenplace.svc.cluster.local/metrics >/tmp/tokenplace.metrics
+```
+
+Public denial when staging or production metrics are enabled:
+
+```sh
+curl -i https://staging.token.place/metrics | sed -n '1,5p'
+```
+
+The response must not be a successful Prometheus metrics response. A `401` from
+the relay or a public edge denial is acceptable; a public unauthenticated `200`
+with metrics is not acceptable.
+
+Release identity and target labels in Prometheus:
+
+```sh
+kubectl -n monitoring port-forward svc/kube-prometheus-stack-prometheus 9090:9090
+curl -fsS 'http://127.0.0.1:9090/api/v1/targets?state=active' \
+  | jq '.data.activeTargets[] | select(.labels.job | test("tokenplace")) | {scrapeUrl, labels, lastScrape, health}'
+curl -fsS 'http://127.0.0.1:9090/api/v1/query?query=up{app="tokenplace"}' | jq .
+```
+
+The discovered target should include the configured bounded labels: `app`,
+`environment`, `release`, and `cluster`.
+
+## Relay constraints
+
+Do not change observability by changing the relay architecture. The chart keeps
+one replica, one Gunicorn worker, `Recreate` rollout strategy, and the in-memory
+relay state model. Registrations, queues, in-flight requests, and replies are
+expected to be lost on pod restart until a future shared-state architecture is
+implemented.

--- a/charts/tokenplace/templates/deployment.yaml
+++ b/charts/tokenplace/templates/deployment.yaml
@@ -122,6 +122,10 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
+          {{- if .Values.metrics.enabled }}
+          {{- $metricsSecret := required "metrics.auth.existingSecret is required when metrics.enabled=true" .Values.metrics.auth.existingSecret }}
+          {{- $_ := set $mergedEnv "TOKENPLACE_METRICS_TOKEN" (dict "name" "TOKENPLACE_METRICS_TOKEN" "valueFrom" (dict "secretKeyRef" (dict "name" $metricsSecret "key" .Values.metrics.auth.secretKey))) }}
+          {{- end }}
           image: {{ include "tokenplace.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/tokenplace/templates/servicemonitor.yaml
+++ b/charts/tokenplace/templates/servicemonitor.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.serviceMonitor.enabled }}
+{{- $existingSecret := required "metrics.auth.existingSecret is required when serviceMonitor.enabled=true" .Values.metrics.auth.existingSecret }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "tokenplace.fullname" . }}
+  labels:
+    {{- include "tokenplace.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "tokenplace.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.metrics.path | quote }}
+      interval: {{ .Values.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | quote }}
+      bearerTokenSecret:
+        name: {{ $existingSecret | quote }}
+        key: {{ .Values.metrics.auth.secretKey | quote }}
+      relabelings:
+        - targetLabel: app
+          replacement: {{ .Values.serviceMonitor.relabelings.app | quote }}
+        - targetLabel: environment
+          replacement: {{ .Values.serviceMonitor.relabelings.environment | quote }}
+        - targetLabel: release
+          replacement: {{ .Values.serviceMonitor.relabelings.release | quote }}
+        - targetLabel: cluster
+          replacement: {{ .Values.serviceMonitor.relabelings.cluster | quote }}
+{{- end }}

--- a/charts/tokenplace/values.schema.json
+++ b/charts/tokenplace/values.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": { "type": "integer", "const": 1 },
+    "strategy": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "const": "Recreate" }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "path": { "type": "string", "default": "/metrics", "pattern": "^/[-A-Za-z0-9_./]*$" },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "existingSecret": { "type": "string", "default": "" },
+            "secretKey": { "type": "string", "default": "token", "minLength": 1 }
+          },
+          "required": ["existingSecret", "secretKey"]
+        }
+      },
+      "required": ["enabled", "path", "auth"]
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "interval": { "type": "string", "default": "30s" },
+        "scrapeTimeout": { "type": "string", "default": "10s" },
+        "additionalLabels": { "type": "object", "additionalProperties": { "type": "string" } },
+        "relabelings": {
+          "type": "object",
+          "properties": {
+            "app": { "type": "string" },
+            "environment": { "type": "string" },
+            "release": { "type": "string" },
+            "cluster": { "type": "string" }
+          },
+          "required": ["app", "environment", "release", "cluster"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["enabled", "interval", "scrapeTimeout", "additionalLabels", "relabelings"]
+    }
+  }
+}

--- a/charts/tokenplace/values.yaml
+++ b/charts/tokenplace/values.yaml
@@ -57,6 +57,27 @@ service:
   type: ClusterIP
   port: 80
 
+
+metrics:
+  enabled: false
+  path: /metrics
+  auth:
+    existingSecret: ""
+    secretKey: token
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  # Keep below interval so Prometheus can complete a scrape before the next one.
+  scrapeTimeout: 10s
+  additionalLabels:
+    release: kube-prometheus-stack
+  relabelings:
+    app: tokenplace
+    environment: dev
+    release: ""
+    cluster: ""
+
 ingress:
   enabled: false
   className: ""

--- a/docs/releases/v0.1.2.md
+++ b/docs/releases/v0.1.2.md
@@ -60,6 +60,55 @@ as part of this plan.
   dashboard variable, alert annotation, and log line touched by observability
   work.
 
+## Implemented canonical scrape contract
+
+- [ ] `charts/tokenplace` now owns an opt-in ServiceMonitor for Sugarkube. The
+  legacy `deploy/charts/tokenplace-relay` monitoring manifests remain historical
+  reference material and are not the release path.
+- [ ] Metrics remain disabled by default. Enabling staging or production metrics
+  requires an existing Kubernetes Secret, injects `TOKENPLACE_METRICS_TOKEN` via
+  `secretKeyRef`, and uses the Prometheus Operator `bearerTokenSecret` endpoint
+  field so Prometheus can scrape without placing plaintext tokens in values or
+  rendered manifests.
+- [ ] ServiceMonitor discovery defaults to the configurable
+  `release: kube-prometheus-stack` label used by Sugarkube, selects the canonical
+  token.place Service, and scrapes the named `http` port at `/metrics`.
+- [ ] The public Ingress remains the application `/` route only; `/metrics` is
+  not exposed as a separate public Ingress path. A public unauthenticated
+  `/metrics` request must be denied whenever staging or production metrics are
+  enabled.
+- [ ] Bounded target relabeling is limited to `app`, `environment`, `release`,
+  and `cluster`; do not add unbounded or user-controlled labels.
+- [ ] The release preserves one replica, one worker, `Recreate`, and in-memory
+  relay constraints. Observability must not disguise expected state loss on pod
+  replacement.
+
+### Canonical scrape verification commands
+
+```sh
+kubectl -n tokenplace create secret generic tokenplace-metrics \
+  --from-literal=token='<random bearer token>'
+helm upgrade --install tokenplace oci://ghcr.io/futuroptimist/charts/tokenplace \
+  --namespace tokenplace --create-namespace \
+  --set metrics.enabled=true \
+  --set metrics.auth.existingSecret=tokenplace-metrics \
+  --set serviceMonitor.enabled=true \
+  --set serviceMonitor.additionalLabels.release=kube-prometheus-stack \
+  --set serviceMonitor.relabelings.environment=staging \
+  --set serviceMonitor.relabelings.release=v0.1.2 \
+  --set serviceMonitor.relabelings.cluster=sugarkube-staging
+TOKEN="$(kubectl -n tokenplace get secret tokenplace-metrics -o jsonpath='{.data.token}' | base64 -d)"
+kubectl -n tokenplace run tokenplace-metrics-curl --rm -i --restart=Never \
+  --image=curlimages/curl:8.10.1 -- \
+  curl -fsS -H "Authorization: Bearer ${TOKEN}" \
+  http://tokenplace.tokenplace.svc.cluster.local/metrics >/tmp/tokenplace.metrics
+curl -i https://staging.token.place/metrics | sed -n '1,5p'
+kubectl -n monitoring port-forward svc/kube-prometheus-stack-prometheus 9090:9090
+curl -fsS 'http://127.0.0.1:9090/api/v1/targets?state=active' \
+  | jq '.data.activeTargets[] | select(.labels.job | test("tokenplace")) | {scrapeUrl, labels, lastScrape, health}'
+curl -fsS 'http://127.0.0.1:9090/api/v1/query?query=up{app="tokenplace"}' | jq .
+```
+
 ## v0.1.2 blockers
 
 ### Relay and API metrics contract

--- a/tests/unit/test_canonical_tokenplace_chart_metrics.py
+++ b/tests/unit/test_canonical_tokenplace_chart_metrics.py
@@ -1,0 +1,142 @@
+"""Guardrails for the canonical Sugarkube token.place metrics scrape contract."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+
+CHART_ROOT = Path("charts/tokenplace")
+
+
+def _render(*args: str) -> list[dict[str, Any]]:
+    helm = subprocess.run(
+        ["helm", "template", "tokenplace", str(CHART_ROOT), "--namespace", "tokenplace", *args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return [doc for doc in yaml.safe_load_all(helm.stdout) if doc]
+
+
+def _kind(docs: list[dict[str, Any]], kind: str) -> list[dict[str, Any]]:
+    return [doc for doc in docs if doc.get("kind") == kind]
+
+
+def test_metrics_and_service_monitor_defaults_are_disabled() -> None:
+    values = yaml.safe_load((CHART_ROOT / "values.yaml").read_text(encoding="utf-8"))
+    schema = json.loads((CHART_ROOT / "values.schema.json").read_text(encoding="utf-8"))
+    docs = _render()
+
+    assert values["metrics"]["enabled"] is False
+    assert values["metrics"]["path"] == "/metrics"
+    assert values["metrics"]["auth"]["existingSecret"] == ""
+    assert values["metrics"]["auth"]["secretKey"] == "token"
+    assert values["serviceMonitor"]["enabled"] is False
+    assert values["serviceMonitor"]["interval"] == "30s"
+    assert values["serviceMonitor"]["scrapeTimeout"] == "10s"
+    assert values["serviceMonitor"]["additionalLabels"]["release"] == "kube-prometheus-stack"
+    assert schema["properties"]["replicaCount"]["const"] == 1
+    assert not _kind(docs, "ServiceMonitor")
+    deployment = _kind(docs, "Deployment")[0]
+    env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
+    assert "TOKENPLACE_METRICS_TOKEN" not in {item["name"] for item in env}
+
+
+def test_enabled_service_monitor_selects_canonical_service_with_bearer_secret() -> None:
+    docs = _render(
+        "--set", "metrics.enabled=true",
+        "--set", "metrics.auth.existingSecret=tokenplace-metrics",
+        "--set", "serviceMonitor.enabled=true",
+        "--set", "serviceMonitor.relabelings.environment=staging",
+        "--set", "serviceMonitor.relabelings.release=v0.1.2",
+        "--set", "serviceMonitor.relabelings.cluster=sugarkube-pi",
+    )
+
+    service = _kind(docs, "Service")[0]
+    monitor = _kind(docs, "ServiceMonitor")[0]
+    deployment = _kind(docs, "Deployment")[0]
+
+    assert service["metadata"]["name"] == "tokenplace"
+    assert service["spec"]["ports"][0]["name"] == "http"
+    assert monitor["metadata"]["labels"]["release"] == "kube-prometheus-stack"
+    assert monitor["spec"]["namespaceSelector"] == {"matchNames": ["tokenplace"]}
+    assert monitor["spec"]["selector"] == {"matchLabels": service["spec"]["selector"]}
+    endpoint = monitor["spec"]["endpoints"][0]
+    assert endpoint["port"] == "http"
+    assert endpoint["path"] == "/metrics"
+    assert endpoint["interval"] == "30s"
+    assert endpoint["scrapeTimeout"] == "10s"
+    assert endpoint["bearerTokenSecret"] == {"name": "tokenplace-metrics", "key": "token"}
+
+    env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
+    metrics_env = next(item for item in env if item["name"] == "TOKENPLACE_METRICS_TOKEN")
+    assert metrics_env["valueFrom"]["secretKeyRef"] == {"name": "tokenplace-metrics", "key": "token"}
+
+
+def test_service_monitor_release_label_and_bounded_relabeling_are_configurable() -> None:
+    docs = _render(
+        "--set", "metrics.auth.existingSecret=tokenplace-metrics",
+        "--set", "metrics.auth.secretKey=bearer",
+        "--set", "serviceMonitor.enabled=true",
+        "--set", "serviceMonitor.additionalLabels.release=observability",
+        "--set", "serviceMonitor.relabelings.app=tokenplace-relay",
+        "--set", "serviceMonitor.relabelings.environment=prod",
+        "--set", "serviceMonitor.relabelings.release=v0.1.2",
+        "--set", "serviceMonitor.relabelings.cluster=sugarkube-prod",
+    )
+    monitor = _kind(docs, "ServiceMonitor")[0]
+
+    assert monitor["metadata"]["labels"]["release"] == "observability"
+    endpoint = monitor["spec"]["endpoints"][0]
+    assert endpoint["bearerTokenSecret"] == {"name": "tokenplace-metrics", "key": "bearer"}
+    assert endpoint["relabelings"] == [
+        {"targetLabel": "app", "replacement": "tokenplace-relay"},
+        {"targetLabel": "environment", "replacement": "prod"},
+        {"targetLabel": "release", "replacement": "v0.1.2"},
+        {"targetLabel": "cluster", "replacement": "sugarkube-prod"},
+    ]
+
+
+def test_no_public_metrics_ingress_and_relay_constraints_are_preserved() -> None:
+    docs = _render(
+        "--set", "metrics.enabled=true",
+        "--set", "metrics.auth.existingSecret=tokenplace-metrics",
+        "--set", "serviceMonitor.enabled=true",
+        "--set", "ingress.enabled=true",
+        "--set", "ingress.host=staging.token.place",
+    )
+    ingress = _kind(docs, "Ingress")[0]
+    deployment = _kind(docs, "Deployment")[0]
+
+    paths = ingress["spec"]["rules"][0]["http"]["paths"]
+    assert paths == [{
+        "path": "/",
+        "pathType": "Prefix",
+        "backend": {"service": {"name": "tokenplace", "port": {"name": "http"}}},
+    }]
+    assert all(path["path"] != "/metrics" for path in paths)
+    assert deployment["spec"]["replicas"] == 1
+    assert deployment["spec"]["strategy"]["type"] == "Recreate"
+    env = deployment["spec"]["template"]["spec"]["containers"][0]["env"]
+    values = {item["name"]: item.get("value") for item in env}
+    assert values["RELAY_WORKERS"] == "1"
+    assert values["TOKENPLACE_RELAY_INTERNAL_URL"] == "http://127.0.0.1:$(RELAY_PORT)"
+
+
+def test_service_monitor_requires_existing_secret_without_plaintext_token() -> None:
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        _render("--set", "serviceMonitor.enabled=true")
+
+    assert "metrics.auth.existingSecret is required" in excinfo.value.stderr
+    chart_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in [CHART_ROOT / "values.yaml", CHART_ROOT / "templates" / "servicemonitor.yaml"]
+    )
+    assert "tokenplace-metrics-token-value" not in chart_text
+    assert "bearerTokenSecret" in chart_text


### PR DESCRIPTION
### Motivation
- Provide an opt-in, authenticated Prometheus scrape contract for the canonical `charts/tokenplace` chart while preserving existing relay runtime constraints and avoiding blind port of legacy `deploy/charts/tokenplace-relay` monitoring resources. 
- Ensure scrapes are internal-only by default and wire the bearer token via Kubernetes Secrets (no plaintext tokens in values, manifests, or Git). 
- Make the ServiceMonitor discovery compatible with the pinned Sugarkube `kube-prometheus-stack` selector model and expose bounded relabel labels for safe operator metadata. 

### Description
- Add safe chart values and defaults in `charts/tokenplace/values.yaml` for `metrics` (disabled, `path: /metrics`, `auth.existingSecret`, `auth.secretKey`) and `serviceMonitor` (disabled, `interval: 30s`, `scrapeTimeout: 10s`, `additionalLabels`, `relabelings`).
- Inject `TOKENPLACE_METRICS_TOKEN` into the pod only when `metrics.enabled=true` using a `valueFrom.secretKeyRef` referencing the configured `metrics.auth.existingSecret` and `metrics.auth.secretKey` in `charts/tokenplace/templates/deployment.yaml`.
- Render a `ServiceMonitor` template at `charts/tokenplace/templates/servicemonitor.yaml` only when `serviceMonitor.enabled=true`, selecting the canonical `tokenplace` Service by Helm selector labels, scraping the named `http` port and configured path, wiring the token via the Prometheus Operator `bearerTokenSecret` field, and applying bounded relabelings for `app`, `environment`, `release`, and `cluster`.
- Add JSON schema guardrails at `charts/tokenplace/values.schema.json` including `replicaCount: 1`, `strategy.type: Recreate`, typed `metrics` and `serviceMonitor` properties, and required relabeling fields to prevent unbounded labels.
- Document the canonical authenticated scrape workflow in `charts/tokenplace/README.md` and update release notes in `docs/releases/v0.1.2.md` with verification commands and invariants prohibiting public `/metrics` ingress and preserving single-replica constraints.
- Extend the Helm publish CI smoke checks in `.github/workflows/ci-helm.yml` and add unit tests in `tests/unit/test_canonical_tokenplace_chart_metrics.py` that assert disabled defaults, ServiceMonitor rendering, selector/secret/label/relabel behavior, no public `/metrics` Ingress, and preserved relay constraints.

Files changed/added: `charts/tokenplace/values.yaml`, `charts/tokenplace/templates/deployment.yaml`, `charts/tokenplace/templates/servicemonitor.yaml` (new), `charts/tokenplace/values.schema.json` (new), `charts/tokenplace/README.md` (new), `docs/releases/v0.1.2.md`, `.github/workflows/ci-helm.yml`, `tests/unit/test_canonical_tokenplace_chart_metrics.py` (new).

### Testing
- Ran `helm lint charts/tokenplace` and the chart lint passed (info-only about icon). (command: `helm lint charts/tokenplace`) — PASSED.
- Rendered templates for default and enabled configurations with `helm template` to inspect generated manifests and saved outputs to `/tmp/tp-disabled.yaml` and `/tmp/tp-enabled.yaml` for review. (commands: `helm template tokenplace charts/tokenplace --namespace tokenplace >/tmp/tp-disabled.yaml` and `helm template tokenplace charts/tokenplace --namespace tokenplace --set metrics.enabled=true --set metrics.auth.existingSecret=tokenplace-metrics --set serviceMonitor.enabled=true --set serviceMonitor.relabelings.environment=staging --set serviceMonitor.relabelings.release=v0.1.2 --set serviceMonitor.relabelings.cluster=sugarkube-staging >/tmp/tp-enabled.yaml`) — Renders completed without error and contain expected ServiceMonitor and env wiring when enabled.
- Executed unit tests covering the new scrape contract and existing CI sentinel tests with `pytest -q tests/unit/test_canonical_tokenplace_chart_metrics.py tests/unit/test_workflow_ci_sentinel.py`, which returned all tests passed. (command: `pytest -q tests/unit/test_canonical_tokenplace_chart_metrics.py tests/unit/test_workflow_ci_sentinel.py`) — PASSED (29 tests total in the final run, including the new tests).
- Ran project pre-commit checks: `pre-commit run --all-files`, which completed successfully after installing verification dependencies used by the project checks. (command: `pre-commit run --all-files`) — PASSED.

Commands used during verification (representative):
- `helm lint charts/tokenplace`
- `helm template tokenplace charts/tokenplace --namespace tokenplace >/tmp/tp-disabled.yaml`
- `helm template tokenplace charts/tokenplace --namespace tokenplace --set metrics.enabled=true --set metrics.auth.existingSecret=tokenplace-metrics --set serviceMonitor.enabled=true --set serviceMonitor.relabelings.environment=staging --set serviceMonitor.relabelings.release=v0.1.2 --set serviceMonitor.relabelings.cluster=sugarkube-staging >/tmp/tp-enabled.yaml`
- `pytest -q tests/unit/test_canonical_tokenplace_chart_metrics.py tests/unit/test_workflow_ci_sentinel.py`
- `pre-commit run --all-files`

All automated checks above passed in the local verification run; CI workflow smoke step for authenticated metrics was also added to ensure chart packaging and rendering continue to be validated by the canonical publication workflow. Residual risks/follow-ups: verify Prometheus scraping end-to-end in a Sugarkube cluster (the README includes commands to create the Secret, enable the chart, and confirm internal scrape and public denial), and ensure platform Prometheus has permission to read the referenced Secret in the target namespace per Sugarkube RBAC conventions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5448aca368832f940a75a122b3863d)