### PR TITLE
Prevent post-sign app mutation during macOS preview probes and enforce ad‑hoc signature verification

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -370,11 +370,18 @@ jobs:
             if [ -n "${APPLE_SIGNING_IDENTITY:-}" ] && [ -n "${APPLE_CERTIFICATE_P12_BASE64:-}" ] && [ -n "${APPLE_CERTIFICATE_PASSWORD:-}" ]; then
               signing_flag="--expect-signing"
             fi
-            python ../scripts/validate_desktop_tauri_release_artifacts.py               --app-only               --require-embedded-python-runtime               --app-path "${app_path}"               --tauri-config src-tauri/tauri.conf.json               --expected-icon src-tauri/icons/icon.icns               ${signing_flag}
+            codesign --verify --deep --strict --verbose=4 "${app_path}"
+            runtime_probe_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/token-place-runtime-probe.XXXXXX")"
+            runtime_probe_app="${runtime_probe_dir}/$(basename "${app_path}")"
+            cp -R "${app_path}" "${runtime_probe_app}"
+            python ../scripts/validate_desktop_tauri_release_artifacts.py               --app-only               --require-embedded-python-runtime               --app-path "${runtime_probe_app}"               --tauri-config src-tauri/tauri.conf.json               --expected-icon src-tauri/icons/icon.icns               ${signing_flag}
+            codesign --verify --deep --strict --verbose=4 "${app_path}"
 
             rm -rf "${dmg_stage_dir}"
             mkdir -p "${dmg_stage_dir}"
             cp -R "${app_path}" "${dmg_stage_dir}/"
+            staged_app="${dmg_stage_dir}/$(basename "${app_path}")"
+            codesign --verify --deep --strict --verbose=4 "${staged_app}"
             cp "${preview_notice}" "${dmg_stage_dir}/${preview_notice_name}"
             ln -s /Applications "${dmg_stage_dir}/Applications"
             rm -f "${dmg_path}"
@@ -441,6 +448,8 @@ jobs:
             if [ -n "${APPLE_NOTARYTOOL_KEYCHAIN_PROFILE:-}" ]; then
               echo "::warning::APPLE_NOTARYTOOL_KEYCHAIN_PROFILE is set, but notarization/stapling is not performed in this workflow yet; skipping strict Gatekeeper notarization enforcement."
             fi
+          else
+            echo "Apple Developer credentials absent; validating the required ad-hoc preview signature."
           fi
 
           python ../scripts/validate_desktop_tauri_release_artifacts.py               --require-embedded-python-runtime               --app-path "${app_path}"               --dmg-path "${dmg_path}"               --tauri-config src-tauri/tauri.conf.json               --expected-icon src-tauri/icons/icon.icns               ${signing_flag}

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -309,24 +309,39 @@ def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
     home = tempfile.mkdtemp(prefix="token-place-home-")
     try:
         app_data = Path(home) / "token.place"
+        pycache_prefix = Path(home) / "pycache-prefix"
+        tmpdir = Path(home) / "tmp"
+        for path in (app_data, pycache_prefix, tmpdir):
+            path.mkdir(parents=True, exist_ok=True)
         env = {
             "HOME": home,
+            "PYTHONDONTWRITEBYTECODE": "1",
             "PYTHONNOUSERSITE": "1",
+            "PYTHONPYCACHEPREFIX": str(pycache_prefix),
+            "TMPDIR": str(tmpdir),
+            "TEMP": str(tmpdir),
+            "TMP": str(tmpdir),
+            "PIP_CACHE_DIR": str(app_data / "pip-cache"),
             "PATH": "/usr/bin:/bin",
             "PYTHONPATH": str(app_for_subprocess / "Contents" / "Resources" / "python"),
             "TOKEN_PLACE_MODELS_DIR": str(app_data / "models"),
+            "TOKEN_PLACE_CACHE_DIR": str(app_data / "cache"),
+            "HF_HOME": str(app_data / "hf-home"),
+            "HUGGINGFACE_HUB_CACHE": str(app_data / "hf-cache"),
+            "TRANSFORMERS_CACHE": str(app_data / "transformers-cache"),
             "XDG_CACHE_HOME": str(app_data / "cache"),
             "XDG_CONFIG_HOME": str(app_data / "config"),
             "XDG_DATA_HOME": str(app_data / "data"),
         }
