### PR TITLE
Fix non‑mutating macOS preview validation and add regression tests

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -412,7 +412,9 @@ jobs:
 
       - name: Install macOS validation test dependencies
         if: runner.os == 'macOS'
-        run: python -m pip install --upgrade pip pytest
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install 'pytest>=8.1'
 
       - name: Validate macOS staged artifact guardrails
         if: runner.os == 'macOS'

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -457,7 +457,7 @@ jobs:
           python ../scripts/validate_desktop_tauri_release_artifacts.py               --require-embedded-python-runtime               --app-path "${app_path}"               --dmg-path "${dmg_path}"               --tauri-config src-tauri/tauri.conf.json               --expected-icon src-tauri/icons/icon.icns               ${signing_flag}
 
           cd ..
-          python -m pytest tests/integration/test_macos_release_probe.py -q
+          python -m pytest --confcutdir=tests/integration tests/integration/test_macos_release_probe.py -q
 
       - name: Generate SHA256 checksums
         shell: bash

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -366,15 +366,20 @@ jobs:
                 "" \
                 "Normal no-warning public macOS distribution requires paid Developer ID signing + notarization." > "${preview_notice}"
             fi
+            codesign --verify --deep --strict --verbose=4 "${app_path}"
+
             signing_flag=""
             if [ -n "${APPLE_SIGNING_IDENTITY:-}" ] && [ -n "${APPLE_CERTIFICATE_P12_BASE64:-}" ] && [ -n "${APPLE_CERTIFICATE_PASSWORD:-}" ]; then
               signing_flag="--expect-signing"
             fi
             python ../scripts/validate_desktop_tauri_release_artifacts.py               --app-only               --require-embedded-python-runtime               --app-path "${app_path}"               --tauri-config src-tauri/tauri.conf.json               --expected-icon src-tauri/icons/icon.icns               ${signing_flag}
+            codesign --verify --deep --strict --verbose=4 "${app_path}"
 
             rm -rf "${dmg_stage_dir}"
             mkdir -p "${dmg_stage_dir}"
             cp -R "${app_path}" "${dmg_stage_dir}/"
+            staged_app_path="${dmg_stage_dir}/$(basename "${app_path}")"
+            codesign --verify --deep --strict --verbose=4 "${staged_app_path}"
             cp "${preview_notice}" "${dmg_stage_dir}/${preview_notice_name}"
             ln -s /Applications "${dmg_stage_dir}/Applications"
             rm -f "${dmg_path}"
@@ -444,6 +449,9 @@ jobs:
           fi
 
           python ../scripts/validate_desktop_tauri_release_artifacts.py               --require-embedded-python-runtime               --app-path "${app_path}"               --dmg-path "${dmg_path}"               --tauri-config src-tauri/tauri.conf.json               --expected-icon src-tauri/icons/icon.icns               ${signing_flag}
+
+          cd ..
+          python -m pytest tests/integration/test_macos_release_probe.py -q
 
       - name: Generate SHA256 checksums
         shell: bash

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -410,6 +410,10 @@ jobs:
             exit 1
           fi
 
+      - name: Install macOS validation test dependencies
+        if: runner.os == 'macOS'
+        run: python -m pip install --upgrade pip pytest
+
       - name: Validate macOS staged artifact guardrails
         if: runner.os == 'macOS'
         shell: bash

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -1474,10 +1474,16 @@ def _is_writable_directory(candidate: Path) -> tuple[bool, Optional[str]]:
 
 
 def _resolve_desktop_dependency_target(runtime_root: Path) -> tuple[Optional[Path], Optional[str]]:
-    preferred_targets = [
-        ("runtime_root", _desktop_dependency_target(runtime_root)),
-        ("home_fallback", Path.home() / ".token_place_desktop_site"),
-    ]
+    dependency_target = os.environ.get("TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET", "").strip()
+    preferred_targets = []
+    if dependency_target:
+        preferred_targets.append(("env_override", Path(dependency_target)))
+    preferred_targets.extend(
+        [
+            ("runtime_root", _desktop_dependency_target(runtime_root)),
+            ("home_fallback", Path.home() / ".token_place_desktop_site"),
+        ]
+    )
     errors: list[str] = []
     for label, candidate in preferred_targets:
         ok, error = _is_writable_directory(candidate)

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -11,7 +11,9 @@ import re
 import shutil
 import subprocess
 import tempfile
+import stat
 import time
+from typing import NamedTuple
 from pathlib import Path
 
 STALE_BRANDS = ("tokenplace Desktop", "tokenplace Desktop Setup", "desktop/electron-builder")
@@ -306,27 +308,41 @@ def _redact_allowed_app_locations(output: str, app_path: Path) -> str:
 def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
     app_for_subprocess = app_path if app_path.is_absolute() else app_path.absolute()
     py_for_subprocess = py if py.is_absolute() else py.absolute()
-    home = tempfile.mkdtemp(prefix="token-place-home-")
+    home = tempfile.mkdtemp(prefix="token-place-probe-")
     try:
-        app_data = Path(home) / "token.place"
+        scratch = Path(home)
+        app_data = scratch / "token.place"
+        pycache = scratch / "pycache"
+        tmpdir = scratch / "tmp"
+        for path in (app_data, pycache, tmpdir):
+            path.mkdir(parents=True, exist_ok=True)
         env = {
-            "HOME": home,
+            "HOME": str(scratch / "home"),
+            "TMPDIR": str(tmpdir),
+            "PIP_CACHE_DIR": str(app_data / "pip-cache"),
+            "PYTHONDONTWRITEBYTECODE": "1",
             "PYTHONNOUSERSITE": "1",
+            "PYTHONPYCACHEPREFIX": str(pycache),
             "PATH": "/usr/bin:/bin",
             "PYTHONPATH": str(app_for_subprocess / "Contents" / "Resources" / "python"),
             "TOKEN_PLACE_MODELS_DIR": str(app_data / "models"),
+            "TOKEN_PLACE_MODEL_DIR": str(app_data / "models"),
+            "TOKEN_PLACE_CACHE_DIR": str(app_data / "cache"),
+            "HF_HOME": str(app_data / "hf-home"),
+            "TRANSFORMERS_CACHE": str(app_data / "transformers-cache"),
             "XDG_CACHE_HOME": str(app_data / "cache"),
             "XDG_CONFIG_HOME": str(app_data / "config"),
             "XDG_DATA_HOME": str(app_data / "data"),
         }
-        probe_cwd = app_for_subprocess / "Contents" / "Resources" / "python"
+        for key in ("TOKEN_PLACE_PYTHON", "TOKEN_PLACE_SIDECAR_PYTHON", "PYTHONHOME", "PYTHONSTARTUP", "PYTHONUSERBASE"):
+            env.pop(key, None)
         result = subprocess.run(
-            [str(py_for_subprocess), "-c", code],
+            [str(py_for_subprocess), "-B", "-c", code],
             check=False,
             capture_output=True,
             text=True,
             env=env,
-            cwd=str(probe_cwd) if probe_cwd.is_dir() else home,
+            cwd=str(tmpdir),
         )
         output = f"{result.stdout}\n{result.stderr}"
         scan_output = _redact_allowed_app_locations(output, app_for_subprocess)
@@ -335,10 +351,86 @@ def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
             if marker in scan_output:
                 _fail(f"embedded Python output leaked forbidden marker: {marker}")
         if result.returncode != 0:
-            _fail(_format_command_failure([str(py_for_subprocess), "-c", "<probe>"], result))
+            _fail(_format_command_failure([str(py_for_subprocess), "-B", "-c", "<probe>"], result))
         return output.strip()
     finally:
         shutil.rmtree(home, ignore_errors=True)
