### PR TITLE
Preserve subprocess init failure categories and Qwen64K CUDA profile recovery

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -150,6 +150,7 @@ jobs:
         run: |
           python -m pytest tests/unit/test_desktop_runtime_setup.py -q
           python -m pytest tests/unit/test_model_manager.py -q
+          python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q
           cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml operator_logs
 
       - name: Upload desktop relay parity logs on failure (Windows)

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -7185,6 +7185,58 @@ def test_qwen_64k_context_create_failure_retries_q8_profile(tmp_path):
     assert manager.last_qwen_64k_init_failures[0]['safe_error_category'] == 'runtime_context_create_kv_cache_allocation'
 
 
+def test_qwen_64k_bare_context_create_sentinel_gets_bounded_three_profile_attempts(tmp_path):
+    from utils.context_profiles import apply_context_profile
+
+    attempts = []
+    config = MagicMock(is_production=False)
+    values = {
+        'model.profile_id': 'qwen3-8b-q4-k-m',
+        'model.context_size': 8192,
+        'model.use_mock': False,
+        'model.n_gpu_layers': -1,
+        'model.gpu_mode': 'gpu',
+        'model.enforce_gpu_memory_headroom': False,
+        'paths.models_dir': str(tmp_path),
+    }
+    config.get.side_effect = lambda key, default=None: values.get(key, default)
+    config.set.side_effect = lambda key, value: values.__setitem__(key, value)
+    manager = ModelManager(config)
+    apply_context_profile(manager, '64k-full')
+    Path(manager.model_path).write_text('fake')
+
+    class FakeLlama:
+        def __init__(self, **kwargs):
+            attempts.append(dict(kwargs))
+            if len(attempts) < 3:
+                raise ValueError('Failed to create llama_context')
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True, enable_thinking=False):
+            return '<qwen>'
+
+    fake_llama_cpp = SimpleNamespace(
+        Llama=FakeLlama,
+        LLAMA_ROPE_SCALING_TYPE_YARN=2,
+        GGML_TYPE_Q8_0=8,
+        GGML_TYPE_Q4_0=2,
+        __file__='/opt/token.place/llama_cpp/__init__.py',
+        __version__='0.3.32',
+    )
+    with patch('utils.llm.model_manager._import_llama_cpp_runtime', return_value=fake_llama_cpp), \
+         patch.object(manager, '_runtime_capabilities', return_value={'backend': 'cuda', 'gpu_offload_supported': True, 'error': None}):
+        llm = manager.get_llm_instance()
+
+    assert llm is not None
+    assert len(attempts) == 3
+    assert attempts[0]['n_ctx'] == 65536
+    assert attempts[1]['type_k'] == 8
+    assert attempts[2]['type_k'] == 2
+    assert manager.last_compute_diagnostics['qwen_64k_runtime_profile_id'] == 'qwen64k_kv_q4_fa_small_batch'
+    assert [item['safe_error_category'] for item in manager.last_qwen_64k_init_failures] == [
+        'runtime_context_create_failed',
+        'runtime_context_create_failed',
+    ]
+
 def test_qwen_64k_all_profiles_fail_closed_before_registration(tmp_path):
     from utils.context_profiles import apply_context_profile
 
