### PR TITLE
Preserve llama.cpp init categories and restore Qwen64K CUDA profile recovery

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -22,6 +22,7 @@ on:
       - 'desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py'
       - 'desktop-tauri/scripts/run_desktop_parity_checks.py'
       - 'tests/unit/test_model_manager.py'
+      - 'tests/integration/test_desktop_qwen64k_packaged_runtime.py'
       - 'utils/**'
       - 'config.py'
       - 'encrypt.py'
@@ -42,6 +43,7 @@ on:
       - 'desktop-tauri/scripts/test_desktop_relay_operator_parity_e2e.py'
       - 'desktop-tauri/scripts/run_desktop_parity_checks.py'
       - 'tests/unit/test_model_manager.py'
+      - 'tests/integration/test_desktop_qwen64k_packaged_runtime.py'
       - 'utils/**'
       - 'config.py'
       - 'encrypt.py'
@@ -150,6 +152,7 @@ jobs:
         run: |
           python -m pytest tests/unit/test_desktop_runtime_setup.py -q
           python -m pytest tests/unit/test_model_manager.py -q
+          python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q
           cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml operator_logs
 
       - name: Upload desktop relay parity logs on failure (Windows)

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -8874,3 +8874,146 @@ def test_legacy_flat_desktop_probe_exported_enum_without_value_fails_closed(monk
     assert 'yarn_enum_value' in diagnostics['missing_required_kwargs']
     assert diagnostics['child_probe_reprobe_attempted'] is False
     assert diagnostics['child_probe_reprobe_skipped_reason'] == 'desktop_probe_incomplete_fail_closed'
+
+def test_child_cuda_allocation_category_survives_empty_stderr_and_retries_q8(tmp_path):
+    from utils.context_profiles import apply_context_profile
+    from utils.llm import model_manager as model_manager_module
+
+    attempts = []
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': -1,
+        'model.gpu_mode': 'gpu',
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    class FakeLlama:
+        def __init__(self, **kwargs):
+            attempts.append(dict(kwargs))
+            if 'type_k' not in kwargs:
+                raise model_manager_module.LlamaCppInitializationError(
+                    'llama_cpp_import failed; child_exception_type=RuntimeError; safe_error_category=runtime_context_create_cuda_memory',
+                    safe_error_category='runtime_context_create_cuda_memory',
+                    child_exception_type='RuntimeError',
+                    child_stderr_tail='',
+                )
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+            return '<qwen>'
+
+    fake_llama_cpp = SimpleNamespace(
+        Llama=FakeLlama,
+        LLAMA_ROPE_SCALING_TYPE_YARN=2,
+        GGML_TYPE_Q8_0=8,
+        __file__='/opt/token.place/llama_cpp/__init__.py',
+        __version__='0.3.32',
+    )
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama_cpp), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'cuda', 'gpu_offload_supported': True, 'error': None}):
+        assert manager.get_llm_instance() is not None
+
+    assert len(attempts) == 2
+    assert 'type_k' not in attempts[0]
+    assert attempts[1]['type_k'] == 8
+    assert manager.last_qwen_64k_init_failures[0]['safe_error_category'] == 'runtime_context_create_cuda_memory'
+
+
+def test_bare_cublas_alloc_failed_classifies_as_cuda_memory_without_cuda_word():
+    from utils.llm import model_manager as model_manager_module
+
+    assert model_manager_module._classify_runtime_context_create_error(
+        RuntimeError('CUBLAS_STATUS_ALLOC_FAILED')
+    ) == 'runtime_context_create_cuda_memory'
+
+
+def test_unknown_child_init_category_is_rejected():
+    from io import StringIO
+    from utils.llm import model_manager as model_manager_module
+
+    process = SimpleNamespace(
+        stdout=StringIO(
+            'TOKEN_PLACE_LLAMA_CPP_JSON:'
+            '{"status":"error","error":"Failed to create llama_context",'
+            '"exception_type":"RuntimeError","safe_error_category":"runtime_context_create_cuda_memory;prompt=SECRET"}\n'
+        )
+    )
+
+    with pytest.raises(model_manager_module.LlamaCppInitializationError) as exc_info:
+        model_manager_module._read_llama_subprocess_message(process, timeout_seconds=5, stage='llama_cpp_import')
+
+    assert exc_info.value.safe_error_category == 'runtime_context_create_failed'
+    assert 'SECRET' not in str(exc_info.value)
+
+
+def test_generic_context_create_sentinel_gets_bounded_qwen64k_profile_attempts(tmp_path):
+    from utils.context_profiles import apply_context_profile
+
+    attempts = []
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': -1,
+        'model.gpu_mode': 'gpu',
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    class FakeLlama:
+        def __init__(self, **kwargs):
+            attempts.append(dict(kwargs))
+            if len(attempts) < 3:
+                raise ValueError('Failed to create llama_context')
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+            return '<qwen>'
+
+    fake_llama_cpp = SimpleNamespace(
+        Llama=FakeLlama,
+        LLAMA_ROPE_SCALING_TYPE_YARN=2,
+        GGML_TYPE_Q8_0=8,
+        GGML_TYPE_Q4_0=2,
+        __file__='/opt/token.place/llama_cpp/__init__.py',
+        __version__='0.3.32',
+    )
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama_cpp), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'cuda', 'gpu_offload_supported': True, 'error': None}):
+        assert manager.get_llm_instance() is not None
+
+    assert len(attempts) == 3
+    assert manager.last_compute_diagnostics['qwen_64k_memory_profile']['profile_id'] == 'qwen64k_kv_q4_fa_small_batch'
+    assert [failure['safe_error_category'] for failure in manager.last_qwen_64k_init_failures] == [
+        'runtime_context_create_failed',
+        'runtime_context_create_failed',
+    ]
+
+
+def test_drained_cuda_stderr_refines_generic_context_create_category():
+    from utils.llm import model_manager as model_manager_module
+
+    exc = model_manager_module.LlamaCppInitializationError(
+        'llama_cpp_import failed; child_exception_type=ValueError; safe_error_category=runtime_context_create_failed',
+        safe_error_category='runtime_context_create_failed',
+        child_exception_type='ValueError',
+        child_stderr_tail='',
+    )
+
+    assert model_manager_module._init_error_category(
+        exc,
+        'ggml_cuda: cudaMalloc failed: CUBLAS_STATUS_ALLOC_FAILED',
+    ) == 'runtime_context_create_cuda_memory'

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -67,6 +67,53 @@ QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES = {
     'runtime_context_create_cuda_memory',
     'runtime_context_create_cuda_buffer_limit',
 }