+
+class AppTreeEntry(NamedTuple):
+    kind: str
+    sha256: str | None
+    executable: bool
+    symlink_target: str | None
+
+
+def _app_tree_fingerprint(app_path: Path) -> dict[str, AppTreeEntry]:
+    fingerprint: dict[str, AppTreeEntry] = {}
+    for path in sorted(app_path.rglob("*")):
+        rel = path.relative_to(app_path).as_posix()
+        st = path.lstat()
+        executable = bool(st.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+        if path.is_symlink():
+            fingerprint[rel] = AppTreeEntry("symlink", None, executable, os.readlink(path))
+        elif path.is_file():
+            fingerprint[rel] = AppTreeEntry("file", _sha256(path), executable, None)
+        elif path.is_dir():
+            fingerprint[rel] = AppTreeEntry("dir", None, executable, None)
+        else:
+            fingerprint[rel] = AppTreeEntry("other", None, executable, None)
+    return fingerprint
+
+
+def _describe_app_tree_changes(before: dict[str, AppTreeEntry], after: dict[str, AppTreeEntry]) -> list[str]:
+    changes: list[str] = []
+    before_paths = set(before)
+    after_paths = set(after)
+    for rel in sorted(after_paths - before_paths):
+        note = " (unsealed Python bytecode)" if rel.endswith(".pyc") or "/__pycache__/" in f"/{rel}" else ""
+        changes.append(f"added: {rel}{note}")
+    for rel in sorted(before_paths - after_paths):
+        changes.append(f"removed: {rel}")
+    for rel in sorted(before_paths & after_paths):
+        old = before[rel]
+        new = after[rel]
+        if old.kind != new.kind:
+            changes.append(f"type changed: {rel} ({old.kind} -> {new.kind})")
+        elif old.sha256 != new.sha256:
+            changes.append(f"rewritten: {rel}")
+        elif old.executable != new.executable:
+            changes.append(f"chmodded: {rel}")
+        elif old.symlink_target != new.symlink_target:
+            changes.append(f"retargeted symlink: {rel} ({old.symlink_target} -> {new.symlink_target})")
+    return changes
+
+
+def _run_with_app_mutation_guard(app_path: Path, action_name: str, action) -> None:
+    before = _app_tree_fingerprint(app_path)
+    action()
+    after = _app_tree_fingerprint(app_path)
+    changes = _describe_app_tree_changes(before, after)
+    if changes:
+        sample = "\n".join(f"- {change}" for change in changes[:50])
+        suffix = "" if len(changes) <= 50 else f"\n... {len(changes) - 50} more changes"
+        _fail(f"{action_name} mutated app bundle {app_path}; executable probes must be non-mutating.\n{sample}{suffix}")
+
+
+def _codesign_verify(app_path: Path) -> None:
+    if platform.system() == "Darwin":
+        if shutil.which("codesign") is None:
+            print("::warning::codesign unavailable; skipping signature verification outside macOS runner tooling.")
+            return
+        _run(["codesign", "--verify", "--deep", "--strict", "--verbose=4", str(app_path)])
+
+
+def _copy_app_for_runtime_validation(app_path: Path) -> tempfile.TemporaryDirectory[str]:
+    temp_dir = tempfile.TemporaryDirectory(prefix="token-place-app-probe-")
+    copy_path = Path(temp_dir.name) / app_path.name
+    shutil.copytree(app_path, copy_path, symlinks=True)
+    return temp_dir
+
+
+def _validate_embedded_python_runtime_non_mutating(app_path: Path) -> None:
+    _run_with_app_mutation_guard(app_path, "embedded Python runtime validation", lambda: _validate_embedded_python_runtime(app_path))
 
 def _parse_otool_rpaths(load_commands: str) -> list[str]:
     rpaths: list[str] = []
@@ -580,7 +672,7 @@ def _parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
+def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool, require_embedded_python_runtime: bool = False) -> None:
     if platform.system() != "Darwin":
         print("::warning::Skipping DMG mounted-content checks outside macOS.")
         return
@@ -606,6 +698,10 @@ def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
                     )
             elif DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[0] not in readme_text:
                 _fail("DMG preview README must include ad-hoc signing guidance for unsigned preview builds")
+            mounted_app = apps[0]
+            if require_embedded_python_runtime:
+                _validate_embedded_python_runtime_non_mutating(mounted_app)
+            _codesign_verify(mounted_app)
         finally:
             _cleanup_dmg_attach_state(dmg_path, Path(mount_dir))
     finally:
@@ -632,7 +728,7 @@ def main() -> None:
             _fail(f"dmg artifact missing or invalid: {dmg_path}")
         if not dmg_path.name.startswith("token.place-desktop-") or not dmg_path.name.endswith("-apple-silicon.dmg"):
             _fail(f"DMG filename must match token.place-desktop-<version>-apple-silicon.dmg: {dmg_path.name}")
-        _validate_dmg_contents(dmg_path, expect_signing=args.expect_signing)
+        _validate_dmg_contents(dmg_path, expect_signing=args.expect_signing, require_embedded_python_runtime=args.require_embedded_python_runtime)
 
     if not app_path.exists() or app_path.suffix != ".app":
         _fail(f"app bundle missing or invalid: {app_path}")
@@ -683,17 +779,26 @@ def main() -> None:
     if "x86_64" in arch_lower and "arm64" not in arch_lower:
         _fail(f"binary is x86_64-only: {arch_out}")
 
-    if args.require_embedded_python_runtime:
-        _validate_embedded_python_runtime(app_path)
+    _codesign_verify(app_path)
 
-    if args.expect_signing:
-        _run(["codesign", "--verify", "--deep", "--strict", "--verbose=2", str(app_path)])
-        if args.expect_notarization:
-            _run(["spctl", "-a", "-vv", "--type", "execute", str(app_path)])
-        else:
-            print("::warning::Signing configured without notarization credentials; skipping strict Gatekeeper assessment.")
+    if args.require_embedded_python_runtime:
+        if args.app_only:
+            with _copy_app_for_runtime_validation(app_path) as probe_dir:
+                probe_app = Path(probe_dir) / app_path.name
+                _validate_embedded_python_runtime_non_mutating(probe_app)
+                _codesign_verify(probe_app)
+        elif platform.system() != "Darwin":
+            with _copy_app_for_runtime_validation(app_path) as probe_dir:
+                probe_app = Path(probe_dir) / app_path.name
+                _validate_embedded_python_runtime_non_mutating(probe_app)
+
+    _codesign_verify(app_path)
+    if args.expect_notarization:
+        _run(["spctl", "-a", "-vv", "--type", "execute", str(app_path)])
+    elif args.expect_signing:
+        print("::warning::Signing configured without notarization credentials; skipping strict Gatekeeper assessment.")
     else:
-        print("::warning::Signing credentials not configured; macOS artifact is preview/dev-only and may fail Gatekeeper.")
+        print("::warning::Apple Developer signing credentials not configured; verifying the existing ad-hoc signature only.")
 
 
 if __name__ == "__main__":

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -315,7 +315,8 @@ def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
         home_dir = scratch / "home"
         pycache = scratch / "pycache"
         tmpdir = scratch / "tmp"
-        for path in (app_data, home_dir, pycache, tmpdir):
+        dependency_target = app_data / "desktop-site"
+        for path in (app_data, dependency_target, home_dir, pycache, tmpdir):
             path.mkdir(parents=True, exist_ok=True)
         # env is a complete replacement for the subprocess environment. Host
         # interpreter overrides are intentionally not inherited by probes.