-        probe_cwd = app_for_subprocess / "Contents" / "Resources" / "python"
+        for key in ("PYTHONHOME", "PYTHONEXECUTABLE", "PYTHONUSERBASE", "PYTHONSTARTUP", "VIRTUAL_ENV", "CONDA_PREFIX"):
+            env.pop(key, None)
         result = subprocess.run(
-            [str(py_for_subprocess), "-c", code],
+            [str(py_for_subprocess), "-B", "-c", code],
             check=False,
             capture_output=True,
             text=True,
             env=env,
-            cwd=str(probe_cwd) if probe_cwd.is_dir() else home,
+            cwd=home,
         )
         output = f"{result.stdout}\n{result.stderr}"
         scan_output = _redact_allowed_app_locations(output, app_for_subprocess)
@@ -335,10 +350,64 @@ def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
             if marker in scan_output:
                 _fail(f"embedded Python output leaked forbidden marker: {marker}")
         if result.returncode != 0:
-            _fail(_format_command_failure([str(py_for_subprocess), "-c", "<probe>"], result))
+            _fail(_format_command_failure([str(py_for_subprocess), "-B", "-c", "<probe>"], result))
         return output.strip()
     finally:
         shutil.rmtree(home, ignore_errors=True)
+
+
+def _app_tree_fingerprint(app_path: Path) -> dict[str, dict[str, object]]:
+    fingerprint: dict[str, dict[str, object]] = {}
+    for path in sorted(app_path.rglob("*")):
+        rel = path.relative_to(app_path).as_posix()
+        try:
+            st = path.lstat()
+        except FileNotFoundError:
+            continue
+        mode = st.st_mode & 0o777
+        if path.is_symlink():
+            fingerprint[rel] = {"type": "symlink", "mode": mode, "target": os.readlink(path)}
+        elif path.is_file():
+            fingerprint[rel] = {"type": "file", "mode": mode, "sha256": _sha256(path), "executable": bool(mode & 0o111)}
+        elif path.is_dir():
+            fingerprint[rel] = {"type": "dir", "mode": mode}
+        else:
+            fingerprint[rel] = {"type": "other", "mode": mode}
+    return fingerprint
+
+
+def _describe_app_tree_mutations(before: dict[str, dict[str, object]], after: dict[str, dict[str, object]]) -> list[str]:
+    changes: list[str] = []
+    before_keys = set(before)
+    after_keys = set(after)
+    for rel in sorted(after_keys - before_keys):
+        marker = " (unsealed Python bytecode)" if rel.endswith(".pyc") or "/__pycache__/" in f"/{rel}" else ""
+        changes.append(f"added: {rel}{marker}")
+    for rel in sorted(before_keys - after_keys):
+        changes.append(f"removed: {rel}")
+    for rel in sorted(before_keys & after_keys):
+        old = before[rel]
+        new = after[rel]
+        if old.get("type") != new.get("type"):
+            changes.append(f"type changed: {rel} ({old.get('type')} -> {new.get('type')})")
+        elif old.get("type") == "file" and old.get("sha256") != new.get("sha256"):
+            changes.append(f"rewritten: {rel}")
+        elif old.get("type") == "symlink" and old.get("target") != new.get("target"):
+            changes.append(f"retargeted symlink: {rel} ({old.get('target')} -> {new.get('target')})")
+        if old.get("mode") != new.get("mode"):
+            changes.append(f"chmodded: {rel} ({old.get('mode')!r} -> {new.get('mode')!r})")
+    return changes
+
+
+def _assert_app_tree_unchanged(app_path: Path, before: dict[str, dict[str, object]]) -> None:
+    changes = _describe_app_tree_mutations(before, _app_tree_fingerprint(app_path))
+    if changes:
+        _fail("Executable app validation mutated the signed app bundle; post-sign unsealed files are forbidden:\n" + "\n".join(changes[:50]))
+
+
+def _verify_codesign_strict(app_path: Path) -> None:
+    if platform.system() == "Darwin":
+        _run(["codesign", "--verify", "--deep", "--strict", "--verbose=4", str(app_path)])
 
 def _parse_otool_rpaths(load_commands: str) -> list[str]:
     rpaths: list[str] = []
@@ -514,59 +583,62 @@ def _validate_macho_linkage(path: Path, app_path: Path) -> None:
                 _fail(f"native audit failed in {rel}: arch={arch} category=rpath ref={_safe_macho_ref(rpath)}")
 
 def _validate_embedded_python_runtime(app_path: Path) -> None:
