### PR TITLE
Fix macOS preview app validation mutation and add regression tests

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -375,6 +375,7 @@ jobs:
             rm -rf "${dmg_stage_dir}"
             mkdir -p "${dmg_stage_dir}"
             cp -R "${app_path}" "${dmg_stage_dir}/"
+            codesign --verify --deep --strict --verbose=4 "${dmg_stage_dir}/$(basename "${app_path}")"
             cp "${preview_notice}" "${dmg_stage_dir}/${preview_notice_name}"
             ln -s /Applications "${dmg_stage_dir}/Applications"
             rm -f "${dmg_path}"

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import stat
 import time
 from pathlib import Path
 
@@ -306,27 +307,51 @@ def _redact_allowed_app_locations(output: str, app_path: Path) -> str:
 def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
     app_for_subprocess = app_path if app_path.is_absolute() else app_path.absolute()
     py_for_subprocess = py if py.is_absolute() else py.absolute()
-    home = tempfile.mkdtemp(prefix="token-place-home-")
-    try:
-        app_data = Path(home) / "token.place"
+    with tempfile.TemporaryDirectory(prefix="token-place-python-probe-") as state_dir:
+        state = Path(state_dir)
+        home = state / "home"
+        pycache = state / "pycache"
+        tmp = state / "tmp"
+        app_data = state / "token.place"
+        for path in (home, pycache, tmp, app_data):
+            path.mkdir(parents=True, exist_ok=True)
         env = {
-            "HOME": home,
-            "PYTHONNOUSERSITE": "1",
+            "HOME": str(home),
             "PATH": "/usr/bin:/bin",
+            "PIP_CACHE_DIR": str(app_data / "pip-cache"),
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONNOUSERSITE": "1",
             "PYTHONPATH": str(app_for_subprocess / "Contents" / "Resources" / "python"),
+            "PYTHONPYCACHEPREFIX": str(pycache),
+            "TMPDIR": str(tmp),
+            "TOKEN_PLACE_CACHE_DIR": str(app_data / "cache"),
+            "TOKEN_PLACE_CONFIG_DIR": str(app_data / "config"),
+            "TOKEN_PLACE_DATA_DIR": str(app_data / "data"),
             "TOKEN_PLACE_MODELS_DIR": str(app_data / "models"),
-            "XDG_CACHE_HOME": str(app_data / "cache"),
-            "XDG_CONFIG_HOME": str(app_data / "config"),
-            "XDG_DATA_HOME": str(app_data / "data"),
+            "TRANSFORMERS_CACHE": str(app_data / "transformers-cache"),
+            "HF_HOME": str(app_data / "hf-home"),
+            "XDG_CACHE_HOME": str(app_data / "xdg-cache"),
+            "XDG_CONFIG_HOME": str(app_data / "xdg-config"),
+            "XDG_DATA_HOME": str(app_data / "xdg-data"),
         }
-        probe_cwd = app_for_subprocess / "Contents" / "Resources" / "python"
+        for key in (
+            "PYTHONHOME",
+            "PYTHONSTARTUP",
+            "PYTHONUSERBASE",
+            "VIRTUAL_ENV",
+            "CONDA_PREFIX",
+            "UV_PYTHON",
+            "TOKEN_PLACE_PYTHON",
+            "TOKEN_PLACE_PYTHON_EXECUTABLE",
+        ):
+            env.pop(key, None)
         result = subprocess.run(
-            [str(py_for_subprocess), "-c", code],
+            [str(py_for_subprocess), "-B", "-c", code],
             check=False,
             capture_output=True,
             text=True,
             env=env,
-            cwd=str(probe_cwd) if probe_cwd.is_dir() else home,
+            cwd=str(state),
         )
         output = f"{result.stdout}\n{result.stderr}"
         scan_output = _redact_allowed_app_locations(output, app_for_subprocess)
@@ -335,10 +360,66 @@ def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
             if marker in scan_output:
                 _fail(f"embedded Python output leaked forbidden marker: {marker}")
         if result.returncode != 0:
