### PR TITLE
Restore macOS preview signature integrity and add regression tests

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -370,11 +370,19 @@ jobs:
             if [ -n "${APPLE_SIGNING_IDENTITY:-}" ] && [ -n "${APPLE_CERTIFICATE_P12_BASE64:-}" ] && [ -n "${APPLE_CERTIFICATE_PASSWORD:-}" ]; then
               signing_flag="--expect-signing"
             fi
-            python ../scripts/validate_desktop_tauri_release_artifacts.py               --app-only               --require-embedded-python-runtime               --app-path "${app_path}"               --tauri-config src-tauri/tauri.conf.json               --expected-icon src-tauri/icons/icon.icns               ${signing_flag}
+            codesign --verify --deep --strict --verbose=4 "${app_path}"
+            probe_dir="$(mktemp -d)"
+            trap 'rm -rf "${probe_dir}"' EXIT
+            cp -R "${app_path}" "${probe_dir}/"
+            probe_app="${probe_dir}/$(basename "${app_path}")"
+            python ../scripts/validate_desktop_tauri_release_artifacts.py               --app-only               --require-embedded-python-runtime               --app-path "${probe_app}"               --tauri-config src-tauri/tauri.conf.json               --expected-icon src-tauri/icons/icon.icns               ${signing_flag}
+            codesign --verify --deep --strict --verbose=4 "${app_path}"
 
             rm -rf "${dmg_stage_dir}"
             mkdir -p "${dmg_stage_dir}"
             cp -R "${app_path}" "${dmg_stage_dir}/"
+            staged_app="${dmg_stage_dir}/$(basename "${app_path}")"
+            codesign --verify --deep --strict --verbose=4 "${staged_app}"
             cp "${preview_notice}" "${dmg_stage_dir}/${preview_notice_name}"
             ln -s /Applications "${dmg_stage_dir}/Applications"
             rm -f "${dmg_path}"

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -306,27 +306,39 @@ def _redact_allowed_app_locations(output: str, app_path: Path) -> str:
 def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
     app_for_subprocess = app_path if app_path.is_absolute() else app_path.absolute()
     py_for_subprocess = py if py.is_absolute() else py.absolute()
-    home = tempfile.mkdtemp(prefix="token-place-home-")
+    home = tempfile.mkdtemp(prefix="token-place-python-probe-")
     try:
         app_data = Path(home) / "token.place"
+        pycache_prefix = Path(home) / "pycache"
+        tmpdir = Path(home) / "tmp"
+        pip_cache = app_data / "pip-cache"
+        for writable_dir in (app_data, pycache_prefix, tmpdir, pip_cache):
+            writable_dir.mkdir(parents=True, exist_ok=True)
         env = {
             "HOME": home,
+            "PYTHONDONTWRITEBYTECODE": "1",
             "PYTHONNOUSERSITE": "1",
+            "PYTHONPYCACHEPREFIX": str(pycache_prefix),
+            "TMPDIR": str(tmpdir),
+            "PIP_CACHE_DIR": str(pip_cache),
             "PATH": "/usr/bin:/bin",
             "PYTHONPATH": str(app_for_subprocess / "Contents" / "Resources" / "python"),
             "TOKEN_PLACE_MODELS_DIR": str(app_data / "models"),
+            "TOKEN_PLACE_MODEL_DIR": str(app_data / "models"),
+            "TOKEN_PLACE_CACHE_DIR": str(app_data / "cache"),
             "XDG_CACHE_HOME": str(app_data / "cache"),
             "XDG_CONFIG_HOME": str(app_data / "config"),
             "XDG_DATA_HOME": str(app_data / "data"),
         }
-        probe_cwd = app_for_subprocess / "Contents" / "Resources" / "python"
+        probe_cwd = Path(home) / "cwd"
+        probe_cwd.mkdir(parents=True, exist_ok=True)
         result = subprocess.run(
-            [str(py_for_subprocess), "-c", code],
+            [str(py_for_subprocess), "-B", "-c", code],
             check=False,
             capture_output=True,
             text=True,
             env=env,
-            cwd=str(probe_cwd) if probe_cwd.is_dir() else home,
+            cwd=str(probe_cwd),
         )
         output = f"{result.stdout}\n{result.stderr}"
         scan_output = _redact_allowed_app_locations(output, app_for_subprocess)
