### PR TITLE
Preserve pip internal build module in embedded runtime cleanup

### DIFF
--- a/desktop-tauri/scripts/prepare_embedded_python_runtime.py
+++ b/desktop-tauri/scripts/prepare_embedded_python_runtime.py
@@ -165,7 +165,7 @@ def probe_runtime(py: Path, m: dict) -> dict:
 
 def clean(runtime: Path) -> None:
     for p in runtime.rglob("*"):
-        if p.is_dir() and p.name in {"__pycache__", "tests", "test", "build"}: shutil.rmtree(p, ignore_errors=True)
+        if p.is_dir() and p.name in {"__pycache__", "tests", "test"}: shutil.rmtree(p, ignore_errors=True)
         elif p.is_file() and (p.suffix == ".pyc" or p.name.endswith(".pyo")): p.unlink(missing_ok=True)
 
 def provenance(m: dict, packages: dict) -> dict:

--- a/tests/unit/test_prepare_embedded_python_runtime.py
+++ b/tests/unit/test_prepare_embedded_python_runtime.py
@@ -257,3 +257,22 @@ def test_install_packages_falls_back_to_source_metal_build(tmp_path, monkeypatch
     assert '--no-binary' in source_cmd
     assert 'llama-cpp-python==0.3.32' == source_cmd[-1]
     assert commands[-3][1]['CMAKE_ARGS'] == '-DGGML_METAL=on'
+
+
+def test_clean_preserves_pip_internal_build_package(tmp_path):
+    runtime = tmp_path / 'python-runtime'
+    pip_build = runtime / 'lib' / 'python3.11' / 'site-packages' / 'pip' / '_internal' / 'operations' / 'build'
+    pip_build.mkdir(parents=True)
+    (pip_build / '__init__.py').write_text('# required pip module\n')
+    test_dir = runtime / 'lib' / 'python3.11' / 'site-packages' / 'somepkg' / 'tests'
+    test_dir.mkdir(parents=True)
+    (test_dir / 'test_sample.py').write_text('def test_sample(): pass\n')
+    pycache = runtime / 'lib' / 'python3.11' / 'site-packages' / 'somepkg' / '__pycache__'
+    pycache.mkdir(parents=True)
+    (pycache / 'module.pyc').write_bytes(b'cache')
+
+    prep.clean(runtime)
+
+    assert (pip_build / '__init__.py').is_file()
+    assert not test_dir.exists()
+    assert not pycache.exists()


### PR DESCRIPTION
### Motivation
- Prevent the embedded runtime cleanup from removing pip's required `pip._internal.operations.build` package by dropping indiscriminate removal of directories named `build` so runtime validation and `pip check` continue to succeed.

### Description
- Stop deleting `build` directories in `desktop-tauri/scripts/prepare_embedded_python_runtime.py` while keeping removal of `__pycache__`, `tests`, and `test` directories.
- Add a focused unit test `test_clean_preserves_pip_internal_build_package` in `tests/unit/test_prepare_embedded_python_runtime.py` that asserts the pip internal build package is preserved and that tests/cache are removed.

### Testing
- Installed verification dependencies with `pip install -r config/requirements_codex_verification.txt` and ran `python -m pytest tests/unit/test_prepare_embedded_python_runtime.py -q`, with all tests passing (11 passed). 
- Verified `python -m py_compile` on the changed files, ran `pre-commit run --all-files`, and ran `git diff --check`, all of which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55cbe67184832fb511c816b9f38bca)