### PR TITLE
Fix macOS Qwen 64K runtime identity handoff

### DIFF
--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -954,9 +954,13 @@ def run(args: argparse.Namespace) -> int:
     context_profile = apply_context_profile(runtime.model_manager, args.context_tier)
     apply_compute_mode(runtime.model_manager, args.mode)
     try:
-        runtime.model_manager.desktop_runtime_probe = dict(runtime_setup)
+        private_probe = json.loads(os.getenv("TOKEN_PLACE_DESKTOP_RUNTIME_PROBE_JSON", "{}"))
+        runtime.model_manager.desktop_runtime_probe = dict(private_probe if isinstance(private_probe, dict) else runtime_setup)
     except Exception:
-        pass
+        try:
+            runtime.model_manager.desktop_runtime_probe = dict(runtime_setup)
+        except Exception:
+            pass
 
     warm_load_enabled = _env_enabled("TOKENPLACE_DESKTOP_WARM_LOAD", WARM_LOAD_DEFAULT)
     runtime_path = _runtime_path_from_env()

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
+import re
 import os
 import platform as platform_module
 import subprocess
@@ -51,6 +53,40 @@ def _strip_windows_extended_path_prefix(path_text: str) -> str:
 
 def _safe_resolve_path(path_text: str | Path) -> Path:
     return Path(_strip_windows_extended_path_prefix(str(path_text))).resolve()
+
+
+_LLAMA_MODULE_IDENTITY_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def _canonical_llama_module_identity_path(module_path: Any) -> Optional[str]:
+    if not module_path:
+        return None
+    try:
+        path_text = _strip_windows_extended_path_prefix(str(module_path))
+        canonical = os.path.normcase(os.path.normpath(os.path.realpath(os.path.abspath(path_text))))
+    except (TypeError, ValueError, OSError):
+        try:
+            canonical = os.path.normcase(os.path.normpath(_strip_windows_extended_path_prefix(str(module_path))))
+        except (TypeError, ValueError, OSError):
+            return None
+    return canonical.replace('\\', '/')
+
+
+def llama_module_identity_from_path(module_path: Any) -> Optional[str]:
+    canonical = _canonical_llama_module_identity_path(module_path)
+    if not canonical or canonical in {'missing', 'unknown'}:
+        return None
+    digest = hashlib.sha256(f'token.place.llama_cpp.module_path.v1\0{canonical}'.encode('utf-8')).hexdigest()
+    return f'sha256:{digest}'
+
+
+def validate_llama_module_identity(identity: Any) -> Optional[str]:
+    if not isinstance(identity, str):
+        return None
+    text = identity.strip()
+    if _LLAMA_MODULE_IDENTITY_RE.fullmatch(text):
+        return text
+    return None
 
 
 @dataclass(frozen=True)
@@ -780,6 +816,8 @@ def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, Any]:
         "dependency_target": probe.dependency_target,
         "pip_version": probe.pip_version,
         "llama_cpp_python_version": probe.llama_cpp_python_version,
+        "llama_module_path_present": bool(probe.llama_module_path and probe.llama_module_path not in {"missing", "unknown"}),
+        "llama_module_identity": llama_module_identity_from_path(probe.llama_module_path),
         "backend": probe.backend,
         "gpu_offload_supported": probe.gpu_offload_supported,
         "constructor_kwarg_support": dict(probe.constructor_kwarg_support),
@@ -1422,6 +1460,8 @@ def _record_desktop_runtime_probe(result: Dict[str, Any]) -> Dict[str, Any]:
         os.environ.pop(RUNTIME_PROBE_ENV, None)
         return result
     public_result = dict(result)