-            _fail(_format_command_failure([str(py_for_subprocess), "-c", "<probe>"], result))
+            _fail(_format_command_failure([str(py_for_subprocess), "-B", "-c", "<probe>"], result))
         return output.strip()
-    finally:
-        shutil.rmtree(home, ignore_errors=True)
+
+def _app_tree_fingerprint(app_path: Path) -> dict[str, dict[str, object]]:
+    fingerprint: dict[str, dict[str, object]] = {}
+    for path in sorted(app_path.rglob("*"), key=lambda p: p.relative_to(app_path).as_posix()):
+        rel = path.relative_to(app_path).as_posix()
+        try:
+            st = path.lstat()
+        except OSError as exc:
+            _fail(f"failed to stat app path during fingerprint: {rel}: {exc}")
+        mode = stat.S_IMODE(st.st_mode)
+        if path.is_symlink():
+            fingerprint[rel] = {"type": "symlink", "mode": mode, "target": os.readlink(path)}
+        elif path.is_file():
+            fingerprint[rel] = {"type": "file", "mode": mode, "sha256": _sha256(path), "executable": bool(mode & 0o111)}
+        elif path.is_dir():
+            fingerprint[rel] = {"type": "dir", "mode": mode}
+        else:
+            fingerprint[rel] = {"type": "other", "mode": mode}
+    return fingerprint
+
+
+def _describe_app_tree_mutations(before: dict[str, dict[str, object]], after: dict[str, dict[str, object]]) -> list[str]:
+    messages: list[str] = []
+    before_paths = set(before)
+    after_paths = set(after)
+    for rel in sorted(after_paths - before_paths):
+        suffix = " (unsealed Python bytecode: __pycache__/*.pyc)" if "__pycache__/" in rel and rel.endswith(".pyc") else ""
+        messages.append(f"added: {rel}{suffix}")
+    for rel in sorted(before_paths - after_paths):
+        messages.append(f"removed: {rel}")
+    for rel in sorted(before_paths & after_paths):
+        old = before[rel]
+        new = after[rel]
+        if old.get("type") != new.get("type"):
+            messages.append(f"type changed: {rel}: {old.get('type')} -> {new.get('type')}")
+        elif old.get("type") == "file" and old.get("sha256") != new.get("sha256"):
+            messages.append(f"rewritten: {rel}")
+        elif old.get("type") == "symlink" and old.get("target") != new.get("target"):
+            messages.append(f"retargeted symlink: {rel}: {old.get('target')} -> {new.get('target')}")
+        if old.get("mode") != new.get("mode"):
+            messages.append(f"chmodded: {rel}: {old.get('mode'):04o} -> {new.get('mode'):04o}")
+    return messages
+
+
+def _run_with_app_tree_mutation_guard(app_path: Path, description: str, callback) -> None:
+    before = _app_tree_fingerprint(app_path)
+    callback()
+    after = _app_tree_fingerprint(app_path)
+    mutations = _describe_app_tree_mutations(before, after)
+    if mutations:
+        _fail(f"{description} mutated app bundle; post-sign unsealed resources are not allowed:\n" + "\n".join(mutations[:50]))
+
+
+def _verify_existing_signature(app_path: Path) -> None:
+    if platform.system() != "Darwin":
+        print("::warning::Skipping macOS codesign verification outside macOS.")
+        return
+    _run(["codesign", "--verify", "--deep", "--strict", "--verbose=4", str(app_path)])
 
 def _parse_otool_rpaths(load_commands: str) -> list[str]:
     rpaths: list[str] = []
@@ -567,6 +648,23 @@ def _validate_embedded_python_runtime(app_path: Path) -> None:
     for candidate in runtime.rglob("*"):
         if candidate.is_file(): _validate_macho_linkage(candidate, app_path)
 