@@ -328,6 +329,7 @@ def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
             "PYTHONPYCACHEPREFIX": str(pycache),
             "PATH": "/usr/bin:/bin",
             "PYTHONPATH": str(app_for_subprocess / "Contents" / "Resources" / "python"),
+            "TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET": str(dependency_target),
             "TOKEN_PLACE_MODELS_DIR": str(app_data / "models"),
             "TOKEN_PLACE_MODEL_DIR": str(app_data / "models"),
             "TOKEN_PLACE_CACHE_DIR": str(app_data / "cache"),

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -312,12 +312,13 @@ def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
     try:
         scratch = Path(home)
         app_data = scratch / "token.place"
+        home_dir = scratch / "home"
         pycache = scratch / "pycache"
         tmpdir = scratch / "tmp"
-        for path in (app_data, pycache, tmpdir):
+        for path in (app_data, home_dir, pycache, tmpdir):
             path.mkdir(parents=True, exist_ok=True)
         env = {
-            "HOME": str(scratch / "home"),
+            "HOME": str(home_dir),
             "TMPDIR": str(tmpdir),
             "PIP_CACHE_DIR": str(app_data / "pip-cache"),
             "PYTHONDONTWRITEBYTECODE": "1",
@@ -334,8 +335,6 @@ def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
             "XDG_CONFIG_HOME": str(app_data / "config"),
             "XDG_DATA_HOME": str(app_data / "data"),
         }