-    runtime = app_path / "Contents" / "Resources" / "python-runtime"
-    py = runtime / "bin" / "python3"
-    if not py.exists() or not os.access(py, os.X_OK):
-        _fail(f"embedded Python interpreter missing or not executable at exact packaged path: {py}")
-    if not (runtime / "embedded_python_runtime_provenance.json").is_file():
-        _fail("embedded runtime provenance missing")
-    for notice in ("LICENSE-PYTHON.txt", "LICENSE-python-build-standalone.txt"):
-        if not (runtime / notice).is_file():
-            _fail(f"embedded runtime notice missing: {notice}")
-    if platform.system() == "Darwin":
-        arch = _run(["lipo", "-archs", str(py)]).lower()
-        if "arm64" not in arch or ("x86_64" in arch and "arm64" not in arch):
-            _fail(f"embedded Python is not arm64: {arch}")
-    code = "import importlib.metadata as im,json,platform,sys; import psutil,requests,dotenv,cryptography,jinja2,numpy,diskcache,llama_cpp; print(json.dumps({'version':sys.version_info[:2],'machine':platform.machine(),'executable':sys.executable,'prefix':sys.prefix,'llama_cpp_python_version':im.version('llama-cpp-python')}))"
-    payload = json.loads(_run_python_sanitized(py, code, app_path).splitlines()[-1])
-    if payload.get("version") != [3, 11]:
-        _fail(f"embedded Python is not CPython 3.11: {payload.get('version')}")
-    if payload.get("machine") != "arm64":
-        _fail(f"embedded Python is not arm64: {payload.get('machine')}")
-    if payload.get("llama_cpp_python_version") != "0.3.32":
-        _fail("embedded runtime has wrong llama-cpp-python version")
-    for key in ("executable", "prefix"):
-        if not Path(payload[key]).resolve().is_relative_to(app_path.resolve()):
-            _fail(f"embedded Python {key} escaped app bundle: {payload[key]}")
-    _run_python_sanitized(py, "import subprocess,sys; raise SystemExit(subprocess.run([sys.executable,'-m','pip','check']).returncode)", app_path)
-    probe = "import json; from desktop_runtime_setup import _probe_llama_runtime; p=_probe_llama_runtime(); print(json.dumps(p.__dict__))"
-    out = _run_python_sanitized(py, probe, app_path)
-    data = json.loads(out.splitlines()[-1])
-    if data.get("backend") != "metal" or not data.get("gpu_offload_supported"):
-        _fail("embedded runtime probe did not report Metal GPU offload")
-    if data.get("qwen_64k_yarn_support") != "supported":
-        _fail("embedded runtime probe missing capability: qwen_64k_yarn_support")
-    top_level_capabilities = {
-        "rope_scaling_type": "rope_scaling_type_supported",
-        "rope_freq_scale": "rope_freq_scale_supported",
-        "yarn_orig_ctx": "yarn_orig_ctx_supported",
-    }
-    for name, field in top_level_capabilities.items():
-        if not data.get(field):
-            _fail(f"embedded runtime probe missing capability: {name}")
-    constructor_support = data.get("constructor_kwarg_support") or {}
-    for key in ("flash_attn", "offload_kqv", "n_batch", "n_ubatch"):
-        if not constructor_support.get(key):
-            _fail(f"embedded runtime probe missing capability: {key}")
-    model_bridge = app_path / "Contents" / "Resources" / "python" / "model_bridge.py"
-    if model_bridge.is_file():
-        model_bridge_for_subprocess = model_bridge if model_bridge.is_absolute() else model_bridge.absolute()
-        _run_python_sanitized(py, f"import subprocess,sys; raise SystemExit(subprocess.run([sys.executable, {str(model_bridge_for_subprocess)!r}, 'inspect']).returncode)", app_path)
-    else:
-        _fail("packaged model_bridge.py missing from app resources")
-    for candidate in runtime.rglob("*"):
-        if candidate.is_file(): _validate_macho_linkage(candidate, app_path)
-
+    mutation_guard = _app_tree_fingerprint(app_path)
+    try:
+        runtime = app_path / "Contents" / "Resources" / "python-runtime"
+        py = runtime / "bin" / "python3"
+        if not py.exists() or not os.access(py, os.X_OK):
+            _fail(f"embedded Python interpreter missing or not executable at exact packaged path: {py}")
+        if not (runtime / "embedded_python_runtime_provenance.json").is_file():
+            _fail("embedded runtime provenance missing")
+        for notice in ("LICENSE-PYTHON.txt", "LICENSE-python-build-standalone.txt"):
+            if not (runtime / notice).is_file():
+                _fail(f"embedded runtime notice missing: {notice}")
+        if platform.system() == "Darwin":
+            arch = _run(["lipo", "-archs", str(py)]).lower()
+            if "arm64" not in arch or ("x86_64" in arch and "arm64" not in arch):
+                _fail(f"embedded Python is not arm64: {arch}")
+        code = "import importlib.metadata as im,json,platform,sys; import psutil,requests,dotenv,cryptography,jinja2,numpy,diskcache,llama_cpp; print(json.dumps({'version':sys.version_info[:2],'machine':platform.machine(),'executable':sys.executable,'prefix':sys.prefix,'llama_cpp_python_version':im.version('llama-cpp-python')}))"
+        payload = json.loads(_run_python_sanitized(py, code, app_path).splitlines()[-1])
+        if payload.get("version") != [3, 11]:
+            _fail(f"embedded Python is not CPython 3.11: {payload.get('version')}")
+        if payload.get("machine") != "arm64":
+            _fail(f"embedded Python is not arm64: {payload.get('machine')}")
+        if payload.get("llama_cpp_python_version") != "0.3.32":
+            _fail("embedded runtime has wrong llama-cpp-python version")
+        for key in ("executable", "prefix"):
+            if not Path(payload[key]).resolve().is_relative_to(app_path.resolve()):
+                _fail(f"embedded Python {key} escaped app bundle: {payload[key]}")
+        _run_python_sanitized(py, "import subprocess,sys; raise SystemExit(subprocess.run([sys.executable,'-m','pip','check']).returncode)", app_path)
+        probe = "import json; from desktop_runtime_setup import _probe_llama_runtime; p=_probe_llama_runtime(); print(json.dumps(p.__dict__))"
+        out = _run_python_sanitized(py, probe, app_path)
+        data = json.loads(out.splitlines()[-1])
+        if data.get("backend") != "metal" or not data.get("gpu_offload_supported"):
+            _fail("embedded runtime probe did not report Metal GPU offload")
+        if data.get("qwen_64k_yarn_support") != "supported":
+            _fail("embedded runtime probe missing capability: qwen_64k_yarn_support")
+        top_level_capabilities = {
+            "rope_scaling_type": "rope_scaling_type_supported",
+            "rope_freq_scale": "rope_freq_scale_supported",
+            "yarn_orig_ctx": "yarn_orig_ctx_supported",
+        }
+        for name, field in top_level_capabilities.items():
+            if not data.get(field):
+                _fail(f"embedded runtime probe missing capability: {name}")
+        constructor_support = data.get("constructor_kwarg_support") or {}
+        for key in ("flash_attn", "offload_kqv", "n_batch", "n_ubatch"):
+            if not constructor_support.get(key):
+                _fail(f"embedded runtime probe missing capability: {key}")
+        model_bridge = app_path / "Contents" / "Resources" / "python" / "model_bridge.py"
+        if model_bridge.is_file():
+            model_bridge_for_subprocess = model_bridge if model_bridge.is_absolute() else model_bridge.absolute()
+            _run_python_sanitized(py, f"import subprocess,sys; raise SystemExit(subprocess.run([sys.executable, {str(model_bridge_for_subprocess)!r}, 'inspect']).returncode)", app_path)
+        else:
+            _fail("packaged model_bridge.py missing from app resources")
+        for candidate in runtime.rglob("*"):
+            if candidate.is_file(): _validate_macho_linkage(candidate, app_path)
+    finally:
+        _assert_app_tree_unchanged(app_path, mutation_guard)
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser()
     p.add_argument("--app-path", required=True)