@@ -335,10 +347,64 @@ def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
             if marker in scan_output:
                 _fail(f"embedded Python output leaked forbidden marker: {marker}")
         if result.returncode != 0:
-            _fail(_format_command_failure([str(py_for_subprocess), "-c", "<probe>"], result))
+            _fail(_format_command_failure([str(py_for_subprocess), "-B", "-c", "<probe>"], result))
         return output.strip()
     finally:
         shutil.rmtree(home, ignore_errors=True)
+
+
+def _app_tree_fingerprint(app_path: Path) -> dict[str, dict[str, object]]:
+    fingerprint: dict[str, dict[str, object]] = {}
+    for path in sorted(app_path.rglob("*"), key=lambda item: str(item.relative_to(app_path))):
+        rel = path.relative_to(app_path).as_posix()
+        st = path.lstat()
+        entry: dict[str, object] = {"mode": st.st_mode & 0o111}
+        if path.is_symlink():
+            entry.update({"type": "symlink", "target": os.readlink(path)})
+        elif path.is_file():
+            entry.update({"type": "file", "sha256": _sha256(path)})
+        elif path.is_dir():
+            entry.update({"type": "dir"})
+        else:
+            entry.update({"type": "other"})
+        fingerprint[rel] = entry
+    return fingerprint
+
+def _describe_app_tree_mutations(before: dict[str, dict[str, object]], after: dict[str, dict[str, object]]) -> list[str]:
+    changes: list[str] = []
+    before_paths = set(before)
+    after_paths = set(after)
+    for rel in sorted(after_paths - before_paths):
+        note = " (unsealed Python bytecode)" if rel.endswith(".pyc") or "/__pycache__/" in rel else ""
+        changes.append(f"added: {rel}{note}")
+    for rel in sorted(before_paths - after_paths):
+        changes.append(f"removed: {rel}")
+    for rel in sorted(before_paths & after_paths):
+        old = before[rel]
+        new = after[rel]
+        if old.get("type") != new.get("type"):
+            changes.append(f"type changed: {rel} ({old.get('type')} -> {new.get('type')})")
+            continue
+        if old.get("type") == "file" and old.get("sha256") != new.get("sha256"):
+            changes.append(f"rewritten: {rel}")
+        if old.get("mode") != new.get("mode"):
+            changes.append(f"chmodded: {rel}")
+        if old.get("type") == "symlink" and old.get("target") != new.get("target"):
+            changes.append(f"retargeted symlink: {rel} ({old.get('target')} -> {new.get('target')})")
+    return changes
+
+def _assert_app_tree_unchanged(before: dict[str, dict[str, object]], app_path: Path, context: str) -> None:
+    after = _app_tree_fingerprint(app_path)
+    changes = _describe_app_tree_mutations(before, after)
+    if changes:
+        preview = "\n".join(changes[:50])
+        if len(changes) > 50:
+            preview += f"\n... {len(changes) - 50} more changes"
+        _fail(f"{context} mutated app bundle {app_path}; executable probes must not create unsealed files:\n{preview}")
+
+def _verify_existing_macos_signature(app_path: Path) -> None:
+    if platform.system() == "Darwin":
+        _run(["codesign", "--verify", "--deep", "--strict", "--verbose=4", str(app_path)])
 
 def _parse_otool_rpaths(load_commands: str) -> list[str]:
     rpaths: list[str] = []
@@ -514,6 +580,7 @@ def _validate_macho_linkage(path: Path, app_path: Path) -> None:
                 _fail(f"native audit failed in {rel}: arch={arch} category=rpath ref={_safe_macho_ref(rpath)}")
 
 def _validate_embedded_python_runtime(app_path: Path) -> None:
+    mutation_guard = _app_tree_fingerprint(app_path)
     runtime = app_path / "Contents" / "Resources" / "python-runtime"
     py = runtime / "bin" / "python3"
     if not py.exists() or not os.access(py, os.X_OK):
@@ -566,6 +633,7 @@ def _validate_embedded_python_runtime(app_path: Path) -> None:
         _fail("packaged model_bridge.py missing from app resources")
     for candidate in runtime.rglob("*"):
         if candidate.is_file(): _validate_macho_linkage(candidate, app_path)
+    _assert_app_tree_unchanged(mutation_guard, app_path, "embedded Python runtime validation")
 
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser()
@@ -580,7 +648,7 @@ def _parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
+def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool, require_embedded_python_runtime: bool = False) -> None:
     if platform.system() != "Darwin":
         print("::warning::Skipping DMG mounted-content checks outside macOS.")
         return