-        for key in ("TOKEN_PLACE_PYTHON", "TOKEN_PLACE_SIDECAR_PYTHON", "PYTHONHOME", "PYTHONSTARTUP", "PYTHONUSERBASE"):
-            env.pop(key, None)
         result = subprocess.run(
             [str(py_for_subprocess), "-B", "-c", code],
             check=False,
@@ -417,7 +416,7 @@ def _run_with_app_mutation_guard(app_path: Path, action_name: str, action) -> No
 def _codesign_verify(app_path: Path) -> None:
     if platform.system() == "Darwin":
         if shutil.which("codesign") is None:
-            print("::warning::codesign unavailable; skipping signature verification outside macOS runner tooling.")
+            print("::warning::codesign not found in PATH; skipping ad-hoc signature verification on this macOS machine.")
             return
         _run(["codesign", "--verify", "--deep", "--strict", "--verbose=4", str(app_path)])
 
@@ -792,7 +791,6 @@ def main() -> None:
                 probe_app = Path(probe_dir) / app_path.name
                 _validate_embedded_python_runtime_non_mutating(probe_app)
 
-    _codesign_verify(app_path)
     if args.expect_notarization:
         _run(["spctl", "-a", "-vv", "--type", "execute", str(app_path)])
     elif args.expect_signing:

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -730,13 +730,17 @@ def main() -> None:
                 _fail(f"stale Electron branding detected: {stale} in {candidate}")
 
     if not args.app_only:
-        if dmg_path is None:
+        allow_macos_runtime_probe_without_dmg = (
+            args.require_embedded_python_runtime and platform.system() == "Darwin" and dmg_path is None
+        )
+        if dmg_path is None and not allow_macos_runtime_probe_without_dmg:
             _fail("--dmg-path is required unless --app-only is set")
-        if not dmg_path.exists() or dmg_path.suffix.lower() != '.dmg' or not dmg_path.is_file():
-            _fail(f"dmg artifact missing or invalid: {dmg_path}")
-        if not dmg_path.name.startswith("token.place-desktop-") or not dmg_path.name.endswith("-apple-silicon.dmg"):
-            _fail(f"DMG filename must match token.place-desktop-<version>-apple-silicon.dmg: {dmg_path.name}")
-        _validate_dmg_contents(dmg_path, expect_signing=args.expect_signing, require_embedded_python_runtime=args.require_embedded_python_runtime)
+        if dmg_path is not None:
+            if not dmg_path.exists() or dmg_path.suffix.lower() != '.dmg' or not dmg_path.is_file():
+                _fail(f"dmg artifact missing or invalid: {dmg_path}")
+            if not dmg_path.name.startswith("token.place-desktop-") or not dmg_path.name.endswith("-apple-silicon.dmg"):
+                _fail(f"DMG filename must match token.place-desktop-<version>-apple-silicon.dmg: {dmg_path.name}")
+            _validate_dmg_contents(dmg_path, expect_signing=args.expect_signing, require_embedded_python_runtime=args.require_embedded_python_runtime)
 
     if not app_path.exists() or app_path.suffix != ".app":
         _fail(f"app bundle missing or invalid: {app_path}")
@@ -790,15 +794,13 @@ def main() -> None:
     _codesign_verify(app_path)
 
     if args.require_embedded_python_runtime:
-        if args.app_only:
+        should_probe_source_app_copy = args.app_only or platform.system() != "Darwin" or dmg_path is None
+        if should_probe_source_app_copy:
             with _copy_app_for_runtime_validation(app_path) as probe_dir:
                 probe_app = Path(probe_dir) / app_path.name
                 _validate_embedded_python_runtime_non_mutating(probe_app)
-                _codesign_verify(probe_app)
-        elif platform.system() != "Darwin":
-            with _copy_app_for_runtime_validation(app_path) as probe_dir:
-                probe_app = Path(probe_dir) / app_path.name
-                _validate_embedded_python_runtime_non_mutating(probe_app)
+                if platform.system() == "Darwin":
+                    _codesign_verify(probe_app)
 
     _codesign_verify(app_path)
 

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -317,6 +317,8 @@ def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
         tmpdir = scratch / "tmp"
         for path in (app_data, home_dir, pycache, tmpdir):
             path.mkdir(parents=True, exist_ok=True)
+        # env is a complete replacement for the subprocess environment. Host
+        # interpreter overrides are intentionally not inherited by probes.
         env = {
             "HOME": str(home_dir),
             "TMPDIR": str(tmpdir),
@@ -404,20 +406,25 @@ def _describe_app_tree_changes(before: dict[str, AppTreeEntry], after: dict[str,
 
 def _run_with_app_mutation_guard(app_path: Path, action_name: str, action) -> None:
     before = _app_tree_fingerprint(app_path)
-    action()
+    action_error: BaseException | None = None
+    try:
+        action()
+    except BaseException as exc:
+        action_error = exc
     after = _app_tree_fingerprint(app_path)
     changes = _describe_app_tree_changes(before, after)
     if changes:
         sample = "\n".join(f"- {change}" for change in changes[:50])
         suffix = "" if len(changes) <= 50 else f"\n... {len(changes) - 50} more changes"
         _fail(f"{action_name} mutated app bundle {app_path}; executable probes must be non-mutating.\n{sample}{suffix}")
+    if action_error is not None:
+        raise action_error
 
 
 def _codesign_verify(app_path: Path) -> None:
     if platform.system() == "Darwin":
         if shutil.which("codesign") is None:
-            print("::warning::codesign not found in PATH; skipping ad-hoc signature verification on this macOS machine.")
-            return
+            _fail("codesign not found in PATH on this macOS machine; cannot verify ad-hoc signature")
         _run(["codesign", "--verify", "--deep", "--strict", "--verbose=4", str(app_path)])
 
 
@@ -790,6 +797,8 @@ def main() -> None:
             with _copy_app_for_runtime_validation(app_path) as probe_dir:
                 probe_app = Path(probe_dir) / app_path.name
                 _validate_embedded_python_runtime_non_mutating(probe_app)
+
+    _codesign_verify(app_path)
 
     if args.expect_notarization:
         _run(["spctl", "-a", "-vv", "--type", "execute", str(app_path)])

--- a/tests/integration/test_macos_release_probe.py
+++ b/tests/integration/test_macos_release_probe.py
@@ -44,7 +44,7 @@ def test_real_macos_sanitized_probe_preserves_ad_hoc_signature_and_dmg_mount(tmp
     before = validator._app_tree_fingerprint(app)
     validator._run_python_sanitized(
         Path(sys.executable),
-        "import probe_module, subprocess, sys; assert probe_module.VALUE == 42; subprocess.check_call([sys.executable, '-c', 'import probe_module; assert probe_module.VALUE == 42'])",
+        "import probe_module, subprocess, sys; assert probe_module.VALUE == 42; subprocess.check_call([sys.executable, '-B', '-c', 'import probe_module; assert probe_module.VALUE == 42'])",
         app,
     )
     assert not list(app.rglob('__pycache__'))
@@ -52,11 +52,17 @@ def test_real_macos_sanitized_probe_preserves_ad_hoc_signature_and_dmg_mount(tmp
     assert validator._describe_app_tree_changes(before, validator._app_tree_fingerprint(app)) == []
     subprocess.run(['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)], check=True)
 
-    pycache = resources / '__pycache__'
-    pycache.mkdir()
-    (pycache / 'probe_module.cpython-311.pyc').write_bytes(b'unsealed')
-    assert any('unsealed Python bytecode' in c for c in validator._describe_app_tree_changes(before, validator._app_tree_fingerprint(app)))
-    shutil.rmtree(pycache)
+    def mutating_failure() -> None:
+        pycache = resources / '__pycache__'
+        pycache.mkdir()
+        (pycache / 'probe_module.cpython-311.pyc').write_bytes(b'unsealed')
+        raise RuntimeError('probe failed after mutation')
+
+    with pytest.raises(SystemExit) as excinfo:
+        validator._run_with_app_mutation_guard(app, 'intentional mutating probe', mutating_failure)
+    assert 'intentional mutating probe mutated app bundle' in str(excinfo.value)
+    assert 'added: Contents/Resources/python/__pycache__/probe_module.cpython-311.pyc (unsealed Python bytecode)' in str(excinfo.value)
+    shutil.rmtree(resources / '__pycache__')
 
     stage = tmp_path / 'stage'
     stage.mkdir()
@@ -67,11 +73,25 @@ def test_real_macos_sanitized_probe_preserves_ad_hoc_signature_and_dmg_mount(tmp
     )
     dmg = tmp_path / 'token.place-desktop-probe-apple-silicon.dmg'
     subprocess.run(['hdiutil', 'create', '-volname', 'Probe', '-srcfolder', str(stage), '-ov', '-format', 'UDZO', str(dmg)], check=True)
-    seen = []
-    original_validate = validator._validate_embedded_python_runtime_non_mutating
+
+    mount = validator._attach_dmg_with_retries(dmg)
     try:
-        validator._validate_embedded_python_runtime_non_mutating = lambda mounted_app: seen.append(mounted_app)
-        validator._validate_dmg_contents(dmg, expect_signing=False, require_embedded_python_runtime=True)
+        root = Path(mount.name)
+        mounted_apps = sorted(p for p in root.iterdir() if p.is_dir() and p.suffix == '.app')
+        assert len(mounted_apps) == 1
+        mounted_app = mounted_apps[0]
+        mounted_before = validator._app_tree_fingerprint(mounted_app)
+        validator._run_python_sanitized(
+            Path(sys.executable),
+            "import probe_module, subprocess, sys; assert probe_module.VALUE == 42; subprocess.check_call([sys.executable, '-B', '-c', 'import probe_module; assert probe_module.VALUE == 42'])",
+            mounted_app,
+        )
+        assert not list(mounted_app.rglob('__pycache__'))
+        assert not list(mounted_app.rglob('*.pyc'))
+        assert validator._describe_app_tree_changes(mounted_before, validator._app_tree_fingerprint(mounted_app)) == []
+        subprocess.run(['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(mounted_app)], check=True)
     finally:
-        validator._validate_embedded_python_runtime_non_mutating = original_validate
-    assert seen and seen[0].name == app.name
+        validator._cleanup_dmg_attach_state(dmg, Path(mount.name))
+        mount.cleanup()
+
+    validator._validate_dmg_contents(dmg, expect_signing=False, require_embedded_python_runtime=False)

--- a/tests/integration/test_macos_release_probe.py
+++ b/tests/integration/test_macos_release_probe.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import importlib.util
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _validator():
+    script_path = Path('scripts/validate_desktop_tauri_release_artifacts.py')
+    spec = importlib.util.spec_from_file_location('validate_desktop_tauri_release_artifacts', script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.skipif(platform.system() != 'Darwin', reason='requires real macOS codesign and hdiutil')
+def test_real_macos_sanitized_probe_preserves_ad_hoc_signature_and_dmg_mount(tmp_path) -> None:
+    validator = _validator()
+    app = tmp_path / 'Probe.app'
+    resources = app / 'Contents' / 'Resources' / 'python'
+    macos = app / 'Contents' / 'MacOS'
+    resources.mkdir(parents=True)
+    macos.mkdir(parents=True)
+    (app / 'Contents' / 'Info.plist').write_text(
+        '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" '
+        '"http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict>'
+        '<key>CFBundleExecutable</key><string>probe</string><key>CFBundleIdentifier</key><string>place.token.probe</string>'
+        '<key>CFBundleName</key><string>Probe</string></dict></plist>',
+        encoding='utf-8',
+    )
+    exe = macos / 'probe'
+    exe.write_text('#!/bin/sh\nexit 0\n', encoding='utf-8')
+    exe.chmod(0o755)
+    (resources / 'probe_module.py').write_text('VALUE = 42\n', encoding='utf-8')
+
+    subprocess.run(['codesign', '--force', '--deep', '--sign', '-', str(app)], check=True)
+    subprocess.run(['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)], check=True)
+    before = validator._app_tree_fingerprint(app)
+    validator._run_python_sanitized(
+        Path(sys.executable),
+        "import probe_module, subprocess, sys; assert probe_module.VALUE == 42; subprocess.check_call([sys.executable, '-c', 'import probe_module; assert probe_module.VALUE == 42'])",
+        app,
+    )
+    assert not list(app.rglob('__pycache__'))
+    assert not list(app.rglob('*.pyc'))
+    assert validator._describe_app_tree_changes(before, validator._app_tree_fingerprint(app)) == []
+    subprocess.run(['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)], check=True)
+
+    pycache = resources / '__pycache__'
+    pycache.mkdir()
+    (pycache / 'probe_module.cpython-311.pyc').write_bytes(b'unsealed')
+    assert any('unsealed Python bytecode' in c for c in validator._describe_app_tree_changes(before, validator._app_tree_fingerprint(app)))
+    shutil.rmtree(pycache)
+
+    stage = tmp_path / 'stage'
+    stage.mkdir()
+    shutil.copytree(app, stage / app.name, symlinks=True)
+    (stage / 'README BEFORE OPENING.txt').write_text(
+        'This preview build is ad-hoc signed and not notarized. Apple could not verify. Privacy & Security. Developer ID notarization.',
+        encoding='utf-8',
+    )
+    dmg = tmp_path / 'token.place-desktop-probe-apple-silicon.dmg'
+    subprocess.run(['hdiutil', 'create', '-volname', 'Probe', '-srcfolder', str(stage), '-ov', '-format', 'UDZO', str(dmg)], check=True)
+    seen = []
+    original_validate = validator._validate_embedded_python_runtime_non_mutating
+    try:
+        validator._validate_embedded_python_runtime_non_mutating = lambda mounted_app: seen.append(mounted_app)
+        validator._validate_dmg_contents(dmg, expect_signing=False, require_embedded_python_runtime=True)
+    finally:
+        validator._validate_embedded_python_runtime_non_mutating = original_validate
+    assert seen and seen[0].name == app.name

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -721,6 +721,11 @@ def test_release_workflow_installs_pytest_before_macos_probe() -> None:
     assert "if: runner.os == 'macOS'" in install_step
     assert 'python -m pip install --upgrade pip' in install_step
     assert "python -m pip install 'pytest>=8.1'" in install_step
+    validate_step = workflow[validate_index:]
+    assert (
+        "python -m pytest --confcutdir=tests/integration "
+        "tests/integration/test_macos_release_probe.py -q"
+    ) in validate_step
 
 
 def test_run_python_sanitized_rejects_forbidden_markers_and_cleans_home(monkeypatch, tmp_path) -> None:

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -1767,3 +1767,89 @@ def test_dmg_validation_runs_against_mounted_app(monkeypatch, tmp_path) -> None:
     validator._validate_dmg_contents(dmg, expect_signing=False, require_embedded_python_runtime=True)
     assert ('runtime', mounted_app) in seen
     assert ('codesign', mounted_app) in seen
+
+
+def test_validator_main_macos_require_runtime_without_dmg_validates_disposable_copy(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app, tauri_config, icon = _minimal_validator_app(validator, tmp_path)
+    runtime_apps = []
+    codesign_apps = []
+    run_calls = []
+    monkeypatch.setattr(
+        validator,
+        '_parse_args',
+        lambda: validator.argparse.Namespace(
+            app_path=str(app),
+            dmg_path=None,
+            app_only=False,
+            tauri_config=str(tauri_config),
+            expected_icon=str(icon),
+            expect_signing=False,
+            require_embedded_python_runtime=True,
+            expect_notarization=False,
+        ),
+    )
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator.shutil, 'which', lambda name: '/usr/bin/codesign' if name == 'codesign' else None)
+
+    def fake_run(cmd):
+        run_calls.append(cmd)
+        return 'arm64' if cmd[:2] == ['lipo', '-archs'] else ''
+
+    def fake_runtime(probe_app):
+        runtime_apps.append(probe_app)
+        assert probe_app != app
+        assert probe_app.name == app.name
+        assert probe_app.exists()
+
+    monkeypatch.setattr(validator, '_run', fake_run)
+    monkeypatch.setattr(validator, '_validate_embedded_python_runtime_non_mutating', fake_runtime)
+    original_codesign = validator._codesign_verify
+    monkeypatch.setattr(validator, '_codesign_verify', lambda probe_app: codesign_apps.append(probe_app) or original_codesign(probe_app))
+
+    validator.main()
+
+    assert len(runtime_apps) == 1
+    assert runtime_apps[0].parent != app.parent
+    assert codesign_apps.count(app) == 2
+    assert runtime_apps[0] in codesign_apps
+
+
+def test_validator_main_macos_dmg_runtime_validation_does_not_probe_source_app(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app, tauri_config, icon = _minimal_validator_app(validator, tmp_path)
+    dmg = tmp_path / 'token.place-desktop-test-apple-silicon.dmg'
+    dmg.write_bytes(b'dmg')
+    dmg_calls = []
+    runtime_apps = []
+    run_calls = []
+    monkeypatch.setattr(
+        validator,
+        '_parse_args',
+        lambda: validator.argparse.Namespace(
+            app_path=str(app),
+            dmg_path=str(dmg),
+            app_only=False,
+            tauri_config=str(tauri_config),
+            expected_icon=str(icon),
+            expect_signing=False,
+            require_embedded_python_runtime=True,
+            expect_notarization=False,
+        ),
+    )
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator.shutil, 'which', lambda name: '/usr/bin/codesign' if name == 'codesign' else None)
+    monkeypatch.setattr(validator, '_validate_dmg_contents', lambda path, **kwargs: dmg_calls.append((path, kwargs)))
+    monkeypatch.setattr(validator, '_validate_embedded_python_runtime_non_mutating', lambda probe_app: runtime_apps.append(probe_app))
+
+    def fake_run(cmd):
+        run_calls.append(cmd)
+        return 'arm64' if cmd[:2] == ['lipo', '-archs'] else ''
+
+    monkeypatch.setattr(validator, '_run', fake_run)
+
+    validator.main()
+
+    assert dmg_calls == [(dmg, {'expect_signing': False, 'require_embedded_python_runtime': True})]
+    assert runtime_apps == []
+    assert run_calls.count(['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)]) == 2

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -663,7 +663,7 @@ def test_validator_uses_packaged_python_resources_for_runtime_probe() -> None:
     assert "'inspect'" in text
 
 
-def test_validator_sanitized_python_env_unsets_override_variables(monkeypatch, tmp_path) -> None:
+def test_validator_sanitized_python_env_replaces_parent_environment(monkeypatch, tmp_path) -> None:
     validator = _load_release_artifact_validator()
     app = tmp_path / 'token.place desktop.app'
     (app / 'Contents' / 'Resources' / 'python').mkdir(parents=True)
@@ -703,6 +703,16 @@ def test_release_workflow_uses_explicit_arm64_macos_runner_for_embedded_runtime(
     assert 'test "$(uname -m)" = "arm64"' in workflow
 
 
+def test_release_workflow_installs_pytest_before_macos_probe() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    install_index = workflow.index('- name: Install macOS validation test dependencies')
+    validate_index = workflow.index('- name: Validate macOS staged artifact guardrails')
+    assert install_index < validate_index
+    install_step = workflow[install_index:validate_index]
+    assert "if: runner.os == 'macOS'" in install_step
+    assert 'python -m pip install --upgrade pip pytest' in install_step
+
+
 def test_run_python_sanitized_rejects_forbidden_markers_and_cleans_home(monkeypatch, tmp_path) -> None:
     validator = _load_release_artifact_validator()
     app = tmp_path / 'token.place desktop.app'
@@ -718,6 +728,7 @@ def test_run_python_sanitized_rejects_forbidden_markers_and_cleans_home(monkeypa
 
     def fake_run(cmd, *, check, capture_output, text, env, cwd=None):
         assert env['HOME'] == str(created_home['path'] / 'home')
+        assert Path(env['HOME']).is_dir()
         assert env['TOKEN_PLACE_MODELS_DIR'] == str(created_home['path'] / 'token.place' / 'models')
         assert env['XDG_CACHE_HOME'] == str(created_home['path'] / 'token.place' / 'cache')
         assert env['XDG_CONFIG_HOME'] == str(created_home['path'] / 'token.place' / 'config')
@@ -1406,7 +1417,7 @@ def test_validator_full_main_validates_dmg_and_signing(monkeypatch, tmp_path) ->
     validator.main()
 
     assert dmg_calls == [(dmg, True)]
-    assert ['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)] in run_calls
+    assert run_calls.count(['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)]) == 1
     assert ['spctl', '-a', '-vv', '--type', 'execute', str(app)] in run_calls
 
 

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -717,12 +717,12 @@ def test_run_python_sanitized_rejects_forbidden_markers_and_cleans_home(monkeypa
         return str(home)
 
     def fake_run(cmd, *, check, capture_output, text, env, cwd=None):
-        assert env['HOME'] == str(created_home['path'])
+        assert env['HOME'] == str(created_home['path'] / 'home')
         assert env['TOKEN_PLACE_MODELS_DIR'] == str(created_home['path'] / 'token.place' / 'models')
         assert env['XDG_CACHE_HOME'] == str(created_home['path'] / 'token.place' / 'cache')
         assert env['XDG_CONFIG_HOME'] == str(created_home['path'] / 'token.place' / 'config')
         assert env['XDG_DATA_HOME'] == str(created_home['path'] / 'token.place' / 'data')
-        assert cwd == str((app / 'Contents' / 'Resources' / 'python').absolute())
+        assert not Path(cwd).resolve().is_relative_to(app.resolve())
         return subprocess.CompletedProcess(cmd, 0, '/usr/bin/python3 leaked', '')
 
     monkeypatch.setattr(validator.tempfile, 'mkdtemp', fake_mkdtemp)
@@ -771,7 +771,7 @@ def test_run_python_sanitized_runs_probes_from_packaged_python_resources(monkeyp
     monkeypatch.setattr(validator.subprocess, 'run', fake_run)
 
     assert validator._run_python_sanitized(py, 'print(1)', app) == 'ok'
-    assert seen['cwd'] == str(resources_python.absolute())
+    assert not Path(seen['cwd']).resolve().is_relative_to(app.resolve())
 
 
 def test_run_python_sanitized_absolutizes_relative_interpreter_before_resource_cwd(
@@ -795,7 +795,7 @@ def test_run_python_sanitized_absolutizes_relative_interpreter_before_resource_c
 
     assert validator._run_python_sanitized(py, 'print(1)', app) == 'ok'
     assert seen['cmd'][0] == str((tmp_path / py).absolute())
-    assert seen['cwd'] == str((tmp_path / app / 'Contents' / 'Resources' / 'python').absolute())
+    assert not Path(seen['cwd']).resolve().is_relative_to((tmp_path / app).resolve())
 
 def test_redact_allowed_app_locations_still_flags_runner_paths_outside_app(tmp_path) -> None:
     validator = _load_release_artifact_validator()
@@ -1311,7 +1311,9 @@ def test_validator_app_only_main_validates_app_without_dmg(monkeypatch, tmp_path
 
     validator.main()
 
-    assert embedded_calls == [app]
+    assert len(embedded_calls) == 1
+    assert embedded_calls[0].name == app.name
+    assert embedded_calls[0] != app
     assert dmg_calls == []
 
 
@@ -1391,18 +1393,20 @@ def test_validator_full_main_validates_dmg_and_signing(monkeypatch, tmp_path) ->
             expect_notarization=True,
         ),
     )
-    monkeypatch.setattr(validator, '_validate_dmg_contents', lambda path, *, expect_signing: dmg_calls.append((path, expect_signing)))
+    monkeypatch.setattr(validator, '_validate_dmg_contents', lambda path, **kwargs: dmg_calls.append((path, kwargs.get('expect_signing'))))
 
     def fake_run(cmd):
         run_calls.append(cmd)
         return 'arm64' if cmd[:2] == ['lipo', '-archs'] else ''
 
     monkeypatch.setattr(validator, '_run', fake_run)
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator.shutil, 'which', lambda name: '/usr/bin/codesign' if name == 'codesign' else None)
 
     validator.main()
 
     assert dmg_calls == [(dmg, True)]
-    assert ['codesign', '--verify', '--deep', '--strict', '--verbose=2', str(app)] in run_calls
+    assert ['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)] in run_calls
     assert ['spctl', '-a', '-vv', '--type', 'execute', str(app)] in run_calls
 
 
@@ -1586,3 +1590,104 @@ def test_validator_embedded_runtime_failure_paths(monkeypatch, tmp_path) -> None
     monkeypatch.setattr(validator, '_validate_macho_linkage', lambda path, app_path: calls.append(str(path)))
     validator._validate_embedded_python_runtime(app)
     assert any('model_bridge.py' in code for code in calls)
+
+
+def test_run_python_sanitized_disables_bytecode_and_uses_external_writable_locations(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'token.place desktop.app'
+    (app / 'Contents' / 'Resources' / 'python').mkdir(parents=True)
+    py = app / 'Contents' / 'Resources' / 'python-runtime' / 'bin' / 'python3'
+    py.parent.mkdir(parents=True)
+    py.write_text('#!/bin/sh\n', encoding='utf-8')
+    captured = {}
+
+    def fake_run(cmd, *, check, capture_output, text, env, cwd=None):
+        captured.update(cmd=cmd, env=env, cwd=cwd)
+        return subprocess.CompletedProcess(cmd, 0, 'ok', '')
+
+    monkeypatch.setattr(validator.subprocess, 'run', fake_run)
+    assert validator._run_python_sanitized(py, 'print(1)', app) == 'ok'
+    assert captured['cmd'][1] == '-B'
+    env = captured['env']
+    assert env['PYTHONDONTWRITEBYTECODE'] == '1'
+    assert env['PYTHONNOUSERSITE'] == '1'
+    assert env['PATH'] == '/usr/bin:/bin'
+    assert env['PYTHONPATH'] == str(app / 'Contents' / 'Resources' / 'python')
+    writable_keys = ['PYTHONPYCACHEPREFIX', 'TMPDIR', 'PIP_CACHE_DIR', 'HOME', 'XDG_CACHE_HOME', 'XDG_CONFIG_HOME', 'XDG_DATA_HOME', 'TOKEN_PLACE_MODELS_DIR', 'HF_HOME', 'TRANSFORMERS_CACHE']
+    for key in writable_keys:
+        assert not Path(env[key]).resolve().is_relative_to(app.resolve()), key
+    assert not Path(captured['cwd']).resolve().is_relative_to(app.resolve())
+
+
+def test_run_python_sanitized_real_import_and_child_import_do_not_create_pycache(tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'token.place desktop.app'
+    pkg = app / 'Contents' / 'Resources' / 'python'
+    pkg.mkdir(parents=True)
+    (pkg / 'probe_module.py').write_text('VALUE = 42\n', encoding='utf-8')
+    code = "import probe_module, subprocess, sys; assert probe_module.VALUE == 42; subprocess.check_call([sys.executable, '-c', 'import probe_module; assert probe_module.VALUE == 42'])"
+    validator._run_python_sanitized(Path(__import__('sys').executable), code, app)
+    assert not list(pkg.rglob('__pycache__'))
+    assert not list(pkg.rglob('*.pyc'))
+
+
+def test_app_tree_fingerprint_reports_mutations(tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'x.app'
+    d = app / 'Contents' / 'Resources'
+    d.mkdir(parents=True)
+    f = d / 'file.txt'; f.write_text('one', encoding='utf-8')
+    exe = d / 'tool'; exe.write_text('tool', encoding='utf-8'); exe.chmod(0o644)
+    link = d / 'link'; link.symlink_to('file.txt')
+    base = validator._app_tree_fingerprint(app)
+    pyc = d / '__pycache__' / 'm.cpython-311.pyc'; pyc.parent.mkdir(); pyc.write_bytes(b'pyc')
+    f.unlink()
+    exe.write_text('changed', encoding='utf-8'); exe.chmod(0o755)
+    link.unlink(); link.symlink_to('tool')
+    changes = '\n'.join(validator._describe_app_tree_changes(base, validator._app_tree_fingerprint(app)))
+    assert 'unsealed Python bytecode' in changes
+    assert 'removed: Contents/Resources/file.txt' in changes
+    assert 'rewritten: Contents/Resources/tool' in changes or 'chmodded: Contents/Resources/tool' in changes
+    assert 'retargeted symlink: Contents/Resources/link' in changes
+
+
+def test_mutation_guard_fails_for_mutating_probe(tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'x.app'; app.mkdir()
+    try:
+        validator._run_with_app_mutation_guard(app, 'test probe', lambda: (app / '__pycache__' / 'x.pyc').parent.mkdir() or (app / '__pycache__' / 'x.pyc').write_bytes(b'x'))
+        assert False
+    except SystemExit as exc:
+        assert 'unsealed Python bytecode' in str(exc)
+
+
+def test_codesign_verification_is_ad_hoc_and_not_spctl_gated(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'x.app'; app.mkdir()
+    calls = []
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator, '_run', lambda cmd: calls.append(cmd) or '')
+    monkeypatch.setattr(validator.shutil, 'which', lambda name: '/usr/bin/codesign' if name == 'codesign' else None)
+    validator._codesign_verify(app)
+    assert ['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)] in calls
+    assert not any(cmd and cmd[0] in {'spctl', 'notarytool', 'stapler'} for cmd in calls)
+
+
+def test_dmg_validation_runs_against_mounted_app(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    mount = tmp_path / 'mount'; mount.mkdir()
+    mounted_app = mount / 'mounted.app'; mounted_app.mkdir()
+    (mount / 'README BEFORE OPENING.txt').write_text('ad-hoc signed not notarized Apple could not verify Privacy & Security Developer ID notarization', encoding='utf-8')
+    class Handle:
+        name = str(mount)
+        def cleanup(self): pass
+    seen = []
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator, '_attach_dmg_with_retries', lambda dmg: Handle())
+    monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', lambda dmg, path: None)
+    monkeypatch.setattr(validator, '_validate_embedded_python_runtime_non_mutating', lambda app: seen.append(('runtime', app)))
+    monkeypatch.setattr(validator, '_codesign_verify', lambda app: seen.append(('codesign', app)))
+    dmg = tmp_path / 'token.place-desktop-x-apple-silicon.dmg'; dmg.write_bytes(b'dmg')
+    validator._validate_dmg_contents(dmg, expect_signing=False, require_embedded_python_runtime=True)
+    assert ('runtime', mounted_app) in seen
+    assert ('codesign', mounted_app) in seen

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -1653,6 +1653,8 @@ def test_run_python_sanitized_disables_bytecode_and_uses_external_writable_locat
     captured = {}
 
     def fake_run(cmd, *, check, capture_output, text, env, cwd=None):
+        assert Path(env['HOME']).is_dir()
+        assert Path(env['TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET']).is_dir()
         captured.update(cmd=cmd, env=env, cwd=cwd)
         return subprocess.CompletedProcess(cmd, 0, 'ok', '')
 
@@ -1664,7 +1666,19 @@ def test_run_python_sanitized_disables_bytecode_and_uses_external_writable_locat
     assert env['PYTHONNOUSERSITE'] == '1'
     assert env['PATH'] == '/usr/bin:/bin'
     assert env['PYTHONPATH'] == str(app / 'Contents' / 'Resources' / 'python')
-    writable_keys = ['PYTHONPYCACHEPREFIX', 'TMPDIR', 'PIP_CACHE_DIR', 'HOME', 'XDG_CACHE_HOME', 'XDG_CONFIG_HOME', 'XDG_DATA_HOME', 'TOKEN_PLACE_MODELS_DIR', 'HF_HOME', 'TRANSFORMERS_CACHE']
+    writable_keys = [
+        'PYTHONPYCACHEPREFIX',
+        'TMPDIR',
+        'PIP_CACHE_DIR',
+        'HOME',
+        'XDG_CACHE_HOME',
+        'XDG_CONFIG_HOME',
+        'XDG_DATA_HOME',
+        'TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET',
+        'TOKEN_PLACE_MODELS_DIR',
+        'HF_HOME',
+        'TRANSFORMERS_CACHE',
+    ]
     for key in writable_keys:
         assert not Path(env[key]).resolve().is_relative_to(app.resolve()), key
     assert not Path(captured['cwd']).resolve().is_relative_to(app.resolve())

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -279,6 +279,8 @@ def test_validator_mounts_macos_dmg_with_retry_helper_and_detaches(monkeypatch, 
         return 'hdiutil info snapshot'
 
     monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator.shutil, 'which', lambda name: '/usr/bin/codesign' if name == 'codesign' else None)
+    monkeypatch.setattr(validator, '_run', lambda cmd: '')
     monkeypatch.setattr(validator, '_attach_dmg_with_retries', fake_attach)
     monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', fake_cleanup_state)
 
@@ -675,16 +677,23 @@ def test_validator_sanitized_python_env_replaces_parent_environment(monkeypatch,
         captured['env'] = env
         return subprocess.CompletedProcess(cmd, 0, 'ok', '')
 
-    monkeypatch.setenv('TOKEN_PLACE_PYTHON', '/usr/bin/python3')
-    monkeypatch.setenv('TOKEN_PLACE_SIDECAR_PYTHON', '/usr/bin/python3')
+    forbidden_parent_env = {
+        'PYTHONHOME': '/bad/pythonhome',
+        'PYTHONSTARTUP': '/bad/startup.py',
+        'PYTHONUSERBASE': '/bad/userbase',
+        'TOKEN_PLACE_PYTHON': '/usr/bin/python3',
+        'TOKEN_PLACE_SIDECAR_PYTHON': '/usr/bin/python3',
+    }
+    for key, value in forbidden_parent_env.items():
+        monkeypatch.setenv(key, value)
     monkeypatch.setattr(validator.subprocess, 'run', fake_run)
 
     assert validator._run_python_sanitized(py, 'print(1)', app) == 'ok'
     assert captured['env']['PYTHONNOUSERSITE'] == '1'
     assert captured['env']['PATH'] == '/usr/bin:/bin'
     assert captured['env']['PYTHONPATH'] == str((app / 'Contents' / 'Resources' / 'python').absolute())
-    assert 'TOKEN_PLACE_PYTHON' not in captured['env']
-    assert 'TOKEN_PLACE_SIDECAR_PYTHON' not in captured['env']
+    for key in forbidden_parent_env:
+        assert key not in captured['env']
 
 
 def test_release_workflow_does_not_rebuild_llama_cpp_on_release_matrix() -> None:
@@ -710,7 +719,8 @@ def test_release_workflow_installs_pytest_before_macos_probe() -> None:
     assert install_index < validate_index
     install_step = workflow[install_index:validate_index]
     assert "if: runner.os == 'macOS'" in install_step
-    assert 'python -m pip install --upgrade pip pytest' in install_step
+    assert 'python -m pip install --upgrade pip' in install_step
+    assert "python -m pip install 'pytest>=8.1'" in install_step
 
 
 def test_run_python_sanitized_rejects_forbidden_markers_and_cleans_home(monkeypatch, tmp_path) -> None:
@@ -1350,6 +1360,8 @@ def test_validator_dmg_contents_checks_preview_readme(monkeypatch, tmp_path) -> 
     handle = MountHandle()
     cleanup_calls = []
     monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator.shutil, 'which', lambda name: '/usr/bin/codesign' if name == 'codesign' else None)
+    monkeypatch.setattr(validator, '_run', lambda cmd: '')
     monkeypatch.setattr(validator, '_attach_dmg_with_retries', lambda dmg: handle)
     monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', lambda dmg, path: cleanup_calls.append((dmg, path)))
 
@@ -1417,8 +1429,36 @@ def test_validator_full_main_validates_dmg_and_signing(monkeypatch, tmp_path) ->
     validator.main()
 
     assert dmg_calls == [(dmg, True)]
-    assert run_calls.count(['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)]) == 1
+    assert run_calls.count(['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)]) == 2
     assert ['spctl', '-a', '-vv', '--type', 'execute', str(app)] in run_calls
+
+
+def test_codesign_verify_fails_on_darwin_when_codesign_missing(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Example.app'
+    app.mkdir()
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator.shutil, 'which', lambda name: None)
+
+    try:
+        validator._codesign_verify(app)
+        assert False
+    except SystemExit as exc:
+        assert 'codesign not found in PATH on this macOS machine' in str(exc)
+
+
+def test_codesign_verify_skips_outside_darwin_when_codesign_missing(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Example.app'
+    app.mkdir()
+    calls = []
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Linux')
+    monkeypatch.setattr(validator.shutil, 'which', lambda name: None)
+    monkeypatch.setattr(validator, '_run', lambda cmd: calls.append(cmd))
+
+    validator._codesign_verify(app)
+
+    assert calls == []
 
 
 def test_validator_dmg_contents_rejects_missing_signed_preview_phrase(monkeypatch, tmp_path) -> None:
@@ -1658,7 +1698,13 @@ def test_app_tree_fingerprint_reports_mutations(tmp_path) -> None:
     changes = '\n'.join(validator._describe_app_tree_changes(base, validator._app_tree_fingerprint(app)))
     assert 'unsealed Python bytecode' in changes
     assert 'removed: Contents/Resources/file.txt' in changes
-    assert 'rewritten: Contents/Resources/tool' in changes or 'chmodded: Contents/Resources/tool' in changes
+    assert 'rewritten: Contents/Resources/tool' in changes
+    mode_only = app / 'Contents' / 'Resources' / 'mode-only'
+    mode_only.write_text('same', encoding='utf-8')
+    before_mode = validator._app_tree_fingerprint(app)
+    mode_only.chmod(0o755)
+    mode_changes = validator._describe_app_tree_changes(before_mode, validator._app_tree_fingerprint(app))
+    assert 'chmodded: Contents/Resources/mode-only' in mode_changes
     assert 'retargeted symlink: Contents/Resources/link' in changes
 
 

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -1807,6 +1807,27 @@ def test_desktop_operator_parity_platform_matrix(monkeypatch, case):
         assert invoked == {"pip": True, "source_repair": False}
 
 
+def test_resolve_desktop_dependency_target_prefers_env_override(monkeypatch, tmp_path):
+    runtime_root = tmp_path / 'runtime'
+    home_dir = tmp_path / 'home'
+    override_target = tmp_path / 'external-desktop-site'
+    home_dir.mkdir()
+    probes = []
+
+    def _fake_writable(candidate):
+        probes.append(candidate)
+        return True, None
+
+    monkeypatch.setenv('TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET', str(override_target))
+    monkeypatch.setattr(desktop_runtime_setup.Path, 'home', staticmethod(lambda: home_dir))
+    monkeypatch.setattr(desktop_runtime_setup, '_is_writable_directory', _fake_writable)
+
+    target, error = desktop_runtime_setup._resolve_desktop_dependency_target(runtime_root)
+
+    assert error is None
+    assert target == override_target
+    assert probes == [override_target]
+
 def test_resolve_desktop_dependency_target_prefers_writable_runtime_target(monkeypatch, tmp_path):
     runtime_root = tmp_path / 'runtime'
     home_dir = tmp_path / 'home'


### PR DESCRIPTION
### Motivation

PR #1465 introduced a macOS preview regression by executing packaged-Python probes after Tauri had ad-hoc signed the `.app`. Those probes created `.pyc` files and other writable runtime state inside the bundle, invalidating its resource seal before it was copied into the DMG.

This PR restores structurally valid ad-hoc-signed, unnotarized preview artifacts without requiring an Apple Developer account, Developer ID certificate, notarization, stapling, or successful `spctl` assessment.

### Changes

- Harden `_run_python_sanitized()` in `scripts/validate_desktop_tauri_release_artifacts.py`:
  - invoke Python with `-B`;
  - set `PYTHONDONTWRITEBYTECODE=1` and an external `PYTHONPYCACHEPREFIX`;
  - redirect `HOME`, temporary files, pip/Hugging Face/XDG caches, models, and desktop dependency state outside the `.app`;
  - use a minimal allowlisted environment so host interpreter overrides are not inherited;
  - run from an external working directory inherited by child Python processes.

- Prevent executable probes from touching the distributable build-tree app:
  - app-only and macOS app-without-DMG validation use a disposable, signature-preserving copy;
  - completed DMGs are mounted read-only and the exact mounted root `.app` is validated;
  - macOS `--require-embedded-python-runtime` invocations without `--app-only` or `--dmg-path` now validate a disposable copy instead of silently skipping the runtime probe.

- Add deterministic app-tree fingerprinting and mutation detection covering paths, file hashes, file types, executable bits, and symlink targets. Validation reports added, removed, rewritten, chmodded, or retargeted paths—including unsealed `__pycache__/*.pyc` files—even when the probe itself fails.

- Require `codesign --verify --deep --strict --verbose=4` for ad-hoc preview signatures:
  - immediately after Tauri signing;
  - after runtime validation;
  - on the staged app before DMG creation;
  - on the exact mounted-DMG app.

- Validate the mounted DMG app’s embedded Python structure and provenance, pinned `llama-cpp-python==0.3.32`, Metal/GPU-offload capabilities, Qwen 64K YaRN/RoPE support, packaged `model_bridge.py inspect`, mutation fingerprint, and strict signature.

- Add `TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET` support in `desktop-tauri/src-tauri/python/desktop_runtime_setup.py` so validation probes can direct dependency installation to external scratch storage. Existing runtime-root and home fallback behavior remains unchanged when the override is absent.

- Add focused unit and real-macOS integration coverage for:
  - parent and child imports without bytecode creation;
  - external writable-state locations;
  - disposable-copy and mounted-DMG targeting;
  - mutation detection and rejection;
  - strict ad-hoc signature verification;
  - missing Apple credentials;
  - the external desktop dependency target;
  - macOS runtime validation without a DMG.

- Update the macOS release workflow to install only the focused pytest dependency and run the integration test with an isolated conftest boundary.

### Compatibility and scope

- Preview artifacts remain ad-hoc signed and unnotarized.
- No paid Apple account, Developer ID identity, notarization, stapling, or `spctl` success is required.
- Existing Gatekeeper guidance remains unchanged.
- Windows provisioning and normal desktop dependency-target behavior remain unchanged unless the new override variable is explicitly supplied.
- Existing Qwen3, Metal, model-verification, reasoning-output, and E2EE invariants are preserved.

### Verification

The latest head passed:

- `python -m pytest tests/unit/test_desktop_release_artifacts.py -q`
- `python -m pytest tests/unit/test_desktop_runtime_setup.py -q`
- `python -m pytest tests/unit/test_prepare_embedded_python_runtime.py -q`
- `python -m pytest tests/unit/test_desktop_gpu_packaging.py -q`
- `python -m py_compile scripts/validate_desktop_tauri_release_artifacts.py desktop-tauri/scripts/prepare_embedded_python_runtime.py desktop-tauri/src-tauri/python/desktop_runtime_setup.py`
- `git diff --check`
- `pre-commit run --all-files`

GitHub Actions passed on the latest commit, including:

- CI
- `run_all_tests.sh PR`
- Desktop operator app e2e
- Desktop Tauri Release on macOS 26 and Windows
- The real macOS signing, sanitized-probe, read-only DMG-mount, and mounted-app integration path

------

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56ff484d50832f833908cef83b309e)