@@ -8874,3 +8926,71 @@ def test_legacy_flat_desktop_probe_exported_enum_without_value_fails_closed(monk
     assert 'yarn_enum_value' in diagnostics['missing_required_kwargs']
     assert diagnostics['child_probe_reprobe_attempted'] is False
     assert diagnostics['child_probe_reprobe_skipped_reason'] == 'desktop_probe_incomplete_fail_closed'
+
+
+def test_subprocess_init_error_preserves_child_cuda_category_with_empty_stderr():
+    from utils.llm import model_manager as model_manager_module
+
+    class FakeProcess:
+        _token_place_stderr_tail = []
+
+    message = {
+        'status': 'error',
+        'error': 'Failed to create llama_context',
+        'exception_type': 'RuntimeError',
+        'safe_error_category': 'cuda_memory_allocation',
+    }
+    process = FakeProcess()
+    process.stdout = iter(['TOKEN_PLACE_LLAMA_CPP_JSON:' + json.dumps(message) + '\n'])
+    with pytest.raises(model_manager_module.LlamaCppInitializationError) as raised:
+        model_manager_module._read_llama_subprocess_message(process, timeout_seconds=1, stage='llama_cpp_import')
+
+    assert raised.value.safe_error_category == 'runtime_context_create_cuda_memory'
+    assert 'safe_error_category=runtime_context_create_cuda_memory' in str(raised.value)
+
+
+def test_cuda_alloc_failed_without_cuda_word_is_runtime_cuda_memory():
+    from utils.llm import model_manager as model_manager_module
+
+    assert model_manager_module._classify_runtime_context_create_error(
+        RuntimeError('CUBLAS_STATUS_ALLOC_FAILED')
+    ) == 'runtime_context_create_cuda_memory'
+
+
+def test_runtime_init_category_refines_generic_context_create_with_drained_cuda_stderr():
+    from utils.llm import model_manager as model_manager_module
+
+    exc = model_manager_module.LlamaCppInitializationError(
+        'llama_cpp_import failed; safe_error_category=runtime_context_create_failed',
+        safe_error_category='runtime_context_create_failed',
+        child_exception_type='ValueError',
+    )
+    category = model_manager_module._runtime_init_category_from_exception(
+        exc,
+        'ggml_cuda: cudaMalloc failed while allocating KV cache buffer',
+    )
+
+    assert category == 'runtime_context_create_kv_cache_allocation'
+
+
+def test_unknown_child_init_category_is_rejected():
+    from utils.llm import model_manager as model_manager_module
+
+    class FakeProcess:
+        pass
+
+    process = FakeProcess()
+    process.stdout = iter([
+        'TOKEN_PLACE_LLAMA_CPP_JSON:' + json.dumps({
+            'status': 'error',
+            'error': 'Failed to create llama_context',
+            'exception_type': 'RuntimeError',
+            'safe_error_category': 'runtime_context_create_cuda_memory;prompt=secret',
+        }) + '\n'
+    ])
+
+    with pytest.raises(model_manager_module.LlamaCppInitializationError) as raised:
+        model_manager_module._read_llama_subprocess_message(process, timeout_seconds=1, stage='llama_cpp_import')
+
+    assert raised.value.safe_error_category == 'runtime_context_create_failed'
+    assert 'prompt=secret' not in str(raised.value)

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -54,12 +54,27 @@ LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS = (
     'rope_scaling_type', 'yarn_ext_factor', 'yarn_attn_factor', 'yarn_beta_fast',
     'yarn_beta_slow', 'yarn_orig_ctx', 'rope_freq_base', 'rope_freq_scale',
 )
-# Only retry context-create failures backed by safe Metal/KV/cache/buffer
-# evidence. A bare ``Failed to create llama_context`` remains classified as
-# ``runtime_context_create_failed`` but is intentionally non-retryable so corrupt
-# GGUF/runtime/ABI init causes are not masked as memory-profile exhaustion. The
-# packaged-runtime retry regression supplies sanitized ggml_metal/KV stderr
-# diagnostics, which exercises the intended bounded recovery path.
+# General context-create retries require safe Metal/CUDA/KV/cache/buffer
+# evidence. The pinned llama-cpp-python context-create sentinel is handled only
+# by the bounded pre-registration Qwen 64K GPU profile loop below, so unrelated
+# GGUF/runtime/ABI init causes are not promoted to broad retry categories.
+RUNTIME_INIT_SAFE_CATEGORY_ALIASES = {
+    'cuda_memory_allocation': 'runtime_context_create_cuda_memory',
+    'metal_memory_allocation': 'runtime_context_create_metal_memory',
+    'kv_cache_allocation': 'runtime_context_create_kv_cache_allocation',
+    'rope_yarn_eval_failure': 'runtime_context_create_rope_yarn_config',
+}
+RUNTIME_INIT_SAFE_CATEGORY_ALLOWLIST = {
+    'runtime_context_create_unsupported_kwarg',
+    'runtime_context_create_rope_yarn_config',
+    'runtime_context_create_kv_cache_allocation',
+    'runtime_context_create_metal_buffer_limit',
+    'runtime_context_create_metal_memory',
+    'runtime_context_create_cuda_memory',
+    'runtime_context_create_cuda_buffer_limit',
+    'runtime_context_create_failed',
+    'runtime_init_unclassified',
+}
 QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES = {
     'runtime_context_create_metal_memory',
     'runtime_context_create_kv_cache_allocation',
@@ -413,7 +428,38 @@ def _build_qwen_64k_runtime_profiles(
         profiles[0]['diagnostics'].setdefault('skipped_profiles', []).extend(skipped_profiles)
     return profiles
 
+
+def _validate_runtime_init_safe_category(category: Any) -> Optional[str]:
+    text = str(category or '').strip()
+    if text in RUNTIME_INIT_SAFE_CATEGORY_ALIASES:
+        text = RUNTIME_INIT_SAFE_CATEGORY_ALIASES[text]
+    if text in RUNTIME_INIT_SAFE_CATEGORY_ALLOWLIST:
+        return text
+    return None
+
+
+def _safe_child_exception_type(value: Any) -> str:
+    text = str(value or 'RuntimeError').strip()
+    if re.fullmatch(r'[A-Za-z_][A-Za-z0-9_]{0,80}', text):
+        return text
+    return 'RuntimeError'
+
+
+def _runtime_init_category_from_exception(error: Any, child_stderr: str = '') -> str:
+    existing = getattr(error, 'safe_error_category', None)
+    validated = _validate_runtime_init_safe_category(existing)
+    if validated:
+        if child_stderr and validated == 'runtime_context_create_failed':
+            refined = _classify_runtime_context_create_error(str(error), child_stderr)
+            if refined != 'runtime_context_create_failed' and refined != 'runtime_init_unclassified':
+                return refined
+        return validated
+    return _classify_runtime_context_create_error(error, child_stderr)
+
 def _classify_runtime_context_create_error(error: Any, child_stderr: str = '') -> str:
+    existing = _validate_runtime_init_safe_category(getattr(error, 'safe_error_category', None))
+    if existing:
+        return existing
     text = f'{error or ""}\n{child_stderr or ""}'.lower()
     if re.search(r'(?:unexpected keyword argument|got an unexpected keyword argument|unsupported (?:parameter|kwarg|argument))', text):
         return 'runtime_context_create_unsupported_kwarg'
@@ -425,7 +471,11 @@ def _classify_runtime_context_create_error(error: Any, child_stderr: str = '') -
         return 'runtime_context_create_metal_buffer_limit'
     if 'metal' in text and any(term in text for term in ('alloc', 'memory', 'oom', 'out of memory', 'failed to create llama_context')):
         return 'runtime_context_create_metal_memory'
-    if 'cuda' in text and any(term in text for term in ('out of memory', 'oom', 'cudamalloc', 'alloc failed', 'allocation failed', 'cublas')):
+    if (
+        any(term in text for term in ('cublas_status_alloc_failed', 'cudamalloc', 'cuda malloc', 'cuda out of memory', 'cuda error: out of memory'))
+        or ('cuda' in text and any(term in text for term in ('out of memory', 'oom', 'alloc failed', 'allocation failed', 'failed to allocate')))
+        or ('ggml_cuda' in text and any(term in text for term in ('alloc', 'memory', 'oom', 'buffer')))
+    ):
         return 'runtime_context_create_cuda_memory'
     if 'cuda' in text and any(term in text for term in ('buffer', 'resource', 'allocation')):
         return 'runtime_context_create_cuda_buffer_limit'
@@ -444,7 +494,7 @@ def _redact_paths_from_text(text: Any, *, limit: int = 2000) -> str:
 
 _CHILD_DIAGNOSTIC_ALLOWLIST = re.compile(
     r'(llama|llama_context|ggml|metal|kv|cache|alloc|memory|oom|buffer|rope|yarn|'
-    r'flash_attn|type_k|type_v|n_ctx|context|unsupported|keyword|argument|failed)',
+    r'flash_attn|type_k|type_v|n_ctx|context|unsupported|keyword|argument|failed|cublas)',
     re.IGNORECASE,
 )
 _CHILD_DIAGNOSTIC_SENSITIVE_FIELD_RE = re.compile(
@@ -927,6 +977,16 @@ def _stdlib_safe_path_order(entries: Iterable[str]) -> list[str]:
 
 DESKTOP_RUNTIME_PROBE_ENV = 'TOKEN_PLACE_DESKTOP_RUNTIME_PROBE_JSON'
 _LLAMA_CPP_IMPORT_PATH_LOCK = Lock()
+
+
+class LlamaCppInitializationError(RuntimeError):
+    """Raised when llama.cpp initialization fails with validated safe metadata."""
+
+    def __init__(self, message: str, *, safe_error_category: str, child_exception_type: str = 'RuntimeError', child_stderr_tail: str = '') -> None:
+        self.safe_error_category = _validate_runtime_init_safe_category(safe_error_category) or 'runtime_init_unclassified'
+        self.child_exception_type = _safe_child_exception_type(child_exception_type)
+        self.child_stderr_tail = _sanitize_child_diagnostic_text(child_stderr_tail)
+        super().__init__(message)
 
 
 class LlamaCppInferenceRequestError(RuntimeError):
@@ -1674,14 +1734,21 @@ def _read_llama_subprocess_message(
             diagnostics = message.get('diagnostics')
             safe_diagnostics = diagnostics if isinstance(diagnostics, dict) else {}
             raise LlamaCppInferenceRequestError(error, diagnostics=safe_diagnostics)
-        category = _classify_runtime_context_create_error(raw_error, str(message.get('stderr') or ''))
-        error = f'{stage} failed; child_exception_type={message.get("exception_type") or "RuntimeError"}; safe_error_category={category}'
+        stderr_tail = _sanitize_child_diagnostic_text(message.get('stderr'))
+        child_category = _validate_runtime_init_safe_category(message.get('safe_error_category'))
+        category = child_category or _classify_runtime_context_create_error(raw_error, stderr_tail)
+        error = f'{stage} failed; child_exception_type={_safe_child_exception_type(message.get("exception_type"))}; safe_error_category={category}'
         traceback_text = str(message.get('traceback') or '').strip()
         if traceback_text:
             safe_tail = _sanitize_child_diagnostic_text(traceback_text)
             if safe_tail:
                 error = f"{error}; child_traceback_tail={safe_tail}"
-        raise RuntimeError(error)
+        raise LlamaCppInitializationError(
+            error,
+            safe_error_category=category,
+            child_exception_type=_safe_child_exception_type(message.get('exception_type')),
+            child_stderr_tail=stderr_tail,
+        )
     return message
 
 
@@ -1783,16 +1850,20 @@ class _SubprocessLlamaProxy:
             self.close()
             raise
         except Exception as exc:
+            self._drain_stderr_tail_reader()
             stderr_tail = _sanitize_child_diagnostic_text(_llama_subprocess_tail(self._process, '_token_place_stderr_tail'))
-            category = _classify_runtime_context_create_error(exc, stderr_tail)
+            category = _runtime_init_category_from_exception(exc, stderr_tail)
             if isinstance(exc, LlamaCppWorkerEOFError):
                 safe_exc = _format_llama_subprocess_early_exit_detail(self._process, stage='llama_cpp_import')
             else:
                 safe_exc = _safe_parent_exception_message(exc, child_stderr=stderr_tail)
             self.close()
-            raise RuntimeError(
-                f"{safe_exc}; child_exception_type={type(exc).__name__}; "
-                f"safe_error_category={category}; child_stderr_tail={stderr_tail or '<empty>'}"
+            raise LlamaCppInitializationError(
+                f"{safe_exc}; child_exception_type={getattr(exc, 'child_exception_type', type(exc).__name__)}; "
+                f"safe_error_category={category}; child_stderr_tail={stderr_tail or '<empty>'}",
+                safe_error_category=category,
+                child_exception_type=getattr(exc, 'child_exception_type', type(exc).__name__),
+                child_stderr_tail=stderr_tail,
             ) from exc
 
     def _start_stderr_tail_reader(self) -> None:
@@ -1808,7 +1879,16 @@ class _SubprocessLlamaProxy:
                     tail.append((seq, line))
                     del tail[:-100]
 
-        threading.Thread(target=_reader, name='llama_cpp_stderr_reader', daemon=True).start()
+        self._stderr_reader_thread = threading.Thread(target=_reader, name='llama_cpp_stderr_reader', daemon=True)
+        self._stderr_reader_thread.start()
+
+    def _drain_stderr_tail_reader(self, timeout_seconds: float = 0.25) -> None:
+        thread = getattr(self, '_stderr_reader_thread', None)
+        if thread is not None and hasattr(thread, 'join'):
+            try:
+                thread.join(timeout=timeout_seconds)
+            except RuntimeError:
+                pass
 
     def _stderr_cursor(self) -> int:
         return int(getattr(self._process, '_token_place_stderr_sequence', 0) or 0)
@@ -4765,7 +4845,7 @@ class ModelManager:
                                         self.last_qwen_64k_memory_profile_diagnostics = profile_diag
                                     break
                                 except Exception as init_exc:
-                                    category = _classify_runtime_context_create_error(init_exc)
+                                    category = _runtime_init_category_from_exception(init_exc)
                                     safe_failure = {
                                         'profile_id': profile_id,
                                         'model_profile_id': self.profile_id,
@@ -4796,7 +4876,14 @@ class ModelManager:
                                         },
                                     }
                                     profile_failures.append(safe_failure)
-                                    if not is_qwen_64k or category not in QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES:
+                                    self.last_qwen_64k_init_failures = list(profile_failures)
+                                    bare_context_retry = (
+                                        is_qwen_64k
+                                        and category == 'runtime_context_create_failed'
+                                        and len(profile_failures) < min(3, len(runtime_profiles))
+                                    )
+                                    if not is_qwen_64k or (category not in QWEN_64K_CONTEXT_CREATE_RETRY_CATEGORIES and not bare_context_retry):
+                                        self.last_qwen_64k_init_failures = list(profile_failures)
                                         raise
                                     close = getattr(init_exc, 'close', None)
                                     if callable(close):


### PR DESCRIPTION
### Motivation

- Prevent child initialization error categories from being flattened to `runtime_init_unclassified`, which blocked the bounded Qwen 64K F16 → Q8 → Q4 profile recovery on Windows/CUDA.
- Ensure parent-side classification can refine a generic context-create sentinel when delayed native stderr contains safe CUDA/KV evidence. 
- Never accept arbitrary child category strings and preserve a validated canonical category across subprocess wrappers.

### Description

- Add a strict allowlist and alias mapping for child-provided initialization categories (`cuda_memory_allocation` → `runtime_context_create_cuda_memory`, `metal_memory_allocation` → `runtime_context_create_metal_memory`, `kv_cache_allocation` → `runtime_context_create_kv_cache_allocation`, `rope_yarn_eval_failure` → `runtime_context_create_rope_yarn_config`).
- Introduce `LlamaCppInitializationError` that carries `safe_error_category`, sanitized `child_stderr_tail`, and a validated `child_exception_type` so structured metadata survives subprocess wrapper boundaries.
- Track the stderr-reader thread on subprocess proxies and perform a bounded `join`/drain before classifying/raising initialization failures; this lets delayed native CUDA/KV diagnostics refine a generic `Failed to create llama_context` without downgrading specific categories.
- Harden parent-side classification to accept validated child categories only, expand CUDA allocation detection (recognize `CUBLAS_STATUS_ALLOC_FAILED`, `cudaMalloc`, `ggml_cuda` allocation markers and common CUDA OOM text), and preserve the canonical category across all wrappers.
- Persist every Qwen 64K profile failure to `last_qwen_64k_init_failures` before rethrow; allow the exact generic `runtime_context_create_failed` sentinel only inside the bounded pre-registration Qwen 64K profile loop (up to the three-profile budget) so F16→Q8→Q4 recovery can run, but fail closed on exhaustion.
- Add deterministic unit and integration tests exercising: empty-stderr child CUDA category preservation, bare CUBLAS classification, stderr-drain refinement of generic sentinel, bounded three-profile attempts for the bare sentinel, and rejection of spoofed child categories.
- Add the packaged Qwen64K integration regression to the Windows packaged-e2e job (fake/CUDA regressions) so the Windows path runs the targeted regression in CI.

### Testing

- Installed focused verification deps: `python -m pip install -r config/requirements_codex_verification.txt` (succeeded).
- Ran unit suite focused checks: `python -m pytest tests/unit/test_model_manager.py -q` (all tests passed locally: 291 passed).
- Ran targeted integration suite: `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q` (all integration packaged Qwen64K tests passed locally: 18 passed).
- Ran broader runtime and bridge tests: `python -m pytest tests/unit/test_compute_node_runtime.py tests/unit/test_desktop_compute_node_bridge.py -q` and `python -m pytest tests/unit/test_relay_client.py::test_qwen_context_admission_preserves_messages_without_no_think_injection tests/unit/test_relay_client.py::test_api_v1_qwen_paths_never_send_enable_thinking_true tests/unit/test_relay_client.py::test_api_v1_qwen_thinking_output_is_rejected_with_safe_reason tests/unit/test_api_v1_models_catalog_minimal.py tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` (all selected tests passed locally).
- Pre-commit checks: `pre-commit run --all-files` (passed).
- Static checks: `git diff --check` (no issues).

Notes and limits

- The Windows GitHub Actions job was updated to run the packaged Qwen64K packaged runtime regression (fake/CUDA path), but the cloud Windows runner was not executed here; CI will exercise that job on push/PR.
- No child plaintext, commands, paths, secrets, or raw tracebacks are exposed; sanitizers and allowlists were preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5497b1b940832f924d6f146b46b18d)