+
+def _validate_embedded_python_runtime_non_mutating(app_path: Path) -> None:
+    _run_with_app_tree_mutation_guard(
+        app_path,
+        "embedded Python runtime validation",
+        lambda: _validate_embedded_python_runtime(app_path),
+    )
+
+
+def _validate_runtime_on_disposable_app_copy(app_path: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="token-place-app-validation-") as temp_dir:
+        copy_path = Path(temp_dir) / app_path.name
+        shutil.copytree(app_path, copy_path, symlinks=True)
+        _verify_existing_signature(copy_path)
+        _validate_embedded_python_runtime_non_mutating(copy_path)
+        _verify_existing_signature(copy_path)
+
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser()
     p.add_argument("--app-path", required=True)
@@ -580,7 +678,7 @@ def _parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
+def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool, require_embedded_python_runtime: bool = True) -> None:
     if platform.system() != "Darwin":
         print("::warning::Skipping DMG mounted-content checks outside macOS.")
         return
@@ -606,6 +704,11 @@ def _validate_dmg_contents(dmg_path: Path, *, expect_signing: bool) -> None:
                     )
             elif DMG_PREVIEW_SIGNING_PHRASE_OPTIONS[0] not in readme_text:
                 _fail("DMG preview README must include ad-hoc signing guidance for unsigned preview builds")
+            mounted_app = apps[0]
+            _verify_existing_signature(mounted_app)
+            if require_embedded_python_runtime:
+                _validate_embedded_python_runtime_non_mutating(mounted_app)
+                _verify_existing_signature(mounted_app)
         finally:
             _cleanup_dmg_attach_state(dmg_path, Path(mount_dir))
     finally:
@@ -632,7 +735,7 @@ def main() -> None:
             _fail(f"dmg artifact missing or invalid: {dmg_path}")
         if not dmg_path.name.startswith("token.place-desktop-") or not dmg_path.name.endswith("-apple-silicon.dmg"):
             _fail(f"DMG filename must match token.place-desktop-<version>-apple-silicon.dmg: {dmg_path.name}")
-        _validate_dmg_contents(dmg_path, expect_signing=args.expect_signing)
+        _validate_dmg_contents(dmg_path, expect_signing=args.expect_signing, require_embedded_python_runtime=args.require_embedded_python_runtime)
 
     if not app_path.exists() or app_path.suffix != ".app":
         _fail(f"app bundle missing or invalid: {app_path}")
@@ -683,17 +786,17 @@ def main() -> None:
     if "x86_64" in arch_lower and "arm64" not in arch_lower:
         _fail(f"binary is x86_64-only: {arch_out}")
 
-    if args.require_embedded_python_runtime:
-        _validate_embedded_python_runtime(app_path)
+    _verify_existing_signature(app_path)
 
-    if args.expect_signing:
-        _run(["codesign", "--verify", "--deep", "--strict", "--verbose=2", str(app_path)])
-        if args.expect_notarization:
-            _run(["spctl", "-a", "-vv", "--type", "execute", str(app_path)])
-        else:
-            print("::warning::Signing configured without notarization credentials; skipping strict Gatekeeper assessment.")
+    if args.require_embedded_python_runtime and args.app_only:
+        _validate_runtime_on_disposable_app_copy(app_path)
+    elif args.require_embedded_python_runtime and dmg_path is None:
+        _validate_runtime_on_disposable_app_copy(app_path)
+
+    if args.expect_notarization:
+        _run(["spctl", "-a", "-vv", "--type", "execute", str(app_path)])
     else:
-        print("::warning::Signing credentials not configured; macOS artifact is preview/dev-only and may fail Gatekeeper.")
+        print("::warning::macOS preview artifacts are ad-hoc/possibly unnotarized; skipping Gatekeeper spctl assessment.")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_macos_ad_hoc_release_artifact.py
+++ b/tests/integration/test_macos_ad_hoc_release_artifact.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import platform
+import plistlib
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(platform.system() != 'Darwin', reason='requires real macOS codesign and hdiutil')
+
+
+def _validator():
+    script = Path(__file__).resolve().parents[2] / 'scripts' / 'validate_desktop_tauri_release_artifacts.py'
+    spec = importlib.util.spec_from_file_location('validate_desktop_tauri_release_artifacts', script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+
+def _make_app(root: Path) -> Path:
+    app = root / 'Minimal.app'
+    macos = app / 'Contents' / 'MacOS'
+    resources_python = app / 'Contents' / 'Resources' / 'python'
+    macos.mkdir(parents=True)
+    resources_python.mkdir(parents=True)
+    exe = macos / 'Minimal'
+    exe.write_text('#!/bin/sh\nexit 0\n', encoding='utf-8')
+    exe.chmod(0o755)
+    (resources_python / 'fixture_module.py').write_text('VALUE = 42\n', encoding='utf-8')
+    (app / 'Contents' / 'Info.plist').write_bytes(plistlib.dumps({
+        'CFBundleExecutable': 'Minimal',
+        'CFBundleIdentifier': 'place.token.MinimalRegression',
+        'CFBundleName': 'Minimal',
+        'CFBundlePackageType': 'APPL',
+        'CFBundleVersion': '1',
+    }))
+    return app
+
+
+def test_real_macos_ad_hoc_probe_dmg_and_mutation_guard(tmp_path: Path) -> None:
+    validator = _validator()
+    app = _make_app(tmp_path)
+    _run(['codesign', '--force', '--deep', '--sign', '-', str(app)])
+    validator._verify_existing_signature(app)
+    before = validator._app_tree_fingerprint(app)
+
+    code = 'import fixture_module, subprocess, sys, os; raise SystemExit(subprocess.run([sys.executable, "-B", "-c", "import fixture_module"], env=os.environ.copy()).returncode)'
+    validator._run_python_sanitized(Path(sys.executable), code, app)
+
+    assert not list(app.rglob('__pycache__'))
+    assert not list(app.rglob('*.pyc'))
+    assert validator._describe_app_tree_mutations(before, validator._app_tree_fingerprint(app)) == []
+    validator._verify_existing_signature(app)
+
+    pycache = app / 'Contents' / 'Resources' / 'python' / '__pycache__'
+    pycache.mkdir()
+    (pycache / 'fixture_module.cpython-311.pyc').write_bytes(b'unsealed')
+    mutations = validator._describe_app_tree_mutations(before, validator._app_tree_fingerprint(app))
+    assert any('unsealed Python bytecode' in m for m in mutations)
+
+    shutil.rmtree(pycache)
+    _run(['codesign', '--force', '--deep', '--sign', '-', str(app)])
+    stage = tmp_path / 'dmg-stage'
+    stage.mkdir()
+    shutil.copytree(app, stage / app.name, symlinks=True)
+    (stage / 'README BEFORE OPENING.txt').write_text(
+        'This preview build is ad-hoc signed and not notarized. Apple could not verify. '
+        'Privacy & Security Developer ID notarization',
+        encoding='utf-8',
+    )
+    dmg = tmp_path / 'token.place-desktop-test-apple-silicon.dmg'
+    _run(['hdiutil', 'create', '-volname', 'Minimal', '-srcfolder', str(stage), '-ov', '-format', 'UDZO', str(dmg)])
+    seen = []
+    original = validator._verify_existing_signature
+
+    def record(path: Path) -> None:
+        seen.append(path)
+        original(path)
+
+    validator._verify_existing_signature = record
+    validator._validate_dmg_contents(dmg, expect_signing=False, require_embedded_python_runtime=False)
+    assert seen and seen[-1].name == app.name
+    assert any('/token-place-dmg-mount-' in str(path) for path in seen)

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -281,6 +281,8 @@ def test_validator_mounts_macos_dmg_with_retry_helper_and_detaches(monkeypatch, 
     monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
     monkeypatch.setattr(validator, '_attach_dmg_with_retries', fake_attach)
     monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', fake_cleanup_state)
+    monkeypatch.setattr(validator, '_verify_existing_signature', lambda path: None)
+    monkeypatch.setattr(validator, '_validate_embedded_python_runtime_non_mutating', lambda path: None)
 
     validator._validate_dmg_contents(dmg_path, expect_signing=False)
 
@@ -708,24 +710,17 @@ def test_run_python_sanitized_rejects_forbidden_markers_and_cleans_home(monkeypa
     app = tmp_path / 'token.place desktop.app'
     (app / 'Contents' / 'Resources' / 'python').mkdir(parents=True)
     py = tmp_path / 'python3'
-    created_home = {}
-
-    def fake_mkdtemp(*, prefix):
-        home = tmp_path / f'{prefix}abc'
-        home.mkdir()
-        created_home['path'] = home
-        return str(home)
+    seen = {}
 
     def fake_run(cmd, *, check, capture_output, text, env, cwd=None):
-        assert env['HOME'] == str(created_home['path'])
-        assert env['TOKEN_PLACE_MODELS_DIR'] == str(created_home['path'] / 'token.place' / 'models')
-        assert env['XDG_CACHE_HOME'] == str(created_home['path'] / 'token.place' / 'cache')
-        assert env['XDG_CONFIG_HOME'] == str(created_home['path'] / 'token.place' / 'config')
-        assert env['XDG_DATA_HOME'] == str(created_home['path'] / 'token.place' / 'data')
-        assert cwd == str((app / 'Contents' / 'Resources' / 'python').absolute())
+        seen['home'] = Path(env['HOME'])
+        assert env['TOKEN_PLACE_MODELS_DIR'].endswith('/token.place/models')
+        assert env['XDG_CACHE_HOME'].endswith('/token.place/xdg-cache')
+        assert env['XDG_CONFIG_HOME'].endswith('/token.place/xdg-config')
+        assert env['XDG_DATA_HOME'].endswith('/token.place/xdg-data')
+        assert not Path(cwd).resolve().is_relative_to(app.resolve())
         return subprocess.CompletedProcess(cmd, 0, '/usr/bin/python3 leaked', '')
 
-    monkeypatch.setattr(validator.tempfile, 'mkdtemp', fake_mkdtemp)
     monkeypatch.setattr(validator.subprocess, 'run', fake_run)
 
     try:
@@ -733,7 +728,7 @@ def test_run_python_sanitized_rejects_forbidden_markers_and_cleans_home(monkeypa
         assert False
     except SystemExit as exc:
         assert 'forbidden marker' in str(exc)
-    assert not created_home['path'].exists()
+    assert not seen['home'].exists()
 
 
 def test_run_python_sanitized_allows_paths_inside_runner_app_bundle(monkeypatch, tmp_path) -> None:
@@ -771,7 +766,7 @@ def test_run_python_sanitized_runs_probes_from_packaged_python_resources(monkeyp
     monkeypatch.setattr(validator.subprocess, 'run', fake_run)
 
     assert validator._run_python_sanitized(py, 'print(1)', app) == 'ok'
-    assert seen['cwd'] == str(resources_python.absolute())
+    assert not Path(seen['cwd']).resolve().is_relative_to(app.resolve())
 
 
 def test_run_python_sanitized_absolutizes_relative_interpreter_before_resource_cwd(
@@ -795,7 +790,7 @@ def test_run_python_sanitized_absolutizes_relative_interpreter_before_resource_c
 
     assert validator._run_python_sanitized(py, 'print(1)', app) == 'ok'
     assert seen['cmd'][0] == str((tmp_path / py).absolute())
-    assert seen['cwd'] == str((tmp_path / app / 'Contents' / 'Resources' / 'python').absolute())
+    assert not Path(seen['cwd']).resolve().is_relative_to((tmp_path / app).resolve())
 
 def test_redact_allowed_app_locations_still_flags_runner_paths_outside_app(tmp_path) -> None:
     validator = _load_release_artifact_validator()
@@ -1311,7 +1306,9 @@ def test_validator_app_only_main_validates_app_without_dmg(monkeypatch, tmp_path
 
     validator.main()
 
-    assert embedded_calls == [app]
+    assert len(embedded_calls) == 1
+    assert embedded_calls[0].name == app.name
+    assert embedded_calls[0] != app
     assert dmg_calls == []
 
 
@@ -1339,6 +1336,8 @@ def test_validator_dmg_contents_checks_preview_readme(monkeypatch, tmp_path) -> 
     monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
     monkeypatch.setattr(validator, '_attach_dmg_with_retries', lambda dmg: handle)
     monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', lambda dmg, path: cleanup_calls.append((dmg, path)))
+    monkeypatch.setattr(validator, '_verify_existing_signature', lambda path: None)
+    monkeypatch.setattr(validator, '_validate_embedded_python_runtime_non_mutating', lambda path: None)
 
     dmg = tmp_path / 'token.place-desktop-test-apple-silicon.dmg'
     dmg.write_bytes(b'dmg')
@@ -1391,7 +1390,8 @@ def test_validator_full_main_validates_dmg_and_signing(monkeypatch, tmp_path) ->
             expect_notarization=True,
         ),
     )
-    monkeypatch.setattr(validator, '_validate_dmg_contents', lambda path, *, expect_signing: dmg_calls.append((path, expect_signing)))
+    monkeypatch.setattr(validator, '_validate_dmg_contents', lambda path, **kwargs: dmg_calls.append((path, kwargs)))
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
 
     def fake_run(cmd):
         run_calls.append(cmd)
@@ -1401,8 +1401,8 @@ def test_validator_full_main_validates_dmg_and_signing(monkeypatch, tmp_path) ->
 
     validator.main()
 
-    assert dmg_calls == [(dmg, True)]
-    assert ['codesign', '--verify', '--deep', '--strict', '--verbose=2', str(app)] in run_calls
+    assert dmg_calls == [(dmg, {'expect_signing': True, 'require_embedded_python_runtime': False})]
+    assert ['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)] in run_calls
     assert ['spctl', '-a', '-vv', '--type', 'execute', str(app)] in run_calls
 
 
@@ -1586,3 +1586,125 @@ def test_validator_embedded_runtime_failure_paths(monkeypatch, tmp_path) -> None
     monkeypatch.setattr(validator, '_validate_macho_linkage', lambda path, app_path: calls.append(str(path)))
     validator._validate_embedded_python_runtime(app)
     assert any('model_bridge.py' in code for code in calls)
+
+
+def test_run_python_sanitized_disables_bytecode_and_uses_external_state(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Example.app'
+    (app / 'Contents' / 'Resources' / 'python').mkdir(parents=True)
+    py = tmp_path / 'python3'
+    captured = {}
+
+    def fake_run(cmd, *, check, capture_output, text, env, cwd=None):
+        captured.update(cmd=cmd, env=env, cwd=cwd)
+        return subprocess.CompletedProcess(cmd, 0, 'ok', '')
+
+    monkeypatch.setattr(validator.subprocess, 'run', fake_run)
+    assert validator._run_python_sanitized(py, 'print(1)', app) == 'ok'
+    assert captured['cmd'][1] == '-B'
+    env = captured['env']
+    assert env['PYTHONDONTWRITEBYTECODE'] == '1'
+    assert env['PYTHONNOUSERSITE'] == '1'
+    assert env['PYTHONPYCACHEPREFIX']
+    writable_keys = [
+        'PYTHONPYCACHEPREFIX', 'TMPDIR', 'PIP_CACHE_DIR', 'HOME', 'XDG_CACHE_HOME',
+        'XDG_CONFIG_HOME', 'XDG_DATA_HOME', 'TOKEN_PLACE_MODELS_DIR', 'HF_HOME',
+        'TRANSFORMERS_CACHE', 'TOKEN_PLACE_CACHE_DIR', 'TOKEN_PLACE_CONFIG_DIR',
+        'TOKEN_PLACE_DATA_DIR',
+    ]
+    app_resolved = app.resolve()
+    for key in writable_keys:
+        assert not Path(env[key]).resolve().is_relative_to(app_resolved), key
+    assert not Path(captured['cwd']).resolve().is_relative_to(app_resolved)
+
+
+def test_run_python_sanitized_real_import_and_child_do_not_write_pyc(tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Example.app'
+    package_dir = app / 'Contents' / 'Resources' / 'python'
+    package_dir.mkdir(parents=True)
+    (package_dir / 'fixture_module.py').write_text('VALUE = 42\n', encoding='utf-8')
+    code = (
+        'import os,subprocess,sys,fixture_module; '
+        'assert os.environ["PYTHONDONTWRITEBYTECODE"] == "1"; '
+        'assert sys.dont_write_bytecode; '
+        'raise SystemExit(subprocess.run([sys.executable,"-B","-c","import fixture_module"], env=os.environ.copy()).returncode)'
+    )
+    validator._run_python_sanitized(Path(subprocess.check_output(['which', 'python3'], text=True).strip()), code, app)
+    assert not list(package_dir.rglob('__pycache__'))
+    assert not list(package_dir.rglob('*.pyc'))
+
+
+def test_app_tree_fingerprint_detects_mutations(tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Example.app'
+    resources = app / 'Contents' / 'Resources'
+    resources.mkdir(parents=True)
+    file_path = resources / 'module.py'
+    file_path.write_text('a', encoding='utf-8')
+    exe = app / 'Contents' / 'MacOS' / 'run'
+    exe.parent.mkdir(parents=True)
+    exe.write_text('x', encoding='utf-8')
+    link = resources / 'link'
+    link.symlink_to('module.py')
+    before = validator._app_tree_fingerprint(app)
+    (resources / '__pycache__').mkdir()
+    (resources / '__pycache__' / 'module.cpython-311.pyc').write_bytes(b'pyc')
+    file_path.write_text('b', encoding='utf-8')
+    exe.chmod(0o755)
+    link.unlink(); link.symlink_to('other.py')
+    (resources / 'removed.txt').write_text('gone', encoding='utf-8')
+    mid = validator._app_tree_fingerprint(app)
+    (resources / 'removed.txt').unlink()
+    after = validator._app_tree_fingerprint(app)
+    messages = validator._describe_app_tree_mutations(before | {'Contents/Resources/removed.txt': mid['Contents/Resources/removed.txt']}, after)
+    joined = '\n'.join(messages)
+    assert 'added: Contents/Resources/__pycache__/module.cpython-311.pyc (unsealed Python bytecode: __pycache__/*.pyc)' in joined
+    assert 'removed: Contents/Resources/removed.txt' in joined
+    assert 'rewritten: Contents/Resources/module.py' in joined
+    assert 'chmodded: Contents/MacOS/run' in joined
+    assert 'retargeted symlink: Contents/Resources/link' in joined
+
+
+def test_mutating_probe_fails_validation_guard(tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Example.app'
+    (app / 'Contents' / 'Resources').mkdir(parents=True)
+    try:
+        validator._run_with_app_tree_mutation_guard(app, 'probe', lambda: (app / 'Contents' / 'Resources' / '__pycache__').mkdir())
+        assert False
+    except SystemExit as exc:
+        assert 'mutated app bundle' in str(exc)
+
+
+def test_preview_signature_verification_is_not_gated_on_paid_secrets(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app = tmp_path / 'Example.app'; app.mkdir()
+    calls = []
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator, '_run', lambda cmd: calls.append(cmd) or '')
+    validator._verify_existing_signature(app)
+    assert calls == [['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)]]
+
+
+def test_mounted_dmg_validation_targets_mounted_app_and_skips_spctl_notary(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    mount = tmp_path / 'mount'; mount.mkdir()
+    mounted_app = mount / 'Mounted.app'; mounted_app.mkdir()
+    (mount / 'README BEFORE OPENING.txt').write_text(
+        'This preview build is ad-hoc signed and not notarized. Apple could not verify. '
+        'Privacy & Security Developer ID notarization', encoding='utf-8')
+
+    class Handle:
+        name = str(mount)
+        def cleanup(self): pass
+
+    calls = []
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator, '_attach_dmg_with_retries', lambda dmg: Handle())
+    monkeypatch.setattr(validator, '_cleanup_dmg_attach_state', lambda dmg, path: None)
+    monkeypatch.setattr(validator, '_verify_existing_signature', lambda path: calls.append(('codesign', path)))
+    monkeypatch.setattr(validator, '_validate_embedded_python_runtime_non_mutating', lambda path: calls.append(('runtime', path)))
+    validator._validate_dmg_contents(tmp_path / 'token.place-desktop-test-apple-silicon.dmg', expect_signing=False)
+    assert ('runtime', mounted_app) in calls
+    assert all(call[0] != 'spctl' for call in calls)


### PR DESCRIPTION
### Motivation

- A previous change caused packaged Python probes to write `.pyc` files into an already-ad-hoc-signed `.app`, breaking the resource seal for preview DMGs; this PR prevents post-sign mutation and restores structurally valid ad-hoc preview artifacts. 
- Validation must continue to probe packaged runtime capabilities without requiring paid Apple credentials or adding notarization/notarytool/stapling.

### Description

- Run sanitized Python probes non-mutating by invoking the interpreter with `-B`, setting `PYTHONDONTWRITEBYTECODE=1`, and redirecting `PYTHONPYCACHEPREFIX`, `TMPDIR`, `PIP_CACHE_DIR`, HOME, XDG/HF/transformers cache paths, and model paths to a temporary directory outside the `.app` in `_run_python_sanitized()` so child processes inherit the same environment. 
- Add deterministic app-tree fingerprinting (`_app_tree_fingerprint` / `_describe_app_tree_mutations`) and a mutation guard `_run_with_app_tree_mutation_guard` to detect added/removed/rewritten/chmodded/retargeted paths and explicitly flag unsealed `__pycache__/*.pyc`. 
- Stop executing mutable probes against the original signed build-tree app by running embedded-runtime validation on a disposable signature-preserving copy via `_validate_runtime_on_disposable_app_copy` and by validating the read-only mounted app from the DMG. 
- Separate existing-signature verification into `_verify_existing_signature` and require `codesign --verify --deep --strict --verbose=4` for preview/ad-hoc builds at these points: immediately after Tauri ad-hoc signing, after runtime validation, on the staged app before `hdiutil create`, and on the mounted DMG app. 
- Refactor mounted-DMG validation to target the exact root `.app` from the read-only mount and to run the non-mutating runtime checks and signature verification against that mounted app. 
- Update the release workflow to verify the staged app in the DMG staging directory before `hdiutil create`. 
- Add unit tests exercising `*_run_python_sanitized` no-bytecode behavior, writable-state redirection outside the `.app`, child-process inheritance, real import probes without creating `__pycache__`, the app-tree fingerprint and mutation guard behavior, and that ad-hoc signature verification is always invoked; add an integration test that runs on real macOS to exercise ad-hoc signing, sanitized probing, mutation detection, and DMG-mounted validation. 

### Testing

- Ran unit test suite for validator and related modules: `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` — all tests passed. 
- Ran related unit suites: `python -m pytest tests/unit/test_prepare_embedded_python_runtime.py -q` and `python -m pytest tests/unit/test_desktop_gpu_packaging.py -q` — both passed. 
- Ensured the modified validator compiles: `python -m py_compile scripts/validate_desktop_tauri_release_artifacts.py desktop-tauri/scripts/prepare_embedded_python_runtime.py` — success. 
- Pre-commit checks: `pre-commit run --all-files` — passed. 
- Added macOS integration regression `tests/integration/test_macos_ad_hoc_release_artifact.py` that must run on a macOS runner; it is present and was `skipped` when executed in this Linux environment (`pytest` skip), but it provides the real-run verification path required by the acceptance criteria. 

Residual notes: the macOS integration test requires a real macOS runner with `codesign`/`hdiutil` and so is intentionally skipped here; the validator now enforces strict ad-hoc `codesign` verification and non-mutation behavior while preserving preview/ad-hoc semantics (no notarization or paid-account dependency was introduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56ff641c64832fa2f0892f1dbbb3c6)