@@ -599,6 +667,10 @@ def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
             missing = [phrase for phrase in DMG_PREVIEW_REQUIRED_PHRASES if phrase not in readme_text]
             if missing:
                 _fail(f"DMG preview README missing required phrases: {missing}")
+            mounted_app = apps[0]
+            _verify_existing_macos_signature(mounted_app)
+            if require_embedded_python_runtime:
+                _validate_embedded_python_runtime(mounted_app)
             if expect_signing:
                 if DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[1] not in readme_text:
                     _fail(
@@ -632,7 +704,7 @@ def main() -> None:
             _fail(f"dmg artifact missing or invalid: {dmg_path}")
         if not dmg_path.name.startswith("token.place-desktop-") or not dmg_path.name.endswith("-apple-silicon.dmg"):
             _fail(f"DMG filename must match token.place-desktop-<version>-apple-silicon.dmg: {dmg_path.name}")
-        _validate_dmg_contents(dmg_path, expect_signing=args.expect_signing)
+        _validate_dmg_contents(dmg_path, expect_signing=args.expect_signing, require_embedded_python_runtime=args.require_embedded_python_runtime)
 
     if not app_path.exists() or app_path.suffix != ".app":
         _fail(f"app bundle missing or invalid: {app_path}")
@@ -683,17 +755,18 @@ def main() -> None:
     if "x86_64" in arch_lower and "arm64" not in arch_lower:
         _fail(f"binary is x86_64-only: {arch_out}")
 
-    if args.require_embedded_python_runtime:
+    _verify_existing_macos_signature(app_path)
+
+    if args.require_embedded_python_runtime and args.app_only:
         _validate_embedded_python_runtime(app_path)
 
     if args.expect_signing:
-        _run(["codesign", "--verify", "--deep", "--strict", "--verbose=2", str(app_path)])
         if args.expect_notarization:
             _run(["spctl", "-a", "-vv", "--type", "execute", str(app_path)])
         else:
             print("::warning::Signing configured without notarization credentials; skipping strict Gatekeeper assessment.")
     else:
-        print("::warning::Signing credentials not configured; macOS artifact is preview/dev-only and may fail Gatekeeper.")
+        print("::warning::Apple Developer signing credentials not configured; verified existing ad-hoc signature for preview/dev-only macOS artifact.")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_macos_release_signature_integrity.py
+++ b/tests/integration/test_macos_release_signature_integrity.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import importlib.util
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(platform.system() != 'Darwin', reason='requires real macOS codesign and hdiutil')
+
+
+def _validator():
+    script = Path('scripts/validate_desktop_tauri_release_artifacts.py')
+    spec = importlib.util.spec_from_file_location('validate_desktop_tauri_release_artifacts', script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(cmd: list[str]) -> str:
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    assert result.returncode == 0, f"{cmd} failed\nstdout={result.stdout}\nstderr={result.stderr}"
+    return f"{result.stdout}\n{result.stderr}"
+
+
+def _minimal_app(tmp_path: Path) -> Path:
+    app = tmp_path / 'Probe.app'
+    macos = app / 'Contents' / 'MacOS'
+    resources_python = app / 'Contents' / 'Resources' / 'python'
+    macos.mkdir(parents=True)
+    resources_python.mkdir(parents=True)
+    executable = macos / 'Probe'
+    executable.write_text('#!/bin/sh\nexit 0\n', encoding='utf-8')
+    executable.chmod(0o755)
+    (app / 'Contents' / 'Info.plist').write_text(
+        '''<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleExecutable</key><string>Probe</string>
+<key>CFBundleIdentifier</key><string>place.token.probe</string>
+<key>CFBundleName</key><string>Probe</string>
+<key>CFBundlePackageType</key><string>APPL</string>
+</dict></plist>
+''',
+        encoding='utf-8',
+    )
+    (resources_python / 'probe_module.py').write_text('VALUE = 123\n', encoding='utf-8')
+    return app
+
+
+def test_real_macos_ad_hoc_signature_survives_sanitized_probe_and_dmg_mount(tmp_path) -> None:
+    validator = _validator()
+    app = _minimal_app(tmp_path)
+    py = Path(shutil.which('python3') or '')
+    assert py.exists(), 'python3 is required on macOS runner'
+
+    _run(['codesign', '--force', '--deep', '--sign', '-', str(app)])
+    _run(['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)])
+    before = validator._app_tree_fingerprint(app)
+
+    validator._run_python_sanitized(py, 'import probe_module; print(probe_module.VALUE)', app)
+
+    assert validator._describe_app_tree_mutations(before, validator._app_tree_fingerprint(app)) == []
+    assert not list(app.rglob('__pycache__'))
+    assert not list(app.rglob('*.pyc'))
+    _run(['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)])
+
+    pycache = app / 'Contents' / 'Resources' / 'python' / '__pycache__'
+    pycache.mkdir()
+    (pycache / 'probe_module.cpython-311.pyc').write_bytes(b'unsealed')
+    changes = validator._describe_app_tree_mutations(before, validator._app_tree_fingerprint(app))
+    assert any('unsealed Python bytecode' in change for change in changes)
+
+    shutil.rmtree(pycache)
+    _run(['codesign', '--force', '--deep', '--sign', '-', str(app)])
+
+    stage = tmp_path / 'stage'
+    stage.mkdir()
+    shutil.copytree(app, stage / app.name, symlinks=True)
+    (stage / 'README BEFORE OPENING.txt').write_text(
+        'This preview build is ad-hoc signed and not notarized. Apple could not verify. Privacy & Security. Developer ID notarization.',
+        encoding='utf-8',
+    )
+    dmg = tmp_path / 'token.place-desktop-test-apple-silicon.dmg'
+    _run(['hdiutil', 'create', '-volname', 'Probe', '-srcfolder', str(stage), '-ov', '-format', 'UDZO', str(dmg)])
+
+    handle = validator._attach_dmg_with_retries(dmg)
+    try:
+        mounted_app = next(Path(handle.name).glob('*.app'))
+        assert mounted_app.name == app.name
+        validator._verify_existing_macos_signature(mounted_app)
+        validator._run_python_sanitized(py, 'import probe_module; print(probe_module.VALUE)', mounted_app)
+    finally:
+        validator._cleanup_dmg_attach_state(dmg, Path(handle.name))
+        handle.cleanup()

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -281,6 +281,7 @@ def test_validator_mounts_macos_dmg_with_retry_helper_and_detaches(monkeypatch, 
     monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
     monkeypatch.setattr(validator, '_attach_dmg_with_retries', fake_attach)
     monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', fake_cleanup_state)
+    monkeypatch.setattr(validator, '_verify_existing_macos_signature', lambda app: None)
 
     validator._validate_dmg_contents(dmg_path, expect_signing=False)
 
@@ -722,7 +723,7 @@ def test_run_python_sanitized_rejects_forbidden_markers_and_cleans_home(monkeypa
         assert env['XDG_CACHE_HOME'] == str(created_home['path'] / 'token.place' / 'cache')
         assert env['XDG_CONFIG_HOME'] == str(created_home['path'] / 'token.place' / 'config')
         assert env['XDG_DATA_HOME'] == str(created_home['path'] / 'token.place' / 'data')
-        assert cwd == str((app / 'Contents' / 'Resources' / 'python').absolute())
+        assert cwd == str(created_home['path'] / 'cwd')
         return subprocess.CompletedProcess(cmd, 0, '/usr/bin/python3 leaked', '')
 
     monkeypatch.setattr(validator.tempfile, 'mkdtemp', fake_mkdtemp)
@@ -771,7 +772,7 @@ def test_run_python_sanitized_runs_probes_from_packaged_python_resources(monkeyp
     monkeypatch.setattr(validator.subprocess, 'run', fake_run)
 
     assert validator._run_python_sanitized(py, 'print(1)', app) == 'ok'
-    assert seen['cwd'] == str(resources_python.absolute())
+    assert not Path(seen['cwd']).resolve().is_relative_to(app.resolve())
 
 
 def test_run_python_sanitized_absolutizes_relative_interpreter_before_resource_cwd(
@@ -795,7 +796,7 @@ def test_run_python_sanitized_absolutizes_relative_interpreter_before_resource_c
 
     assert validator._run_python_sanitized(py, 'print(1)', app) == 'ok'
     assert seen['cmd'][0] == str((tmp_path / py).absolute())
-    assert seen['cwd'] == str((tmp_path / app / 'Contents' / 'Resources' / 'python').absolute())
+    assert not Path(seen['cwd']).resolve().is_relative_to((tmp_path / app).resolve())
 
 def test_redact_allowed_app_locations_still_flags_runner_paths_outside_app(tmp_path) -> None:
     validator = _load_release_artifact_validator()
@@ -1339,6 +1340,7 @@ def test_validator_dmg_contents_checks_preview_readme(monkeypatch, tmp_path) -> 
     monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
     monkeypatch.setattr(validator, '_attach_dmg_with_retries', lambda dmg: handle)
     monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', lambda dmg, path: cleanup_calls.append((dmg, path)))
+    monkeypatch.setattr(validator, '_verify_existing_macos_signature', lambda app: None)
 
     dmg = tmp_path / 'token.place-desktop-test-apple-silicon.dmg'
     dmg.write_bytes(b'dmg')
@@ -1391,7 +1393,8 @@ def test_validator_full_main_validates_dmg_and_signing(monkeypatch, tmp_path) ->
             expect_notarization=True,
         ),
     )
-    monkeypatch.setattr(validator, '_validate_dmg_contents', lambda path, *, expect_signing: dmg_calls.append((path, expect_signing)))
+    monkeypatch.setattr(validator, '_validate_dmg_contents', lambda path, *, expect_signing, require_embedded_python_runtime=False: dmg_calls.append((path, expect_signing, require_embedded_python_runtime)))
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
 
     def fake_run(cmd):
         run_calls.append(cmd)
@@ -1401,8 +1404,8 @@ def test_validator_full_main_validates_dmg_and_signing(monkeypatch, tmp_path) ->
 
     validator.main()
 
-    assert dmg_calls == [(dmg, True)]
-    assert ['codesign', '--verify', '--deep', '--strict', '--verbose=2', str(app)] in run_calls
+    assert dmg_calls == [(dmg, True, False)]
+    assert ['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)] in run_calls
     assert ['spctl', '-a', '-vv', '--type', 'execute', str(app)] in run_calls
 
 
@@ -1425,6 +1428,7 @@ def test_validator_dmg_contents_rejects_missing_signed_preview_phrase(monkeypatc
     monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
     monkeypatch.setattr(validator, '_attach_dmg_with_retries', lambda dmg: MountHandle())
     monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', lambda dmg, path: None)
+    monkeypatch.setattr(validator, '_verify_existing_macos_signature', lambda app: None)
 
     try:
         validator._validate_dmg_contents(tmp_path / 'token.place-desktop-test-apple-silicon.dmg', expect_signing=True)
@@ -1586,3 +1590,135 @@ def test_validator_embedded_runtime_failure_paths(monkeypatch, tmp_path) -> None
     monkeypatch.setattr(validator, '_validate_macho_linkage', lambda path, app_path: calls.append(str(path)))
     validator._validate_embedded_python_runtime(app)
     assert any('model_bridge.py' in code for code in calls)
+
+
+def test_run_python_sanitized_real_imports_do_not_create_bytecode_in_app(tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Fake.app'
+    resources_python = app / 'Contents' / 'Resources' / 'python'
+    resources_python.mkdir(parents=True)
+    (resources_python / 'fakeprobe.py').write_text('VALUE = 42\n', encoding='utf-8')
+
+    output = validator._run_python_sanitized(
+        Path(subprocess.check_output(['python', '-c', 'import sys; print(sys.executable)'], text=True).strip()),
+        'import fakeprobe; print(fakeprobe.VALUE)',
+        app,
+    )
+
+    assert output.splitlines()[-1] == '42'
+    assert not list(resources_python.rglob('__pycache__'))
+    assert not list(resources_python.rglob('*.pyc'))
+
+
+def test_run_python_sanitized_nested_child_inherits_no_bytecode_env(tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Fake.app'
+    resources_python = app / 'Contents' / 'Resources' / 'python'
+    resources_python.mkdir(parents=True)
+    (resources_python / 'childprobe.py').write_text('VALUE = 99\n', encoding='utf-8')
+    py = Path(subprocess.check_output(['python', '-c', 'import sys; print(sys.executable)'], text=True).strip())
+    code = "import subprocess,sys; raise SystemExit(subprocess.run([sys.executable,'-c','import childprobe; print(childprobe.VALUE)']).returncode)"
+
+    validator._run_python_sanitized(py, code, app)
+
+    assert not list(resources_python.rglob('__pycache__'))
+    assert not list(resources_python.rglob('*.pyc'))
+
+
+def test_app_tree_fingerprint_reports_release_seal_mutations(tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Fake.app'
+    resources = app / 'Contents' / 'Resources'
+    resources.mkdir(parents=True)
+    payload = resources / 'payload.txt'
+    payload.write_text('before', encoding='utf-8')
+    executable = resources / 'tool'
+    executable.write_text('run', encoding='utf-8')
+    executable.chmod(0o644)
+    link = resources / 'link'
+    link.symlink_to('payload.txt')
+    before = validator._app_tree_fingerprint(app)
+
+    (resources / '__pycache__').mkdir()
+    (resources / '__pycache__' / 'payload.cpython-311.pyc').write_bytes(b'pyc')
+    payload.unlink()
+    (resources / 'tool').write_text('rewritten', encoding='utf-8')
+    executable.chmod(0o755)
+    link.unlink()
+    link.symlink_to('tool')
+
+    changes = validator._describe_app_tree_mutations(before, validator._app_tree_fingerprint(app))
+
+    assert any('unsealed Python bytecode' in change for change in changes)
+    assert any(change.startswith('removed: Contents/Resources/payload.txt') for change in changes)
+    assert any(change.startswith('rewritten: Contents/Resources/tool') for change in changes)
+    assert any(change.startswith('chmodded: Contents/Resources/tool') for change in changes)
+    assert any(change.startswith('retargeted symlink: Contents/Resources/link') for change in changes)
+
+
+def test_mutating_embedded_runtime_probe_fails_with_pyc_context(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app, _tauri_config, _icon = _minimal_validator_app(validator, tmp_path)
+    runtime = app / 'Contents' / 'Resources' / 'python-runtime'
+    py = runtime / 'bin' / 'python3'
+    py.parent.mkdir(parents=True)
+    py.write_text('python')
+    py.chmod(0o755)
+    for name in ('embedded_python_runtime_provenance.json', 'LICENSE-PYTHON.txt', 'LICENSE-python-build-standalone.txt'):
+        (runtime / name).write_text('{}', encoding='utf-8')
+    python_dir = app / 'Contents' / 'Resources' / 'python'
+    python_dir.mkdir(exist_ok=True)
+    (python_dir / 'model_bridge.py').write_text('print("ok")', encoding='utf-8')
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Linux')
+    monkeypatch.setattr(validator, '_validate_macho_linkage', lambda path, app_path: None)
+
+    def mutating_probe(_py, code, _app):
+        if 'version_info' in code:
+            return json.dumps({'version': [3, 11], 'machine': 'arm64', 'executable': str(py), 'prefix': str(runtime), 'llama_cpp_python_version': '0.3.32'})
+        if '_probe_llama_runtime' in code:
+            (python_dir / '__pycache__').mkdir(exist_ok=True)
+            (python_dir / '__pycache__' / 'model_bridge.cpython-311.pyc').write_bytes(b'pyc')
+            return json.dumps({'backend': 'metal', 'gpu_offload_supported': True, 'qwen_64k_yarn_support': 'supported', 'rope_scaling_type_supported': True, 'rope_freq_scale_supported': True, 'yarn_orig_ctx_supported': True, 'constructor_kwarg_support': {'flash_attn': True, 'offload_kqv': True, 'n_batch': True, 'n_ubatch': True}})
+        return 'ok'
+
+    monkeypatch.setattr(validator, '_run_python_sanitized', mutating_probe)
+    try:
+        validator._validate_embedded_python_runtime(app)
+        assert False
+    except SystemExit as exc:
+        message = str(exc)
+    assert 'mutated app bundle' in message
+    assert 'unsealed Python bytecode' in message
+
+
+def test_preview_workflow_verifies_ad_hoc_signatures_and_avoids_notarization_requirement() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'codesign --verify --deep --strict --verbose=4 "${app_path}"' in text
+    assert 'codesign --verify --deep --strict --verbose=4 "${staged_app}"' in text
+    assert 'notarytool' not in text.split('- name: Validate macOS staged artifact guardrails', 1)[1]
+    assert 'stapler' not in text
+    assert 'spctl' not in text.split('- name: Validate macOS staged artifact guardrails', 1)[0]
+
+
+def test_mounted_dmg_validation_targets_mounted_app_for_runtime_and_signature(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    mount = tmp_path / 'mount'
+    mounted_app = mount / 'token.place desktop.app'
+    mounted_app.mkdir(parents=True)
+    (mount / 'README BEFORE OPENING.txt').write_text('ad-hoc signed not notarized Apple could not verify Privacy & Security Developer ID notarization')
+    calls = []
+
+    class MountHandle:
+        name = str(mount)
+        def cleanup(self):
+            pass
+
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator, '_attach_dmg_with_retries', lambda dmg: MountHandle())
+    monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', lambda dmg, path: None)
+    monkeypatch.setattr(validator, '_verify_existing_macos_signature', lambda app: calls.append(('codesign', app)))
+    monkeypatch.setattr(validator, '_validate_embedded_python_runtime', lambda app: calls.append(('runtime', app)))
+
+    validator._validate_dmg_contents(tmp_path / 'token.place-desktop-test-apple-silicon.dmg', expect_signing=False, require_embedded_python_runtime=True)
+
+    assert calls == [('codesign', mounted_app), ('runtime', mounted_app)]


### PR DESCRIPTION
### Motivation
- A recent change caused the validator to execute the embedded Python runtime inside an already-signed .app which produced post-sign `.pyc` files and broke the codesign resource seal for ad-hoc preview DMGs.
- The release workflow treated ad-hoc-signed preview apps as unsigned for strict verification, allowing mutated apps to be copied into the DMG.
- The goal is to ensure preview artifacts remain structurally valid for ad-hoc signing (no post-sign unsealed files) without requiring paid Apple credentials or notarization.

### Description
- Make packaged-Python probes non-mutating by running Python with `-B`, setting `PYTHONDONTWRITEBYTECODE=1`, `PYTHONPYCACHEPREFIX` to a temp dir, and redirecting `TMPDIR`, `PIP_CACHE_DIR`, `HOME`, and XDG dirs outside the app, while using an out-of-app working directory so child processes inherit the same non-writing environment (changes in `scripts/validate_desktop_tauri_release_artifacts.py` `_run_python_sanitized`).
- Add deterministic app-tree fingerprinting and mutation reporting (`_app_tree_fingerprint`, `_describe_app_tree_mutations`, `_assert_app_tree_unchanged`) and apply a guard around embedded runtime probes so any added/removed/rewritten/chmodded/retargeted paths (explicitly flagging unsealed `.pyc`/`__pycache__`) fail validation.
- Verify existing macOS signatures (ad-hoc identity `-` included) via `codesign --verify --deep --strict --verbose=4` separated from paid signing operations and run it at these points: immediately after Tauri ad-hoc signing, after runtime validation, on the staged app before DMG creation, and against the exact mounted app from the DMG (added `_verify_existing_macos_signature`).
- Never probe the distributable app in-place: workflow updated to copy the signed `.app` to a disposable probe directory and run executable runtime validation on that copy, then re-verify the original and staged apps; mounted-DMG checks now target the actual root `.app` from the mounted image.
- Tests: extended `tests/unit/test_desktop_release_artifacts.py` with behavioral tests that assert `-B` and no-bytecode environment, child-process inheritance, non-mutation detection for added/removed/rewritten/chmodded/retargeted paths, failing on mutating probes, and mounted-DMG runtime/signature targeting; added an integration test `tests/integration/test_macos_release_signature_integrity.py` that runs the real macOS flow and is skipped on non-Darwin runners.

### Testing
- Ran `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` and it passed (new unit coverage for sanitized probes, fingerprinting, mutating-probe rejection, and mounted-DMG targeting).
- Ran `python -m pytest tests/unit/test_prepare_embedded_python_runtime.py -q` and `python -m pytest tests/unit/test_desktop_gpu_packaging.py -q` and both test suites passed.
- Verified `scripts/validate_desktop_tauri_release_artifacts.py` compiles with `python -m py_compile scripts/validate_desktop_tauri_release_artifacts.py desktop-tauri/scripts/prepare_embedded_python_runtime.py` (passed) and ran `git diff --check` and `pre-commit run --all-files` (passed).
- Added a real macOS integration test and exercised it locally where possible; `python -m pytest tests/integration/test_macos_release_signature_integrity.py -q` is included but is skipped on non-macOS runners (skipped in the Linux environment used for verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56ff5829c8832fa626b7ab49874180)