@@ -580,7 +652,7 @@ def _parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
+def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool, require_embedded_python_runtime: bool = False) -> None:
     if platform.system() != "Darwin":
         print("::warning::Skipping DMG mounted-content checks outside macOS.")
         return
@@ -599,6 +671,10 @@ def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
             missing = [phrase for phrase in DMG_PREVIEW_REQUIRED_PHRASES if phrase not in readme_text]
             if missing:
                 _fail(f"DMG preview README missing required phrases: {missing}")
+            mounted_app = apps[0]
+            _verify_codesign_strict(mounted_app)
+            if require_embedded_python_runtime:
+                _validate_embedded_python_runtime(mounted_app)
             if expect_signing:
                 if DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[1] not in readme_text:
                     _fail(
@@ -632,7 +708,7 @@ def main() -> None:
             _fail(f"dmg artifact missing or invalid: {dmg_path}")
         if not dmg_path.name.startswith("token.place-desktop-") or not dmg_path.name.endswith("-apple-silicon.dmg"):
             _fail(f"DMG filename must match token.place-desktop-<version>-apple-silicon.dmg: {dmg_path.name}")
-        _validate_dmg_contents(dmg_path, expect_signing=args.expect_signing)
+        _validate_dmg_contents(dmg_path, expect_signing=args.expect_signing, require_embedded_python_runtime=args.require_embedded_python_runtime)
 
     if not app_path.exists() or app_path.suffix != ".app":
         _fail(f"app bundle missing or invalid: {app_path}")
@@ -683,17 +759,18 @@ def main() -> None:
     if "x86_64" in arch_lower and "arm64" not in arch_lower:
         _fail(f"binary is x86_64-only: {arch_out}")
 
-    if args.require_embedded_python_runtime:
+    if args.require_embedded_python_runtime and args.app_only:
         _validate_embedded_python_runtime(app_path)
 
+    _verify_codesign_strict(app_path)
+
     if args.expect_signing:
-        _run(["codesign", "--verify", "--deep", "--strict", "--verbose=2", str(app_path)])
         if args.expect_notarization:
             _run(["spctl", "-a", "-vv", "--type", "execute", str(app_path)])
         else:
             print("::warning::Signing configured without notarization credentials; skipping strict Gatekeeper assessment.")
     else:
-        print("::warning::Signing credentials not configured; macOS artifact is preview/dev-only and may fail Gatekeeper.")
+        print("::warning::Apple Developer credentials not configured; requiring ad-hoc signature verification only for this preview build.")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
+import sys
 from pathlib import Path
+
+import pytest
 
 WORKFLOW = Path('.github/workflows/desktop-release.yml')
 TAURI_CONFIG = Path('desktop-tauri/src-tauri/tauri.conf.json')
@@ -281,6 +285,7 @@ def test_validator_mounts_macos_dmg_with_retry_helper_and_detaches(monkeypatch, 
     monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
     monkeypatch.setattr(validator, '_attach_dmg_with_retries', fake_attach)
     monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', fake_cleanup_state)
+    monkeypatch.setattr(validator, '_verify_codesign_strict', lambda app: None)
 
     validator._validate_dmg_contents(dmg_path, expect_signing=False)
 
@@ -722,7 +727,10 @@ def test_run_python_sanitized_rejects_forbidden_markers_and_cleans_home(monkeypa
         assert env['XDG_CACHE_HOME'] == str(created_home['path'] / 'token.place' / 'cache')
         assert env['XDG_CONFIG_HOME'] == str(created_home['path'] / 'token.place' / 'config')
         assert env['XDG_DATA_HOME'] == str(created_home['path'] / 'token.place' / 'data')
-        assert cwd == str((app / 'Contents' / 'Resources' / 'python').absolute())
+        assert cwd == str(created_home['path'])
+        assert cmd[1] == '-B'
+        assert env['PYTHONDONTWRITEBYTECODE'] == '1'
+        assert not Path(env['PYTHONPYCACHEPREFIX']).is_relative_to(app)
         return subprocess.CompletedProcess(cmd, 0, '/usr/bin/python3 leaked', '')
 
     monkeypatch.setattr(validator.tempfile, 'mkdtemp', fake_mkdtemp)
@@ -771,7 +779,8 @@ def test_run_python_sanitized_runs_probes_from_packaged_python_resources(monkeyp
     monkeypatch.setattr(validator.subprocess, 'run', fake_run)
 
     assert validator._run_python_sanitized(py, 'print(1)', app) == 'ok'
-    assert seen['cwd'] == str(resources_python.absolute())
+    assert seen['cwd'] != str(resources_python.absolute())
+    assert not Path(seen['cwd']).is_relative_to(app)
 
 
 def test_run_python_sanitized_absolutizes_relative_interpreter_before_resource_cwd(
@@ -795,7 +804,7 @@ def test_run_python_sanitized_absolutizes_relative_interpreter_before_resource_c
 
     assert validator._run_python_sanitized(py, 'print(1)', app) == 'ok'
     assert seen['cmd'][0] == str((tmp_path / py).absolute())
-    assert seen['cwd'] == str((tmp_path / app / 'Contents' / 'Resources' / 'python').absolute())
+    assert seen['cwd'] != str((tmp_path / app / 'Contents' / 'Resources' / 'python').absolute())
 
 def test_redact_allowed_app_locations_still_flags_runner_paths_outside_app(tmp_path) -> None:
     validator = _load_release_artifact_validator()
@@ -1339,6 +1348,7 @@ def test_validator_dmg_contents_checks_preview_readme(monkeypatch, tmp_path) -> 
     monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
     monkeypatch.setattr(validator, '_attach_dmg_with_retries', lambda dmg: handle)
     monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', lambda dmg, path: cleanup_calls.append((dmg, path)))
+    monkeypatch.setattr(validator, '_verify_codesign_strict', lambda app: None)
 
     dmg = tmp_path / 'token.place-desktop-test-apple-silicon.dmg'
     dmg.write_bytes(b'dmg')
@@ -1391,7 +1401,8 @@ def test_validator_full_main_validates_dmg_and_signing(monkeypatch, tmp_path) ->
             expect_notarization=True,
         ),
     )
-    monkeypatch.setattr(validator, '_validate_dmg_contents', lambda path, *, expect_signing: dmg_calls.append((path, expect_signing)))
+    monkeypatch.setattr(validator, '_validate_dmg_contents', lambda path, **kwargs: dmg_calls.append((path, kwargs['expect_signing'])))
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
 
     def fake_run(cmd):
         run_calls.append(cmd)
@@ -1402,7 +1413,7 @@ def test_validator_full_main_validates_dmg_and_signing(monkeypatch, tmp_path) ->
     validator.main()
 
     assert dmg_calls == [(dmg, True)]
-    assert ['codesign', '--verify', '--deep', '--strict', '--verbose=2', str(app)] in run_calls
+    assert ['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)] in run_calls
     assert ['spctl', '-a', '-vv', '--type', 'execute', str(app)] in run_calls
 
 
@@ -1425,6 +1436,7 @@ def test_validator_dmg_contents_rejects_missing_signed_preview_phrase(monkeypatc
     monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
     monkeypatch.setattr(validator, '_attach_dmg_with_retries', lambda dmg: MountHandle())
     monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', lambda dmg, path: None)
+    monkeypatch.setattr(validator, '_verify_codesign_strict', lambda app: None)
 
     try:
         validator._validate_dmg_contents(tmp_path / 'token.place-desktop-test-apple-silicon.dmg', expect_signing=True)
@@ -1586,3 +1598,141 @@ def test_validator_embedded_runtime_failure_paths(monkeypatch, tmp_path) -> None
     monkeypatch.setattr(validator, '_validate_macho_linkage', lambda path, app_path: calls.append(str(path)))
     validator._validate_embedded_python_runtime(app)
     assert any('model_bridge.py' in code for code in calls)
+
+def test_run_python_sanitized_imports_app_module_without_bytecode_in_parent_or_child(tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Example.app'
+    package_dir = app / 'Contents' / 'Resources' / 'python'
+    package_dir.mkdir(parents=True)
+    (package_dir / 'probe_module.py').write_text('VALUE = 42\n', encoding='utf-8')
+    code = "import probe_module, subprocess, sys; subprocess.check_call([sys.executable, '-c', 'import probe_module']); print(probe_module.VALUE)"
+
+    assert validator._run_python_sanitized(Path(sys.executable), code, app).splitlines()[-1] == '42'
+    assert not list(package_dir.rglob('__pycache__'))
+    assert not list(package_dir.rglob('*.pyc'))
+
+
+def test_app_tree_fingerprint_reports_mutations(tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Example.app'
+    resources = app / 'Contents' / 'Resources'
+    resources.mkdir(parents=True)
+    keep = resources / 'keep.txt'
+    keep.write_text('before', encoding='utf-8')
+    remove = resources / 'remove.txt'
+    remove.write_text('remove', encoding='utf-8')
+    executable = resources / 'tool'
+    executable.write_text('tool', encoding='utf-8')
+    executable.chmod(0o644)
+    link = resources / 'link'
+    link.symlink_to('keep.txt')
+    before = validator._app_tree_fingerprint(app)
+
+    (resources / '__pycache__').mkdir()
+    (resources / '__pycache__' / 'new.cpython-312.pyc').write_bytes(b'pyc')
+    remove.unlink()
+    keep.write_text('after', encoding='utf-8')
+    executable.chmod(0o755)
+    link.unlink()
+    link.symlink_to('tool')
+
+    changes = validator._describe_app_tree_mutations(before, validator._app_tree_fingerprint(app))
+    assert any('unsealed Python bytecode' in change for change in changes)
+    assert any(change.startswith('removed: Contents/Resources/remove.txt') for change in changes)
+    assert any(change.startswith('rewritten: Contents/Resources/keep.txt') for change in changes)
+    assert any(change.startswith('chmodded: Contents/Resources/tool') for change in changes)
+    assert any(change.startswith('retargeted symlink: Contents/Resources/link') for change in changes)
+
+
+def test_validate_embedded_python_runtime_mutation_guard_rejects_pyc(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Example.app'
+    runtime = app / 'Contents' / 'Resources' / 'python-runtime'
+    py = runtime / 'bin' / 'python3'
+    py.parent.mkdir(parents=True)
+    py.write_text('python')
+    py.chmod(0o755)
+    (runtime / 'embedded_python_runtime_provenance.json').write_text('{}')
+    (runtime / 'LICENSE-PYTHON.txt').write_text('x')
+    (runtime / 'LICENSE-python-build-standalone.txt').write_text('x')
+    py_resources = app / 'Contents' / 'Resources' / 'python'
+    py_resources.mkdir(parents=True)
+    (py_resources / 'model_bridge.py').write_text('x')
+    calls = {'count': 0}
+
+    def fake_probe(_py, code, _app):
+        calls['count'] += 1
+        if calls['count'] == 1:
+            return json.dumps({'version': [3, 11], 'machine': 'arm64', 'executable': str(py), 'prefix': str(runtime), 'llama_cpp_python_version': '0.3.32'})
+        if '_probe_llama_runtime' in code:
+            (py_resources / '__pycache__').mkdir()
+            (py_resources / '__pycache__' / 'model_bridge.cpython-311.pyc').write_bytes(b'bad')
+            return json.dumps({'backend': 'metal', 'gpu_offload_supported': True, 'qwen_64k_yarn_support': 'supported', 'rope_scaling_type_supported': True, 'rope_freq_scale_supported': True, 'yarn_orig_ctx_supported': True, 'constructor_kwarg_support': {'flash_attn': True, 'offload_kqv': True, 'n_batch': True, 'n_ubatch': True}})
+        return 'ok'
+
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Linux')
+    monkeypatch.setattr(validator, '_run_python_sanitized', fake_probe)
+    with pytest.raises(SystemExit) as exc:
+        validator._validate_embedded_python_runtime(app)
+    assert 'unsealed Python bytecode' in str(exc.value)
+
+
+def test_preview_signature_verification_not_gated_on_paid_signing(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Example.app'
+    calls = []
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator, '_run', lambda cmd: calls.append(cmd) or '')
+    validator._verify_codesign_strict(app)
+    assert calls == [['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)]]
+
+
+def test_workflow_probes_disposable_copy_and_verifies_staged_and_source_apps() -> None:
+    text = WORKFLOW.read_text(encoding='utf-8')
+    assert 'runtime_probe_app=' in text
+    assert '--app-path "${runtime_probe_app}"' in text
+    assert 'codesign --verify --deep --strict --verbose=4 "${app_path}"' in text
+    assert 'codesign --verify --deep --strict --verbose=4 "${staged_app}"' in text
+    assert 'Apple Developer credentials absent; validating the required ad-hoc preview signature.' in text
+    assert 'spctl' not in text
+    assert 'notarization/stapling is not performed' in text
+
+
+@pytest.mark.skipif(sys.platform != 'darwin', reason='requires real macOS codesign and hdiutil')
+def test_macos_sanitized_probe_preserves_ad_hoc_signature_and_dmg_mount(tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Fixture.app'
+    (app / 'Contents' / 'MacOS').mkdir(parents=True)
+    resources_python = app / 'Contents' / 'Resources' / 'python'
+    resources_python.mkdir(parents=True)
+    exe = app / 'Contents' / 'MacOS' / 'Fixture'
+    exe.write_text('#!/bin/sh\nexit 0\n')
+    exe.chmod(0o755)
+    (app / 'Contents' / 'Info.plist').write_bytes(validator.plistlib.dumps({'CFBundleIdentifier': 'place.token.fixture', 'CFBundleExecutable': 'Fixture'}))
+    (resources_python / 'fixture_module.py').write_text('VALUE=1\n')
+    validator._run(['codesign', '--force', '--deep', '--sign', '-', str(app)])
+    validator._verify_codesign_strict(app)
+    before = validator._app_tree_fingerprint(app)
+    validator._run_python_sanitized(Path(sys.executable), 'import fixture_module; print(fixture_module.VALUE)', app)
+    validator._assert_app_tree_unchanged(app, before)
+    assert not list(app.rglob('*.pyc'))
+    validator._verify_codesign_strict(app)
+    (resources_python / '__pycache__').mkdir()
+    (resources_python / '__pycache__' / 'fixture_module.cpython-312.pyc').write_bytes(b'bad')
+    with pytest.raises(SystemExit):
+        validator._assert_app_tree_unchanged(app, before)
+    (resources_python / '__pycache__' / 'fixture_module.cpython-312.pyc').unlink()
+    (resources_python / '__pycache__').rmdir()
+    stage = tmp_path / 'stage'
+    stage.mkdir()
+    shutil.copytree(app, stage / app.name, symlinks=True)
+    readme = stage / 'README BEFORE OPENING.txt'
+    readme.write_text('ad-hoc signed not notarized Apple could not verify Privacy & Security Developer ID notarization')
+    dmg = tmp_path / 'token.place-desktop-fixture-apple-silicon.dmg'
+    validator._run(['hdiutil', 'create', '-volname', 'fixture', '-srcfolder', str(stage), '-ov', '-format', 'UDZO', str(dmg)])
+    seen = []
+    old_validate = validator._validate_embedded_python_runtime
+    validator._validate_embedded_python_runtime = lambda mounted_app: seen.append(mounted_app)
+    validator._validate_dmg_contents(dmg, expect_signing=False, require_embedded_python_runtime=True)
+    assert seen and str(seen[0]).startswith('/private/var/') or seen
+    validator._validate_embedded_python_runtime = old_validate


### PR DESCRIPTION
### Motivation
- A recent change executed the packaged Python runtime inside the app after Tauri ad‑hoc signing, which produced `__pycache__`/`.pyc` files and invalidated the app resource seal for preview DMGs.
- The goal is to ensure runtime probes are non‑mutating and that ad‑hoc signatures are strictly verified for preview artifacts without requiring a paid Apple account.
- Add deterministic mutation detection so any probe that mutates a signed app fails early with clear diagnostics and replace brittle workflow checks with behavioral validation.

### Description
- Hardened `_run_python_sanitized()` so probes run with `-B`, `PYTHONDONTWRITEBYTECODE=1`, `PYTHONPYCACHEPREFIX` pointing at a temp dir outside the app, external `TMPDIR`/`PIP_CACHE_DIR`/HF/XDG locations, a minimal `PATH`, removal of interpreter override vars, and the subprocess `cwd` set outside the app; nested child probes inherit the same environment.
- Added a deterministic app‑tree fingerprint and mutation helpers: `_app_tree_fingerprint()`, `_describe_app_tree_mutations()`, and `_assert_app_tree_unchanged()` which detect added/removed/rewritten/chmodded/retargeted paths and explicitly flag unsealed `__pycache__`/`.pyc` additions.
- Wrapped embedded runtime validation with the mutation guard so the app tree is snapshotted before probes and asserted unchanged after probing, and introduced `_verify_codesign_strict()` to always run `codesign --verify --deep --strict --verbose=4` for macOS preview artifacts.
- Updated DMG/mounted‑app validation to verify the exact `.app` inside the read‑only mounted DMG (one root `.app`) and run embedded runtime validation against the mounted app when requested.
- Modified the macOS release workflow so probes execute against a disposable, signature‑preserving copy of the app and added explicit `codesign --verify` checks on the source app before/after probing and on the staged app copied into the DMG staging directory; preserved current preview/no‑notarization behavior.
- Added/updated unit tests in `tests/unit/test_desktop_release_artifacts.py` covering the sanitized probe env, pycache isolation for parent/child imports, fingerprint mutation detection, mutation‑failing behavior, and that ad‑hoc `codesign` verification is always invoked; included a macOS‑only integration test (skipped outside Darwin) that runs the real ad‑hoc sign / probe / DMG mount sequence.

### Testing
- Installed verification deps: `pip install -r config/requirements_codex_verification.txt` (succeeded).
- Unit test suites run locally (Linux runner):
  - `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` — 66 passed, 1 skipped (the skipped test is the real macOS `codesign`/`hdiutil` integration, skipped on non‑Darwin).
  - `python -m pytest tests/unit/test_prepare_embedded_python_runtime.py -q` — all tests passed.
  - `python -m pytest tests/unit/test_desktop_gpu_packaging.py -q` — all tests passed.
- Static/format checks: `python -m py_compile scripts/validate_desktop_tauri_release_artifacts.py desktop-tauri/scripts/prepare_embedded_python_runtime.py` (succeeded) and `pre-commit run --all-files` (passed).
- Workflow changes were validated by unit tests that inspect the workflow file; the real macOS integration test that exercises `codesign` and `hdiutil` is included but must be run on a macOS runner to fully prove end‑to‑end behavior.
- Limitations / follow‑ups: the full end‑to‑end macOS preview workflow (real `codesign` on GitHub macOS runner, DMG creation in CI) could not be executed in this Linux environment; the included macOS integration test is intended to run in CI on macOS to provide final verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56ff6171f0832fa4760be1ddf26da7)