+_INIT_CHILD_CATEGORY_MAP = {
+    'cuda_memory_allocation': 'runtime_context_create_cuda_memory',
+    'metal_memory_allocation': 'runtime_context_create_metal_memory',
+    'kv_cache_allocation': 'runtime_context_create_kv_cache_allocation',
+    'rope_yarn_eval_failure': 'runtime_context_create_rope_yarn_config',
+}
+_INIT_CANONICAL_CATEGORY_ALLOWLIST = set(QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES).union({
+    'runtime_context_create_unsupported_kwarg',
+    'runtime_context_create_rope_yarn_config',
+    'runtime_context_create_failed',
+    'runtime_init_unclassified',
+})
+
+
+class LlamaCppInitializationError(RuntimeError):
+    def __init__(self, message: str, *, safe_error_category: str, child_exception_type: str = 'RuntimeError', child_stderr_tail: str = '') -> None:
+        category = _canonical_init_safe_category(safe_error_category) or 'runtime_init_unclassified'
+        self.safe_error_category = category
+        self.child_exception_type = _safe_child_exception_type(child_exception_type)
+        self.child_stderr_tail = _sanitize_child_diagnostic_text(child_stderr_tail)
+        super().__init__(message)
+
+
+def _safe_child_exception_type(value: Any) -> str:
+    text = str(value or 'RuntimeError').strip()
+    return text if re.fullmatch(r'[A-Za-z_][A-Za-z0-9_]{0,80}', text) else 'RuntimeError'
+
+
+def _canonical_init_safe_category(value: Any) -> Optional[str]:
+    text = str(value or '').strip()
+    mapped = _INIT_CHILD_CATEGORY_MAP.get(text, text)
+    return mapped if mapped in _INIT_CANONICAL_CATEGORY_ALLOWLIST else None
+
+
+def _init_error_category(error: Any, child_stderr: str = '') -> str:
+    if isinstance(error, LlamaCppInitializationError):
+        category = error.safe_error_category
+        refined = _classify_runtime_context_create_error('', child_stderr or error.child_stderr_tail)
+        if category == 'runtime_context_create_failed' and refined in QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES:
+            return refined
+        return category
+    return _classify_runtime_context_create_error(error, child_stderr)
+
+
+def _qwen_64k_pre_registration_retryable_init_category(category: str) -> bool:
+    return category in QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES or category == 'runtime_context_create_failed'
+
 
 CRITICAL_STDLIB_IMPORT_MODULES = (
     'collections',
@@ -425,7 +472,15 @@ def _classify_runtime_context_create_error(error: Any, child_stderr: str = '') -
         return 'runtime_context_create_metal_buffer_limit'
     if 'metal' in text and any(term in text for term in ('alloc', 'memory', 'oom', 'out of memory', 'failed to create llama_context')):
         return 'runtime_context_create_metal_memory'
-    if 'cuda' in text and any(term in text for term in ('out of memory', 'oom', 'cudamalloc', 'alloc failed', 'allocation failed', 'cublas')):
+    cuda_memory_markers = (
+        'cublas_status_alloc_failed', 'cublas alloc', 'cudamalloc', 'cuda malloc',
+        'cuda out of memory', 'cuda error: out of memory', 'cuda oom',
+    )
+    if (
+        any(term in text for term in cuda_memory_markers)
+        or ('cuda' in text and any(term in text for term in ('out of memory', 'oom', 'alloc failed', 'allocation failed', 'failed to allocate')))
+        or ('ggml_cuda' in text and any(term in text for term in ('alloc', 'memory', 'oom', 'buffer')))
+    ):
         return 'runtime_context_create_cuda_memory'
     if 'cuda' in text and any(term in text for term in ('buffer', 'resource', 'allocation')):
         return 'runtime_context_create_cuda_buffer_limit'
@@ -636,7 +691,7 @@ def _classify_safe_metal_backend_failure(lines: Iterable[str]) -> Dict[str, Any]
     return diagnostics
 
 def _safe_parent_exception_message(error: Any, *, child_stderr: str = '') -> str:
-    category = _classify_runtime_context_create_error(error, child_stderr)
+    category = _init_error_category(error, child_stderr)
     return (
         f"{type(error).__name__ if isinstance(error, BaseException) else 'RuntimeError'}; "
         f"safe_error_category={category}"
@@ -1674,14 +1729,25 @@ def _read_llama_subprocess_message(
             diagnostics = message.get('diagnostics')
             safe_diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
             raise LlamaCppInferenceRequestError(error, diagnostics=safe_diagnostics)
-        category = _classify_runtime_context_create_error(raw_error, str(message.get('stderr') or ''))
-        error = f'{stage} failed; child_exception_type={message.get("exception_type") or "RuntimeError"}; safe_error_category={category}'
+        stderr_tail = _sanitize_child_diagnostic_text(message.get('stderr') or '')
+        child_category = _canonical_init_safe_category(message.get('safe_error_category'))
+        classified_category = _classify_runtime_context_create_error(raw_error, stderr_tail)
+        category = child_category or classified_category
+        if category == 'runtime_context_create_failed' and classified_category in QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES:
+            category = classified_category
+        child_exception_type = _safe_child_exception_type(message.get('exception_type') or 'RuntimeError')
+        error = f'{stage} failed; child_exception_type={child_exception_type}; safe_error_category={category}'
         traceback_text = str(message.get('traceback') or '').strip()
         if traceback_text:
             safe_tail = _sanitize_child_diagnostic_text(traceback_text)
             if safe_tail:
                 error = f"{error}; child_traceback_tail={safe_tail}"
-        raise RuntimeError(error)
+        raise LlamaCppInitializationError(
+            error,
+            safe_error_category=category,
+            child_exception_type=child_exception_type,
+            child_stderr_tail=stderr_tail,
+        )
     return message
 
 
@@ -1783,16 +1849,21 @@ class _SubprocessLlamaProxy:
             self.close()
             raise
         except Exception as exc:
+            self._drain_stderr_tail()
             stderr_tail = _sanitize_child_diagnostic_text(_llama_subprocess_tail(self._process, '_token_place_stderr_tail'))
-            category = _classify_runtime_context_create_error(exc, stderr_tail)
+            category = _init_error_category(exc, stderr_tail)
             if isinstance(exc, LlamaCppWorkerEOFError):
                 safe_exc = _format_llama_subprocess_early_exit_detail(self._process, stage='llama_cpp_import')
             else:
                 safe_exc = _safe_parent_exception_message(exc, child_stderr=stderr_tail)
             self.close()
-            raise RuntimeError(
-                f"{safe_exc}; child_exception_type={type(exc).__name__}; "
-                f"safe_error_category={category}; child_stderr_tail={stderr_tail or '<empty>'}"
+            child_exception_type = getattr(exc, 'child_exception_type', type(exc).__name__)
+            raise LlamaCppInitializationError(
+                f"{safe_exc}; child_exception_type={child_exception_type}; "
+                f"safe_error_category={category}; child_stderr_tail={stderr_tail or '<empty>'}",
+                safe_error_category=category,
+                child_exception_type=child_exception_type,
+                child_stderr_tail=stderr_tail,
             ) from exc
 
     def _start_stderr_tail_reader(self) -> None:
@@ -1808,7 +1879,14 @@ class _SubprocessLlamaProxy:
                     tail.append((seq, line))
                     del tail[:-100]
 
-        threading.Thread(target=_reader, name='llama_cpp_stderr_reader', daemon=True).start()
+        self._stderr_reader_thread = threading.Thread(target=_reader, name='llama_cpp_stderr_reader', daemon=True)
+        self._stderr_reader_thread.start()
+
+    def _drain_stderr_tail(self, timeout: float = 0.25) -> None:
+        thread = getattr(self, '_stderr_reader_thread', None)
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=timeout)
+        time.sleep(0.05)
 
     def _stderr_cursor(self) -> int:
         return int(getattr(self._process, '_token_place_stderr_sequence', 0) or 0)
@@ -4765,7 +4843,7 @@ class ModelManager:
                                         self.last_qwen_64k_memory_profile_diagnostics = profile_diag
                                     break
                                 except Exception as init_exc:
-                                    category = _classify_runtime_context_create_error(init_exc)
+                                    category = _init_error_category(init_exc)
                                     safe_failure = {
                                         'profile_id': profile_id,
                                         'model_profile_id': self.profile_id,
@@ -4796,7 +4874,8 @@ class ModelManager:
                                         },
                                     }
                                     profile_failures.append(safe_failure)
-                                    if not is_qwen_64k or category not in QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES:
+                                    self.last_qwen_64k_init_failures = profile_failures
+                                    if not is_qwen_64k or not _qwen_64k_pre_registration_retryable_init_category(category):
                                         raise
                                     close = getattr(init_exc, 'close', None)
                                     if callable(close):


### PR DESCRIPTION
### Motivation

- Qwen3 64K startup on Windows with pinned `llama-cpp-python==0.3.32` lost child-init failure taxonomy when errors were wrapped, preventing the F16 → Q8 → Q4 KV-cache recovery loop from running.
- The subprocess stderr reader and error-wrapping logic needed to preserve canonical safe categories, drain delayed native stderr evidence, and persist profile failures so diagnostics and bounded retries behave correctly.

### Description

- Added a typed internal exception `LlamaCppInitializationError` carrying a canonical `safe_error_category`, sanitized `child_exception_type`, and sanitized `child_stderr_tail`, and a strict mapping/allowlist that canonicalizes validated child categories (e.g. `cuda_memory_allocation` → `runtime_context_create_cuda_memory`). (modified: `utils/llm/model_manager.py`)
- Improved CUDA/context-create classification to catch bare CUBLAS alloc failures, `cudaMalloc` markers, ggml_cuda allocation/buffer failures, and other CUDA OOM evidence so CUDA allocation failures are recognized even when the literal word "cuda" is absent. (modified: `utils/llm/model_manager.py`)
- Preserve child-provided canonical categories from the subprocess JSON handshake, sanitize stderr/traceback tails, and raise the new `LlamaCppInitializationError` instead of a plain `RuntimeError`, so parent wrappers cannot downgrade already-validated categories. (modified: `utils/llm/model_manager.py`)
- Track the stderr-reader thread and perform a bounded drain/join before final classification and cleanup when an init handshake fails, allowing delayed native diagnostics to refine generic context-create failures but never to downgrade a more specific category. (modified: `utils/llm/model_manager.py`)
- Ensure Qwen 64K profile loop persists every safe profile failure before rethrowing and only treats the generic `runtime_context_create_failed` sentinel as a bounded pre-registration retry for the Qwen 64K profile sequence (at most three profiles), preserving the original profile order and settings. (modified: `utils/llm/model_manager.py`)
- Added deterministic unit tests covering preserved empty-stderr CUDA category propagation, CUBLAS classification, rejection of spoofed child categories, bounded generic sentinel Qwen64K retries, and stderr-driven refinement. (modified: `tests/unit/test_model_manager.py`)
- Included the packaged Qwen64K packaged-runtime integration suite in the Windows desktop operator e2e job (fakes only) so the regression remains covered by CI. (modified: `.github/workflows/desktop-operator-e2e.yml`)

### Testing

Commands run and results (all executed locally in the repository):

- `python -m pip install -r config/requirements_codex_verification.txt` — OK (dependencies installed)
- `python -m pytest tests/unit/test_model_manager.py -q` — PASSED (all unit tests in that file passed)
- `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q` — PASSED (integration packaged-runtime fakes passed)
- `python -m pytest tests/unit/test_compute_node_runtime.py tests/unit/test_desktop_compute_node_bridge.py -q` — PASSED
- `python -m pytest tests/unit/test_relay_client.py::test_qwen_context_admission_preserves_messages_without_no_think_injection tests/unit/test_relay_client.py::test_api_v1_qwen_paths_never_send_enable_thinking_true tests/unit/test_relay_client.py::test_api_v1_qwen_thinking_output_is_rejected_with_safe_reason tests/unit/test_api_v1_models_catalog_minimal.py tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` — PASSED
- `python -m pytest tests/unit/test_desktop_python_pep604_runtime_alias_guard.py::test_desktop_packaged_import_graph_has_no_runtime_pep604_type_alias_assignments -q` — PASSED (guard against PEP604 runtime aliases)
- `python -m pytest tests/unit/test_model_manager.py::test_child_cuda_allocation_category_survives_empty_stderr_and_retries_q8 tests/unit/test_model_manager.py::test_bare_cublas_alloc_failed_classifies_as_cuda_memory_without_cuda_word tests/unit/test_model_manager.py::test_unknown_child_init_category_is_rejected tests/unit/test_model_manager.py::test_generic_context_create_sentinel_gets_bounded_qwen64k_profile_attempts -q` — PASSED (new targeted unit cases)
- `pre-commit run --all-files` — PASSED (project checks and hooks)
- `git diff --check` — OK (no whitespace/path issues)

All automated tests and project checks that were run locally passed.

If additional hardware-level Windows CUDA verification is desired, run the CI Windows job (which now includes the packaged Qwen64K packaged-runtime tests) on a runner with the focused fake runtime; the changes were implemented to be safe with the pinned `llama-cpp-python==0.3.32` runtime and rely on sanitized stderr evidence rather than changing upstream pins.

Residual notes and scope

- The change preserves existing safety allowlists and redaction rules and does not expose child tracebacks, commands, env values, model paths, prompts, ciphertext/plaintext, or secrets.
- No changes to model defaults, `n_ctx`, `n_gpu_layers`, API v1 behaviors, E2EE, or runtime pinning were made beyond the error-classification/retry logic and tests described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5497a6b230832f92286c1342460d05)