+    public_result.pop("llama_module_identity", None)
+    public_result.pop("llama_module_path", None)
     for key in (
         "yarn_rope_supported",
         "rope_scaling_type_supported",

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -2391,3 +2391,34 @@ def test_qwen_64k_bootstrap_disabled_version_mismatch_failed_without_module_path
     assert sentinel not in result['fallback_reason']
     assert sentinel not in json.dumps(result, sort_keys=True)
     assert sentinel not in emitted
+
+
+def test_probe_result_payload_carries_private_identity_but_public_result_redacts(tmp_path, monkeypatch):
+    module_path = tmp_path / 'site-packages' / 'llama_cpp' / '__init__.py'
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text('# llama_cpp')
+    probe = desktop_runtime_setup.RuntimeProbe(
+        backend='metal',
+        gpu_offload_supported=True,
+        detected_device='metal',
+        interpreter=sys.executable,
+        prefix=sys.prefix,
+        llama_module_path=str(module_path),
+        llama_cpp_python_version='0.3.32',
+        qwen_64k_yarn_support='supported',
+        yarn_enum_value=2,
+        constructor_signature_inspectable=True,
+        constructor_kwarg_support={name: True for name in desktop_runtime_setup.LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS},
+    )
+
+    payload = desktop_runtime_setup._probe_result_payload(probe)
+    public = desktop_runtime_setup._record_desktop_runtime_probe(dict(payload))
+    private = json.loads(os.environ[desktop_runtime_setup.RUNTIME_PROBE_ENV])
+
+    assert 'llama_module_path' not in payload
+    assert payload['llama_module_path_present'] is True
+    assert desktop_runtime_setup.validate_llama_module_identity(payload['llama_module_identity'])
+    assert 'llama_module_identity' not in public
+    assert str(module_path) not in json.dumps(public)
+    assert private['llama_module_identity'] == payload['llama_module_identity']
+    assert str(module_path) not in json.dumps(private)

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -10120,3 +10120,113 @@ def test_legacy_flat_desktop_probe_exported_enum_without_value_fails_closed(monk
     assert 'yarn_enum_value' in diagnostics['missing_required_kwargs']
     assert diagnostics['child_probe_reprobe_attempted'] is False
     assert diagnostics['child_probe_reprobe_skipped_reason'] == 'desktop_probe_incomplete_fail_closed'
+
+
+def _complete_desktop_probe_for_identity(model_manager_module, module_path):
+    return {
+        'backend': 'metal',
+        'gpu_offload_supported': True,
+        'runtime_action': 'metal_already_supported',
+        'llama_module_path_present': True,
+        'llama_module_identity': model_manager_module.llama_module_identity_from_path(module_path),
+        'llama_cpp_python_version': '0.3.32',
+        'constructor_kwarg_support': {
+            'rope_scaling_type': True,
+            'rope_freq_scale': True,
+            'yarn_orig_ctx': True,
+            'yarn_ext_factor': True,
+        },
+        'constructor_signature_inspectable': True,
+        'constructor_has_var_kwargs': False,
+        'qwen_64k_yarn_support': 'supported',
+        'yarn_resolver_source': 'top_level_enum',
+        'yarn_enum_value': 2,
+        'q8_kv_cache_type_value': 8,
+        'capability_source': 'desktop_runtime_setup_probe',
+    }
+
+
+def test_qwen_64k_desktop_probe_identity_authoritative_without_reprobe(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    module_path = tmp_path / 'site-packages' / 'llama_cpp' / '__init__.py'
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text('# llama_cpp')
+    facade = model_manager_module._SubprocessLlamaCppModule(
+        str(module_path),
+        desktop_runtime_probe=_complete_desktop_probe_for_identity(model_manager_module, str(module_path)),
+    )
+    monkeypatch.setattr(
+        model_manager_module,
+        '_probe_llama_cpp_capabilities_in_subprocess',
+        lambda **_: (_ for _ in ()).throw(AssertionError('secondary reprobe must not run')),
+    )
+
+    diagnostics = model_manager_module._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
+
+    assert diagnostics['supported'] is True
+    assert diagnostics['desktop_probe_authoritative'] is True
+    assert diagnostics['child_probe_reprobe_attempted'] is False
+    assert diagnostics['llama_module_identity_match'] is True
+
+
+def test_qwen_64k_desktop_probe_missing_or_bad_identity_fails_closed(tmp_path, monkeypatch):
+    from utils.llm import model_manager as model_manager_module
+
+    module_path = tmp_path / 'site-packages' / 'llama_cpp' / '__init__.py'
+    other_path = tmp_path / 'other' / 'llama_cpp' / '__init__.py'
+    module_path.parent.mkdir(parents=True)
+    other_path.parent.mkdir(parents=True)
+    module_path.write_text('# llama_cpp')
+    other_path.write_text('# other')
+    monkeypatch.setattr(
+        model_manager_module,
+        '_probe_llama_cpp_capabilities_in_subprocess',
+        lambda **_: (_ for _ in ()).throw(AssertionError('secondary reprobe must not run')),
+    )
+
+    for identity in (None, 'sha256:not-valid', model_manager_module.llama_module_identity_from_path(str(other_path))):
+        probe = _complete_desktop_probe_for_identity(model_manager_module, str(module_path))
+        if identity is None:
+            probe.pop('llama_module_identity')
+        else:
+            probe['llama_module_identity'] = identity
+        facade = model_manager_module._SubprocessLlamaCppModule(str(module_path), desktop_runtime_probe=probe)
+        diagnostics = model_manager_module._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
+        assert diagnostics['supported'] is False
+        assert diagnostics['desktop_probe_authoritative'] is False
+        assert diagnostics['child_probe_reprobe_attempted'] is False
+        assert diagnostics['llama_module_identity_match'] is False
+        assert 'llama_module_identity' in diagnostics['incomplete_probe_fields'] or 'llama_module_identity_match' in diagnostics['incomplete_probe_fields']
+
+
+def test_llama_module_identity_canonicalizes_symlinks_and_differs(tmp_path):
+    from utils.llm import model_manager as model_manager_module
+
+    real = tmp_path / 'real' / 'llama_cpp' / '__init__.py'
+    other = tmp_path / 'other' / 'llama_cpp' / '__init__.py'
+    real.parent.mkdir(parents=True)
+    other.parent.mkdir(parents=True)
+    real.write_text('# real')
+    other.write_text('# other')
+    link_dir = tmp_path / 'link'
+    link_dir.symlink_to(real.parent.parent, target_is_directory=True)
+
+    assert model_manager_module.llama_module_identity_from_path(real) == model_manager_module.llama_module_identity_from_path(link_dir / 'llama_cpp' / '..' / 'llama_cpp' / '__init__.py')
+    assert model_manager_module.llama_module_identity_from_path(real) != model_manager_module.llama_module_identity_from_path(other)
+    assert model_manager_module.validate_llama_module_identity(model_manager_module.llama_module_identity_from_path(real))
+    assert model_manager_module.validate_llama_module_identity('sha256:' + 'A' * 64) is None
+
+
+def test_qwen_yarn_unsupported_diagnostics_preserves_false_and_empty_values():
+    from utils.llm import model_manager as model_manager_module
+
+    formatted = model_manager_module._format_qwen_yarn_unsupported_diagnostics({
+        'child_probe_reprobe_attempted': False,
+        'constructor_kwargs_attempted': [],
+        'incomplete_probe_fields': ['llama_module_identity'],
+    })
+
+    assert 'child_probe_reprobe_attempted=False' in formatted
+    assert 'constructor_kwargs_attempted=[]' in formatted
+    assert "incomplete_probe_fields=['llama_module_identity']" in formatted

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -231,6 +231,8 @@ def _safe_constructor_capability_payload(llama_cpp_module: Any) -> Dict[str, Any
         'constructor_signature_inspectable',
         'qwen_64k_yarn_support',
         'yarn_resolver_source',
+        'llama_module_identity',
+        'llama_module_path_present',
         'llama_module_path',
         'child_probe_reprobe_attempted',
         'child_probe_reprobe_skipped_reason',
@@ -788,6 +790,9 @@ def _format_qwen_yarn_unsupported_diagnostics(diagnostics: Dict[str, Any]) -> st
         'active_profile_id',
         'active_context_tier',
         'llama_module_path',
+        'llama_module_path_present',
+        'llama_module_identity_match',
+        'incomplete_probe_fields',
         'llama_cpp_python_version',
         'missing_reason',
         'yarn_resolver_source',
@@ -796,10 +801,16 @@ def _format_qwen_yarn_unsupported_diagnostics(diagnostics: Dict[str, Any]) -> st
         'child_probe_reprobe_attempted',
         'constructor_kwargs_attempted',
     )
-    return ', '.join(
-        f'{field}={diagnostics.get(field) or "unknown"}'
-        for field in safe_fields
-    )
+    parts = []
+    for field in safe_fields:
+        if field == 'llama_module_path':
+            value = 'unknown'
+        else:
+            value = diagnostics.get(field, None)
+            if value is None:
+                value = 'unknown'
+        parts.append(f'{field}={value}')
+    return ', '.join(parts)
 
 
 def _qwen_64k_rope_support_diagnostics(llama_cpp_module: Any, llama_cls: Any) -> Dict[str, Any]:
@@ -887,13 +898,20 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
         required_supported = isinstance(kwarg_support, dict) and all(kwarg_support.get(name) is True for name in required)
         authoritative_backend = str(capabilities.get('backend') or '').lower() in {'cuda', 'metal'}
         capability_module_path = capabilities.get('llama_module_path')
+        capability_identity = validate_llama_module_identity(capabilities.get('llama_module_identity'))
         facade_module_path = getattr(llama_cpp_module, '__file__', None)
-        module_paths_match = (
+        facade_identity = llama_module_identity_from_path(facade_module_path)
+        path_match_available = (
             bool(capability_module_path)
+            and str(capability_module_path).strip() not in {'missing', 'unknown'}
             and bool(facade_module_path)
             and _canonical_path_for_compare(capability_module_path)
             == _canonical_path_for_compare(facade_module_path)
         )
+        identity_match_available = bool(capability_identity and facade_identity and capability_identity == facade_identity)
+        module_paths_match = identity_match_available or path_match_available
+        if capability_identity and capability_module_path and str(capability_module_path).strip() not in {'missing', 'unknown'}:
+            module_paths_match = identity_match_available and path_match_available
         authoritative = (
             source in {'desktop_runtime_setup_probe', 'desktop_runtime_setup_probe_legacy'}
             and authoritative_backend
@@ -912,6 +930,8 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
             diagnostics['child_probe_reprobe_attempted'] = False
             diagnostics['child_probe_reprobe_skipped_reason'] = 'desktop_probe_authoritative'
             diagnostics['desktop_probe_authoritative'] = True
+            diagnostics['llama_module_identity_match'] = identity_match_available
+            diagnostics['llama_module_path_present'] = bool(facade_module_path)
             return diagnostics
         if source in {'desktop_runtime_setup_probe', 'desktop_runtime_setup_probe_legacy'} and not complete:
             missing = []
@@ -924,7 +944,9 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
             if capabilities.get('constructor_signature_inspectable') is not True:
                 missing.append('constructor_signature_inspectable')
             if not module_paths_match:
-                missing.append('llama_module_path')
+                missing.append('llama_module_identity' if not capability_identity else 'llama_module_identity_match')
+                if capability_module_path and str(capability_module_path).strip() not in {'missing', 'unknown'}:
+                    missing.append('llama_module_path')
             if not authoritative_backend:
                 missing.append('backend')
             if capabilities.get('gpu_offload_supported') is not True:
@@ -934,6 +956,9 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
                 'supported': False,
                 'missing_reason': 'runtime_desktop_capability_probe_incomplete',
                 'missing_required_kwargs': sorted(set(missing)),
+                'incomplete_probe_fields': sorted(set(missing)),
+                'llama_module_path_present': bool(facade_module_path),
+                'llama_module_identity_match': identity_match_available,
                 'child_probe_reprobe_attempted': False,
                 'child_probe_reprobe_skipped_reason': 'desktop_probe_incomplete_fail_closed',
                 'desktop_probe_authoritative': False,
@@ -1111,6 +1136,9 @@ def _sanitize_subprocess_path_env(env: Dict[str, str], pythonpath_entries: list[
     return sanitized
 
 
+_LLAMA_MODULE_IDENTITY_RE = re.compile(r'^sha256:[0-9a-f]{64}$')
+
+
 def _canonical_path_for_compare(module_path: Any) -> Optional[str]:
     if not module_path:
         return None
@@ -1122,6 +1150,35 @@ def _canonical_path_for_compare(module_path: Any) -> Optional[str]:
             return os.path.normcase(os.path.normpath(_strip_windows_extended_path_prefix(str(module_path))))
         except (TypeError, ValueError, OSError):
             return None
+
+
+def _canonical_llama_module_identity_path(module_path: Any) -> Optional[str]:
+    canonical = _canonical_path_for_compare(module_path)
+    if not canonical:
+        return None
+    return canonical.replace('\\', '/')
+
+
+def llama_module_identity_from_path(module_path: Any) -> Optional[str]:
+    canonical = _canonical_llama_module_identity_path(module_path)
+    if not canonical or canonical in {'missing', 'unknown'}:
+        return None
+    digest = hashlib.sha256(f'token.place.llama_cpp.module_path.v1\0{canonical}'.encode('utf-8')).hexdigest()
+    return f'sha256:{digest}'
+
+
+def validate_llama_module_identity(identity: Any) -> Optional[str]:
+    if not isinstance(identity, str):
+        return None
+    text = identity.strip()
+    if _LLAMA_MODULE_IDENTITY_RE.fullmatch(text):
+        return text
+    return None
+
+
+def _llama_module_identity_matches_path(identity: Any, module_path: Any) -> bool:
+    validated = validate_llama_module_identity(identity)
+    return bool(validated and validated == llama_module_identity_from_path(module_path))
 
 
 def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
@@ -4018,6 +4075,7 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
     gpu_bool = _coerce_strict_bool(probe.get('gpu_offload_supported', True if backend in {'cuda', 'metal'} else False))
     gpu_supported = bool(gpu_bool)
     module_path = str(probe.get('llama_module_path') or '').strip()
+    identity = validate_llama_module_identity(probe.get('llama_module_identity'))
     if not backend or backend == 'missing' or action in {'failed', 'unavailable', 'shadowed_repo_llama_cpp'}:
         return None
     if error and action not in {'already_supported', 'metal_already_supported'}:
@@ -4051,6 +4109,10 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
             value = _coerce_strict_bool(probe.get(field))
             if value is not None:
                 support[kwarg] = value
+    if identity:
+        coerced['llama_module_identity'] = identity
+    elif 'llama_module_identity' in probe:
+        coerced['llama_module_identity_malformed'] = True
     if support:
         coerced['constructor_kwarg_support'] = support
 


### PR DESCRIPTION
### Motivation

- Packaged macOS probes showed the bundled runtime was healthy but the compute-node/ModelManager handoff lost the authoritative llama_cpp binding because the raw `llama_module_path` was removed too early and got coerced to `"unknown"` down the consumer chain. 
- The redaction intended to protect path privacy prevented the subprocess facade (which has a concrete `__file__`) from matching the desktop probe, causing the Qwen 64K capability gate to fail closed on otherwise-valid macOS bundles. 
- The change restores a verifiable, path-free identity that preserves privacy while allowing an authoritative match between producer probe and consumer facade without launching reprobes (preserving Windows no-reprobe protection).

### Description

- Add a canonicalization+hash identity: compute `llama_module_identity = sha256:<64 hex>` from a canonical resolved module path (symlinks/`..`, case/separator normalization, Windows extended-prefix stripping) in `desktop_runtime_setup.py` and `utils/llm/model_manager.py`. 
- Carry `llama_module_identity` and a safe boolean `llama_module_path_present` in the private runtime probe payload (`TOKEN_PLACE_DESKTOP_RUNTIME_PROBE_JSON`) while continuing to omit raw paths from the public probe result; public output redacts both raw path and identity. 
- Make the compute bridge prefer the private probe env payload when assigning `ModelManager.desktop_runtime_probe` so the background warm-load/facade path receives the opaque identity without leaking it to logs. 
- Validate identity schema strictly and require an exact identity match (or canonical path agreement for legacy probes) in `_runtime_supports_qwen_yarn_rope()`, preserve fail-closed semantics for missing/malformed/mismatched identity, and avoid launching secondary native reprobes. 
- Fix diagnostic formatting in `_format_qwen_yarn_unsupported_diagnostics()` so False and empty-list values are serialized literally (not as `unknown`) while forcing raw module path diagnostics to remain `unknown` (privacy). 
- Add unit/regression tests exercising the full producer→consumer chain: authoritative identity handoff (no reprobe), missing/malformed/mismatched identity failure, canonicalization (symlinks/`..`), and payload redaction/privacy checks.

### Testing

- Installed focused test deps: `python -m pip install -r config/requirements_codex_verification.txt` (succeeded). 
- Ran unit test sweep: `python -m pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_model_manager.py -q` and observed all unit tests pass (551 passed). 
- Ran integration tests: `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py tests/integration/test_macos_release_probe.py -q` and observed success (20 passed, 1 skipped on Linux). 
- Ran operator E2E and relay invariants: `python desktop-tauri/scripts/test_packaged_operator_e2e.py` and `python -m pytest tests/unit/test_crypto_helpers_api_v1_relay.py tests/unit/test_e2ee_relay_invariant.py -q` (succeeded). 
- Pre-commit and project checks: `pre-commit run --all-files` and `git diff --check` were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57fc405d08832f94f8fe49f7ab080a)