### PR TITLE
Fix macOS Qwen 64K runtime identity handoff

### DIFF
--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -193,7 +193,7 @@ def _packaged_env(
     env["HOME"] = str(home_dir)
     env["PYTHONNOUSERSITE"] = "1"
     env["TOKEN_PLACE_PYTHON_IMPORT_ROOT"] = str(resources_root)
-    env["PYTHONPATH"] = str(resources_root / "python")
+    env["PYTHONPATH"] = os.pathsep.join([str(resources_root / "python"), str(resources_root)])
     if extra_env:
         env.update(extra_env)
     return env
@@ -209,6 +209,7 @@ def run_desktop_dependency_preflight(tmp_root: Path, *, resources_root: Path | N
             "-c",
             (
                 "import json, pathlib, sys; "
+                "sys.path.insert(0, r'" + str(resources_root) + "'); "
                 "sys.path.insert(0, r'" + str(resources_root / 'python') + "'); "
                 "import desktop_runtime_setup as mod; "
                 "print(json.dumps(mod.ensure_desktop_python_dependencies()))"
@@ -282,6 +283,8 @@ def run_model_bridge_inspect_probe(tmp_root: Path, *, resources_root: Path | Non
             (
                 "import pathlib,sys; "
                 "python_dir=pathlib.Path(r'" + str(model_bridge.parent) + "'); "
+                "resources_dir=python_dir.parent; "
+                "sys.path.insert(0,str(resources_dir)); "
                 "sys.path.insert(0,str(python_dir)); "
                 "import desktop_runtime_setup as mod; "
                 "payload=mod.ensure_desktop_python_dependencies(); "

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -542,17 +542,20 @@ def run_compute_bridge_startup_probe(
     log_dir.mkdir(parents=True, exist_ok=True)
     safe_layout_label = layout_label.replace(" ", "_").replace("/", "_")
     log_file = log_dir / f"packaged-bridge-startup-{safe_layout_label}.log"
+    bridge_args = [
+        sys.executable,
+        str(bridge_script),
+        "--model",
+        model_arg,
+        "--mode",
+        mode,
+        "--relay-url",
+        f"http://127.0.0.1:{relay_port}",
+    ]
+    if mode == "auto":
+        bridge_args.extend(["--context-tier", "64k-full"])
     bridge = subprocess.Popen(  # noqa: S603
-        [
-            sys.executable,
-            str(bridge_script),
-            "--model",
-            model_arg,
-            "--mode",
-            mode,
-            "--relay-url",
-            f"http://127.0.0.1:{relay_port}",
-        ],
+        bridge_args,
         cwd=tmp_root,
         env=env,
         stdin=subprocess.PIPE,
@@ -929,12 +932,17 @@ def create_fake_metal_llama_cpp_site(tmp_root: Path, layout_label: str) -> Path:
     fake_pkg = fake_site / "llama_cpp"
     fake_pkg.mkdir(parents=True, exist_ok=True)
     (fake_pkg / "__init__.py").write_text(
+        "__version__ = '0.3.32'\n"
         "GGML_USE_METAL = True\n"
+        "LLAMA_ROPE_SCALING_TYPE_YARN = 2\n"
+        "GGML_TYPE_Q8_0 = 8\n"
+        "GGML_TYPE_Q4_0 = 4\n"
+        "GGML_TYPE_F16 = 1\n"
         "def llama_supports_gpu_offload():\n"
         "    return True\n"
         "class Llama:\n"
-        "    def __init__(self, *args, **kwargs):\n"
-        "        self.args = args\n"
+        "    def __init__(self, model_path=None, *, n_ctx=512, n_gpu_layers=0, type_k=None, type_v=None, flash_attn=False, offload_kqv=True, n_batch=512, n_ubatch=512, rope_scaling_type=None, yarn_ext_factor=None, yarn_attn_factor=None, yarn_beta_fast=None, yarn_beta_slow=None, yarn_orig_ctx=None, rope_freq_base=None, rope_freq_scale=None, **kwargs):\n"
+        "        self.model_path = model_path\n"
         "        self.kwargs = kwargs\n"
         "    def create_chat_completion(self, *args, **kwargs):\n"
         "        return {'choices': [{'message': {'role': 'assistant', 'content': 'fake metal ok'}}]}\n"
@@ -956,6 +964,9 @@ def create_fake_metal_llama_cpp_site(tmp_root: Path, layout_label: str) -> Path:
         "        return ([0] if add_bos else []) + tokens\n",
         encoding="utf-8",
     )
+    dist_info = fake_site / "llama_cpp_python-0.3.32.dist-info"
+    dist_info.mkdir(parents=True, exist_ok=True)
+    (dist_info / "METADATA").write_text("Name: llama-cpp-python\nVersion: 0.3.32\n", encoding="utf-8")
     return fake_site
 
 
@@ -995,8 +1006,17 @@ def run_macos_mock_metal_packaged_registration_probe(
             ),
         },
     )
+    sentinel_identity = __import__("hashlib").sha256(
+        f"token.place.llama_cpp.module_path.v1\0{fake_metal_site / 'llama_cpp' / '__init__.py'}".encode("utf-8")
+    ).hexdigest()
     assert '"registered": true' in output.lower(), output
     assert "runtime_action=metal_already_supported" in output, output
+    assert "warm_load_state" in output and "ready" in output, output
+    assert '"api_v1_readiness_result": "passed"' in output, output
+    assert '"api_v1_readiness_yarn_rope_scaling_type_source": "top_level_enum"' in output, output
+    assert "native_reprobe" not in output, output
+    assert str(fake_metal_site) not in output, output
+    assert sentinel_identity not in output, output
 
 
 def run_macos_gpu_failure_blocks_registration_probe(

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -424,12 +424,17 @@ def create_fake_llama_cpp_site(tmp_root: Path, layout_label: str) -> tuple[Path,
     fake_init.write_text(
         "import os, time\n"
         "__file__ = __file__\n"
+        "__version__ = '0.3.32'\n"
         "GGML_USE_CUDA = True\n"
+        "LLAMA_ROPE_SCALING_TYPE_YARN = 2\n"
+        "GGML_TYPE_Q8_0 = 8\n"
+        "GGML_TYPE_Q4_0 = 4\n"
+        "GGML_TYPE_F16 = 1\n"
         "def llama_supports_gpu_offload():\n"
         "    return True\n"
         "class Llama:\n"
-        "    def __init__(self, *args, **kwargs):\n"
-        "        self.args = args\n"
+        "    def __init__(self, model_path=None, *, n_ctx=512, n_gpu_layers=0, type_k=None, type_v=None, flash_attn=False, offload_kqv=True, n_batch=512, n_ubatch=512, rope_scaling_type=None, yarn_ext_factor=None, yarn_attn_factor=None, yarn_beta_fast=None, yarn_beta_slow=None, yarn_orig_ctx=None, rope_freq_base=None, rope_freq_scale=None, **kwargs):\n"
+        "        self.model_path = model_path\n"
         "        self.kwargs = kwargs\n"
         "    def create_chat_completion(self, *args, **kwargs):\n"
         "        return {'choices': [{'message': {'role': 'assistant', 'content': 'fake llama ok'}}]}\n"
@@ -451,6 +456,9 @@ def create_fake_llama_cpp_site(tmp_root: Path, layout_label: str) -> tuple[Path,
         "        return ([0] if add_bos else []) + tokens\n",
         encoding="utf-8",
     )
+    dist_info = fake_site / "llama_cpp_python-0.3.32.dist-info"
+    dist_info.mkdir(parents=True, exist_ok=True)
+    (dist_info / "METADATA").write_text("Name: llama-cpp-python\nVersion: 0.3.32\n", encoding="utf-8")
     return fake_site, fake_init
 
 def run_llama_cpp_watchdog_regression_probe(

--- a/desktop-tauri/scripts/test_packaged_operator_e2e.py
+++ b/desktop-tauri/scripts/test_packaged_operator_e2e.py
@@ -922,7 +922,11 @@ def run_llama_cpp_watchdog_packaged_bridge_lifecycle_probe(
         mode="auto",
         model_path=fake_model,
         extra_env={
-            "TOKEN_PLACE_LLAMA_CPP_RUNTIME_STAGE_TIMEOUT_SECONDS": "5",
+            # Windows CI can spend more than five seconds importing the packaged
+            # fake runtime and completing the background Qwen 64K capability gate.
+            # Keep this lifecycle probe deterministic by giving the warm-load
+            # watchdog enough room while still bounding a genuinely wedged child.
+            "TOKEN_PLACE_LLAMA_CPP_RUNTIME_STAGE_TIMEOUT_SECONDS": "15",
             "PYTHONPATH": os.pathsep.join(
                 [str(polluted_site), str(fake_site), str(resources_root / "python"), str(resources_root)]
             ),

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -954,7 +954,18 @@ def run(args: argparse.Namespace) -> int:
     context_profile = apply_context_profile(runtime.model_manager, args.context_tier)
     apply_compute_mode(runtime.model_manager, args.mode)
     try:
-        runtime.model_manager.desktop_runtime_probe = dict(runtime_setup)
+        private_runtime_setup = dict(runtime_setup)
+        raw_private_probe = os.environ.get("TOKEN_PLACE_DESKTOP_RUNTIME_PROBE_JSON", "").strip()
+        if raw_private_probe:
+            try:
+                parsed_private_probe = json.loads(raw_private_probe)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                parsed_private_probe = None
+            if isinstance(parsed_private_probe, dict):
+                identity = parsed_private_probe.get("llama_module_identity")
+                if isinstance(identity, str):
+                    private_runtime_setup["llama_module_identity"] = identity
+        runtime.model_manager.desktop_runtime_probe = private_runtime_setup
     except Exception:
         pass
 

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -8,6 +8,7 @@ import os
 import ntpath
 import hashlib
 import platform as platform_module
+import re
 import subprocess
 import sys
 import time
@@ -19,11 +20,46 @@ _PACKAGED_RESOURCES_ROOT = Path(__file__).resolve().parent.parent
 if (_PACKAGED_RESOURCES_ROOT / "utils").is_dir() and str(_PACKAGED_RESOURCES_ROOT) not in sys.path:
     sys.path.insert(0, str(_PACKAGED_RESOURCES_ROOT))
 
-from utils.llm.llama_module_identity import (
-    canonical_llama_module_identity_input as _shared_canonical_llama_module_identity_input,
-    strip_windows_extended_path_prefix,
-    valid_llama_module_identity,
+_PACKAGED_IDENTITY_HELPER = _PACKAGED_RESOURCES_ROOT / "utils" / "llm" / "llama_module_identity.py"
+_HAS_PACKAGED_IDENTITY_HELPER = _PACKAGED_IDENTITY_HELPER.is_file() or any(
+    (Path(entry or ".") / "utils" / "llm" / "llama_module_identity.py").is_file() for entry in sys.path
 )
+
+if _HAS_PACKAGED_IDENTITY_HELPER:
+    from utils.llm.llama_module_identity import (
+        canonical_llama_module_identity_input as _shared_canonical_llama_module_identity_input,
+        strip_windows_extended_path_prefix,
+        valid_llama_module_identity,
+    )
+else:
+    _LLAMA_MODULE_IDENTITY_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+    _LLAMA_MODULE_IDENTITY_DOMAIN = "token.place.llama_cpp.module_path.v1"
+
+    def strip_windows_extended_path_prefix(path_text: str) -> str:
+        if path_text.startswith("\\\\?\\UNC\\"):
+            return "\\\\" + path_text[8:]
+        if path_text.startswith("\\\\?\\"):
+            return path_text[4:]
+        return path_text
+
+    def _shared_canonical_llama_module_identity_input(module_path: Any) -> Optional[str]:
+        if not module_path:
+            return None
+        try:
+            path_text = strip_windows_extended_path_prefix(str(module_path))
+            canonical = os.path.normcase(os.path.normpath(os.path.realpath(os.path.abspath(path_text))))
+        except (TypeError, ValueError, OSError):
+            try:
+                canonical = os.path.normcase(os.path.normpath(strip_windows_extended_path_prefix(str(module_path))))
+            except (TypeError, ValueError, OSError):
+                return None
+        return canonical.replace("\\", "/")
+
+    def valid_llama_module_identity(value: Any) -> Optional[str]:
+        if not isinstance(value, str):
+            return None
+        text = value.strip()
+        return text if _LLAMA_MODULE_IDENTITY_RE.fullmatch(text) else None
 
 from desktop_gpu_packaging import (
     LlamaCppInstallPlan,

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -15,6 +15,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+_PACKAGED_RESOURCES_ROOT = Path(__file__).resolve().parent.parent
+if (_PACKAGED_RESOURCES_ROOT / "utils").is_dir() and str(_PACKAGED_RESOURCES_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PACKAGED_RESOURCES_ROOT))
+
 from utils.llm.llama_module_identity import (
     canonical_llama_module_identity_input as _shared_canonical_llama_module_identity_input,
     strip_windows_extended_path_prefix,

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
-import hashlib
 import json
-import re
 import os
 import platform as platform_module
 import subprocess
@@ -14,6 +12,12 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+from utils.llm.llama_module_identity import (
+    llama_module_identity_from_path,
+    strip_windows_extended_path_prefix,
+    valid_llama_module_identity,
+)
 
 from desktop_gpu_packaging import (
     LlamaCppInstallPlan,
@@ -43,47 +47,17 @@ LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS = (
 )
 
 
+
 def _strip_windows_extended_path_prefix(path_text: str) -> str:
-    if path_text.startswith("\\\\?\\UNC\\"):
-        return "\\\\" + path_text[8:]
-    if path_text.startswith("\\\\?\\"):
-        return path_text[4:]
-    return path_text
+    return strip_windows_extended_path_prefix(path_text)
 
 
 def _safe_resolve_path(path_text: str | Path) -> Path:
     return Path(_strip_windows_extended_path_prefix(str(path_text))).resolve()
 
 
-_LLAMA_MODULE_IDENTITY_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
-_LLAMA_MODULE_IDENTITY_DOMAIN = "token.place.llama_cpp.module_path.v1"
-
-
-def _canonical_llama_module_identity_input(module_path: Any) -> Optional[str]:
-    if not module_path:
-        return None
-    try:
-        path_text = _strip_windows_extended_path_prefix(str(module_path))
-        canonical = os.path.normcase(os.path.normpath(os.path.realpath(os.path.abspath(path_text))))
-    except (TypeError, ValueError, OSError):
-        try:
-            canonical = os.path.normcase(os.path.normpath(_strip_windows_extended_path_prefix(str(module_path))))
-        except (TypeError, ValueError, OSError):
-            return None
-    return canonical.replace('\\', '/')
-
-
-def llama_module_identity_from_path(module_path: Any) -> Optional[str]:
-    canonical = _canonical_llama_module_identity_input(module_path)
-    if not canonical or canonical in {'missing', 'unknown'}:
-        return None
-    digest = hashlib.sha256(f"{_LLAMA_MODULE_IDENTITY_DOMAIN}\0{canonical}".encode('utf-8')).hexdigest()
-    return f"sha256:{digest}"
-
-
 def _valid_llama_module_identity(value: Any) -> Optional[str]:
-    text = str(value or '').strip()
-    return text if _LLAMA_MODULE_IDENTITY_RE.fullmatch(text) else None
+    return valid_llama_module_identity(value)
 
 
 @dataclass(frozen=True)

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -32,6 +32,10 @@ if _HAS_PACKAGED_IDENTITY_HELPER:
         valid_llama_module_identity,
     )
 else:
+    # The signed macOS bundle can execute this module from Contents/Resources/python
+    # without packaging the repository-level utils package. Keep this fallback byte-for-byte
+    # compatible with utils.llm.llama_module_identity; unit tests launch a subprocess in
+    # that packaged shape and compare POSIX, Windows, sentinel, and schema results.
     _LLAMA_MODULE_IDENTITY_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
     _LLAMA_MODULE_IDENTITY_DOMAIN = "token.place.llama_cpp.module_path.v1"
 

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import importlib.util
+import hashlib
 import json
+import re
 import os
 import platform as platform_module
 import subprocess
@@ -51,6 +53,37 @@ def _strip_windows_extended_path_prefix(path_text: str) -> str:
 
 def _safe_resolve_path(path_text: str | Path) -> Path:
     return Path(_strip_windows_extended_path_prefix(str(path_text))).resolve()
+
+
+_LLAMA_MODULE_IDENTITY_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_LLAMA_MODULE_IDENTITY_DOMAIN = "token.place.llama_cpp.module_path.v1"
+
+
+def _canonical_llama_module_identity_input(module_path: Any) -> Optional[str]:
+    if not module_path:
+        return None
+    try:
+        path_text = _strip_windows_extended_path_prefix(str(module_path))
+        canonical = os.path.normcase(os.path.normpath(os.path.realpath(os.path.abspath(path_text))))
+    except (TypeError, ValueError, OSError):
+        try:
+            canonical = os.path.normcase(os.path.normpath(_strip_windows_extended_path_prefix(str(module_path))))
+        except (TypeError, ValueError, OSError):
+            return None
+    return canonical.replace('\\', '/')
+
+
+def llama_module_identity_from_path(module_path: Any) -> Optional[str]:
+    canonical = _canonical_llama_module_identity_input(module_path)
+    if not canonical or canonical in {'missing', 'unknown'}:
+        return None
+    digest = hashlib.sha256(f"{_LLAMA_MODULE_IDENTITY_DOMAIN}\0{canonical}".encode('utf-8')).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _valid_llama_module_identity(value: Any) -> Optional[str]:
+    text = str(value or '').strip()
+    return text if _LLAMA_MODULE_IDENTITY_RE.fullmatch(text) else None
 
 
 @dataclass(frozen=True)
@@ -780,6 +813,7 @@ def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, Any]:
         "dependency_target": probe.dependency_target,
         "pip_version": probe.pip_version,
         "llama_cpp_python_version": probe.llama_cpp_python_version,
+        "llama_module_path_present": bool(llama_module_identity_from_path(probe.llama_module_path)),
         "backend": probe.backend,
         "gpu_offload_supported": probe.gpu_offload_supported,
         "constructor_kwarg_support": dict(probe.constructor_kwarg_support),
@@ -791,6 +825,7 @@ def _probe_result_payload(probe: RuntimeProbe) -> Dict[str, Any]:
         "q4_kv_cache_type_value": probe.q4_kv_cache_type_value,
         "f16_kv_cache_type_value": probe.f16_kv_cache_type_value,
         "capability_source": probe.capability_source,
+        **({"llama_module_identity": identity} if (identity := llama_module_identity_from_path(probe.llama_module_path)) else {}),
         "yarn_rope_supported": probe.yarn_rope_supported,
         "yarn_resolver_source": probe.yarn_resolver_source,
         "rope_scaling_type_supported": probe.rope_scaling_type_supported,
@@ -1422,6 +1457,8 @@ def _record_desktop_runtime_probe(result: Dict[str, Any]) -> Dict[str, Any]:
         os.environ.pop(RUNTIME_PROBE_ENV, None)
         return result
     public_result = dict(result)
+    for private_key in ("llama_module_identity",):
+        public_result.pop(private_key, None)
     for key in (
         "yarn_rope_supported",
         "rope_scaling_type_supported",

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import ntpath
+import hashlib
 import platform as platform_module
 import subprocess
 import sys
@@ -14,7 +16,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from utils.llm.llama_module_identity import (
-    llama_module_identity_from_path,
+    canonical_llama_module_identity_input as _shared_canonical_llama_module_identity_input,
     strip_windows_extended_path_prefix,
     valid_llama_module_identity,
 )
@@ -47,6 +49,54 @@ LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS = (
 )
 
 
+def _raw_path_sentinel(module_path: Any) -> bool:
+    if module_path is None:
+        return True
+    try:
+        text = str(module_path).strip()
+    except (TypeError, ValueError, OSError):
+        return True
+    return text == "" or text.lower() in {"missing", "unknown"}
+
+
+def _looks_like_windows_path(path_text: str) -> bool:
+    stripped = path_text.strip()
+    return (
+        stripped.startswith("\\")
+        or stripped.startswith("\\?\\")
+        or (len(stripped) >= 3 and stripped[1] == ":" and stripped[2] in {"\\", "/"})
+    )
+
+def _canonical_windows_path_for_identity(path_text: str) -> str:
+    stripped = _strip_windows_extended_path_prefix(path_text.strip())
+    if stripped.startswith('\\?/'):
+        stripped = stripped[3:]
+    if stripped.startswith('/'):
+        canonical = _shared_canonical_llama_module_identity_input(stripped)
+        return canonical or os.path.normpath(stripped).replace("\\", "/")
+    normalized = ntpath.normpath(stripped).replace("\\", "/")
+    return normalized.lower()
+
+
+def _canonical_llama_module_identity_input(module_path: Any) -> Optional[str]:
+    if _raw_path_sentinel(module_path):
+        return None
+    path_text = str(module_path)
+    if _looks_like_windows_path(path_text):
+        return _canonical_windows_path_for_identity(path_text)
+    canonical = _shared_canonical_llama_module_identity_input(module_path)
+    if not canonical or canonical.strip().lower() in {"missing", "unknown"}:
+        return None
+    return canonical
+
+
+def llama_module_identity_from_path(module_path: Any) -> Optional[str]:
+    canonical = _canonical_llama_module_identity_input(module_path)
+    if not canonical:
+        return None
+    digest = hashlib.sha256(f"token.place.llama_cpp.module_path.v1\0{canonical}".encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
 
 def _strip_windows_extended_path_prefix(path_text: str) -> str:
     return strip_windows_extended_path_prefix(path_text)
@@ -57,6 +107,8 @@ def _safe_resolve_path(path_text: str | Path) -> Path:
 
 
 def _valid_llama_module_identity(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
     return valid_llama_module_identity(value)
 
 

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -324,6 +324,7 @@ def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
             "HOME": str(home_dir),
             "TMPDIR": str(tmpdir),
             "PIP_CACHE_DIR": str(app_data / "pip-cache"),
+            "PIP_NO_INDEX": "1",
             "PYTHONDONTWRITEBYTECODE": "1",
             "PYTHONNOUSERSITE": "1",
             "PYTHONPYCACHEPREFIX": str(pycache),
@@ -663,6 +664,65 @@ def _validate_embedded_python_runtime(app_path: Path) -> None:
     for key in ("flash_attn", "offload_kqv", "n_batch", "n_ubatch"):
         if not constructor_support.get(key):
             _fail(f"embedded runtime probe missing capability: {key}")
+
+    background_probe = r"""
+import json, os, threading
+from desktop_runtime_setup import RUNTIME_PROBE_ENV, ensure_desktop_llama_runtime
+from utils.llm import model_manager
+
+result = {}
+
+def worker():
+    setup = ensure_desktop_llama_runtime('auto', context_tier='64k-full')
+    private_probe = json.loads(os.environ.get(RUNTIME_PROBE_ENV) or '{}')
+    facade = model_manager._import_llama_cpp_subprocess_module(
+        timeout_seconds=10, desktop_runtime_probe=private_probe
+    )
+    gate = model_manager._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
+    constructor = gate.get('constructor_kwarg_support') or {}
+    result.update({
+        'runtime_action_ok': setup.get('runtime_action') in {'metal_already_supported', 'already_supported'},
+        'facade_type': type(facade).__name__,
+        'backend': gate.get('backend'),
+        'gpu_offload_supported': gate.get('gpu_offload_supported') is True,
+        'version': gate.get('llama_cpp_python_version'),
+        'yarn_resolver_source': gate.get('yarn_resolver_source'),
+        'constructor_signature_inspectable': gate.get('constructor_signature_inspectable') is True,
+        'required_kwargs_supported': all(constructor.get(name) for name in (
+            'type_k', 'type_v', 'flash_attn', 'offload_kqv', 'n_batch', 'n_ubatch',
+            'rope_scaling_type', 'yarn_ext_factor', 'yarn_attn_factor', 'yarn_beta_fast',
+            'yarn_beta_slow', 'yarn_orig_ctx', 'rope_freq_base', 'rope_freq_scale')),
+        'llama_module_identity_match': gate.get('llama_module_identity_match') is True,
+        'supported': gate.get('supported') is True,
+        'desktop_probe_authoritative': gate.get('desktop_probe_authoritative') is True,
+        'secondary_reprobe_skipped': gate.get('child_probe_reprobe_skipped_reason') == 'desktop_probe_authoritative',
+    })
+
+thread = threading.Thread(target=worker, name='token-place-release-qwen64k-probe')
+thread.start()
+thread.join(timeout=30)
+if thread.is_alive():
+    raise SystemExit('background facade probe timed out')
+print(json.dumps(result, sort_keys=True))
+"""
+    background_data = json.loads(_run_python_sanitized(py, background_probe, app_path).splitlines()[-1])
+    expected_background = {
+        "runtime_action_ok": True,
+        "facade_type": "_SubprocessLlamaCppModule",
+        "backend": "metal",
+        "gpu_offload_supported": True,
+        "version": "0.3.32",
+        "yarn_resolver_source": "top_level_enum",
+        "constructor_signature_inspectable": True,
+        "required_kwargs_supported": True,
+        "llama_module_identity_match": True,
+        "supported": True,
+        "desktop_probe_authoritative": True,
+        "secondary_reprobe_skipped": True,
+    }
+    for key, expected in expected_background.items():
+        if background_data.get(key) != expected:
+            _fail(f"embedded background Qwen 64K facade probe failed {key}: {background_data.get(key)!r}")
     model_bridge = app_path / "Contents" / "Resources" / "python" / "model_bridge.py"
     if model_bridge.is_file():
         model_bridge_for_subprocess = model_bridge if model_bridge.is_absolute() else model_bridge.absolute()

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -328,7 +328,12 @@ def _run_python_sanitized(py: Path, code: str, app_path: Path) -> str:
             "PYTHONNOUSERSITE": "1",
             "PYTHONPYCACHEPREFIX": str(pycache),
             "PATH": "/usr/bin:/bin",
-            "PYTHONPATH": str(app_for_subprocess / "Contents" / "Resources" / "python"),
+            "PYTHONPATH": os.pathsep.join(
+                [
+                    str(app_for_subprocess / "Contents" / "Resources" / "python"),
+                    str(app_for_subprocess / "Contents" / "Resources"),
+                ]
+            ),
             "TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET": str(dependency_target),
             "TOKEN_PLACE_MODELS_DIR": str(app_data / "models"),
             "TOKEN_PLACE_MODEL_DIR": str(app_data / "models"),

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -702,6 +702,7 @@ def worker():
         desktop_runtime_probe=private_runtime_setup,
     )
     gate = model_manager._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
+    facade_capabilities = model_manager._safe_constructor_capability_payload(facade)
     constructor = gate.get('constructor_kwarg_support') or {}
     result.update({
         'runtime_action': setup.get('runtime_action'),
@@ -711,8 +712,8 @@ def worker():
         'capability_source': gate.get('capability_source'),
         'incomplete_probe_fields': gate.get('incomplete_probe_fields'),
         'facade_type': type(facade).__name__,
-        'backend': gate.get('backend'),
-        'gpu_offload_supported': gate.get('gpu_offload_supported') is True,
+        'backend': facade_capabilities.get('backend'),
+        'gpu_offload_supported': facade_capabilities.get('gpu_offload_supported') is True,
         'version': gate.get('llama_cpp_python_version'),
         'yarn_resolver_source': gate.get('yarn_resolver_source'),
         'constructor_signature_inspectable': gate.get('constructor_signature_inspectable') is True,

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -667,6 +667,14 @@ def _validate_embedded_python_runtime(app_path: Path) -> None:
 
     background_probe = r"""
 import json, os, threading
+import desktop_runtime_setup
+from path_bootstrap import ensure_runtime_import_paths
+
+ensure_runtime_import_paths(
+    desktop_runtime_setup.__file__,
+    avoid_llama_cpp_shadowing=True,
+)
+
 from desktop_runtime_setup import RUNTIME_PROBE_ENV, ensure_desktop_llama_runtime
 from utils.llm import model_manager
 

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -676,12 +676,21 @@ ensure_runtime_import_paths(
 )
 
 from desktop_runtime_setup import RUNTIME_PROBE_ENV, ensure_desktop_llama_runtime
+from pathlib import Path
 from utils.llm import model_manager
+
+runtime_import_root = Path(model_manager.__file__).resolve().parents[2]
+if not (runtime_import_root / 'requirements.txt').is_file():
+    raise SystemExit('packaged runtime metadata missing: requirements.txt')
 
 result = {}
 
 def worker():
-    setup = ensure_desktop_llama_runtime('auto', context_tier='64k-full')
+    setup = ensure_desktop_llama_runtime(
+        'auto',
+        repo_root=runtime_import_root,
+        context_tier='64k-full',
+    )
     private_probe = json.loads(os.environ.get(RUNTIME_PROBE_ENV) or '{}')
     facade = model_manager._import_llama_cpp_subprocess_module(
         timeout_seconds=10, desktop_runtime_probe=private_probe
@@ -689,7 +698,10 @@ def worker():
     gate = model_manager._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
     constructor = gate.get('constructor_kwarg_support') or {}
     result.update({
+        'runtime_action': setup.get('runtime_action'),
         'runtime_action_ok': setup.get('runtime_action') in {'metal_already_supported', 'already_supported'},
+        'runtime_selected_backend': setup.get('runtime_selected_backend'),
+        'version_match': setup.get('version_match'),
         'facade_type': type(facade).__name__,
         'backend': gate.get('backend'),
         'gpu_offload_supported': gate.get('gpu_offload_supported') is True,
@@ -728,9 +740,16 @@ print(json.dumps(result, sort_keys=True))
         "desktop_probe_authoritative": True,
         "secondary_reprobe_skipped": True,
     }
+    safe_background_diagnostics = {
+        key: background_data.get(key)
+        for key in ("runtime_action", "runtime_selected_backend", "version_match")
+    }
     for key, expected in expected_background.items():
         if background_data.get(key) != expected:
-            _fail(f"embedded background Qwen 64K facade probe failed {key}: {background_data.get(key)!r}")
+            _fail(
+                f"embedded background Qwen 64K facade probe failed {key}: "
+                f"{background_data.get(key)!r}; diagnostics={safe_background_diagnostics!r}"
+            )
     model_bridge = app_path / "Contents" / "Resources" / "python" / "model_bridge.py"
     if model_bridge.is_file():
         model_bridge_for_subprocess = model_bridge if model_bridge.is_absolute() else model_bridge.absolute()

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -703,7 +703,7 @@ def worker():
     )
     gate = model_manager._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
     facade_capabilities = model_manager._safe_constructor_capability_payload(facade)
-    constructor = gate.get('constructor_kwarg_support') or {}
+    constructor = facade_capabilities.get('constructor_kwarg_support') or {}
     result.update({
         'runtime_action': setup.get('runtime_action'),
         'runtime_action_ok': setup.get('runtime_action') in {'metal_already_supported', 'already_supported'},

--- a/scripts/validate_desktop_tauri_release_artifacts.py
+++ b/scripts/validate_desktop_tauri_release_artifacts.py
@@ -691,17 +691,25 @@ def worker():
         repo_root=runtime_import_root,
         context_tier='64k-full',
     )
+    private_runtime_setup = dict(setup)
     private_probe = json.loads(os.environ.get(RUNTIME_PROBE_ENV) or '{}')
-    facade = model_manager._import_llama_cpp_subprocess_module(
-        timeout_seconds=10, desktop_runtime_probe=private_probe
+    private_identity = private_probe.get('llama_module_identity')
+    if isinstance(private_identity, str):
+        private_runtime_setup['llama_module_identity'] = private_identity
+    facade = model_manager._import_llama_cpp_runtime(
+        require_real_runtime=True,
+        timeout_seconds=10,
+        desktop_runtime_probe=private_runtime_setup,
     )
     gate = model_manager._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
     constructor = gate.get('constructor_kwarg_support') or {}
     result.update({
         'runtime_action': setup.get('runtime_action'),
         'runtime_action_ok': setup.get('runtime_action') in {'metal_already_supported', 'already_supported'},
-        'runtime_selected_backend': setup.get('runtime_selected_backend'),
-        'version_match': setup.get('version_match'),
+        'selected_backend': setup.get('selected_backend'),
+        'llama_cpp_python_version_match': setup.get('llama_cpp_python_version_match'),
+        'capability_source': gate.get('capability_source'),
+        'incomplete_probe_fields': gate.get('incomplete_probe_fields'),
         'facade_type': type(facade).__name__,
         'backend': gate.get('backend'),
         'gpu_offload_supported': gate.get('gpu_offload_supported') is True,
@@ -742,7 +750,7 @@ print(json.dumps(result, sort_keys=True))
     }
     safe_background_diagnostics = {
         key: background_data.get(key)
-        for key in ("runtime_action", "runtime_selected_backend", "version_match")
+        for key in ("runtime_action", "selected_backend", "llama_cpp_python_version_match", "capability_source", "llama_module_identity_match", "incomplete_probe_fields")
     }
     for key, expected in expected_background.items():
         if background_data.get(key) != expected:

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -4314,7 +4314,12 @@ def test_multi_relay_recovery_exhaustion_reports_none_registered_or_ready(capsys
 
 def test_multi_relay_network_failure_does_not_trigger_shared_model_recovery(capsys, monkeypatch):
     _reset_cancel_queue()
-    calls = {'warm': 0, 'poll': 0}
+    calls = {'warm': 0}
+    poll_attempts_by_relay = {}
+    poll_lock = threading.Lock()
+    first_poll_barrier = threading.Barrier(2, timeout=5)
+    registered_relay_emitted = threading.Event()
+    max_poll_attempts = 20
 
     class NetworkFailureRuntime(FakeRuntime):
         def __init__(self, config, *_, model_manager=None, crypto_manager=None):
@@ -4328,14 +4333,32 @@ def test_multi_relay_network_failure_does_not_trigger_shared_model_recovery(caps
             return True
 
         def register_and_poll_once(self):
-            calls['poll'] += 1
-            if self.relay_client.relay_url.endswith('a.example'):
+            relay_url = self.relay_client.relay_url
+            with poll_lock:
+                poll_attempts_by_relay[relay_url] = poll_attempts_by_relay.get(relay_url, 0) + 1
+                first_attempt_for_relay = poll_attempts_by_relay[relay_url] == 1
+            if first_attempt_for_relay:
+                first_poll_barrier.wait()
+            if relay_url.endswith('a.example'):
                 return {'error': 'temporary relay outage', 'next_ping_in_x_seconds': 0}
             return {'next_ping_in_x_seconds': 0}
 
+    original_emit = compute_node_bridge.emit
+
+    def observe_registered_relay_emit(payload):
+        original_emit(payload)
+        if payload.get('registered_relay_count', 0) > 0:
+            registered_relay_emitted.set()
+
+    def deterministic_stop_requested():
+        with poll_lock:
+            poll_attempt_count = sum(poll_attempts_by_relay.values())
+        return registered_relay_emitted.is_set() or poll_attempt_count >= max_poll_attempts
+
     _install_fake_runtime_module(monkeypatch, runtime_cls=NetworkFailureRuntime)
     monkeypatch.setenv('TOKENPLACE_DESKTOP_WARM_LOAD', '0')
-    monkeypatch.setattr(compute_node_bridge, 'stop_requested', lambda: calls['poll'] > 3)
+    monkeypatch.setattr(compute_node_bridge, 'emit', observe_registered_relay_emit)
+    monkeypatch.setattr(compute_node_bridge, 'stop_requested', deterministic_stop_requested)
     args = SimpleNamespace(
         model='/tmp/model.gguf',
         mode='cpu',

--- a/tests/unit/test_desktop_model_bridge.py
+++ b/tests/unit/test_desktop_model_bridge.py
@@ -253,6 +253,7 @@ def test_inspect_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_
     import_root = resources_dir / '_up_' / '_up_'
     utils_llm_dir = import_root / 'utils' / 'llm'
     model_profiles_path = MODULE_PATH.parents[3] / 'utils' / 'llm' / 'model_profiles.py'
+    llama_identity_path = MODULE_PATH.parents[3] / 'utils' / 'llm' / 'llama_module_identity.py'
     python_dir.mkdir(parents=True)
     utils_llm_dir.mkdir(parents=True)
 
@@ -267,6 +268,7 @@ def test_inspect_subprocess_succeeds_for_packaged_layout_without_pythonpath(tmp_
     (import_root / 'utils' / '__init__.py').write_text('', encoding='utf-8')
     (utils_llm_dir / '__init__.py').write_text('', encoding='utf-8')
     (utils_llm_dir / 'model_profiles.py').write_text(model_profiles_path.read_text(encoding='utf-8'), encoding='utf-8')
+    (utils_llm_dir / 'llama_module_identity.py').write_text(llama_identity_path.read_text(encoding='utf-8'), encoding='utf-8')
     (utils_llm_dir / 'model_manager.py').write_text(
         """
 class _Manager:

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -710,10 +710,30 @@ def test_validator_sanitized_python_env_replaces_parent_environment(monkeypatch,
 def test_background_probe_bootstraps_nested_tauri_resources_before_utils_import(tmp_path) -> None:
     resources = tmp_path / 'token.place desktop.app' / 'Contents' / 'Resources'
     python_resources = resources / 'python'
-    nested_utils = resources / '_up_' / '_up_' / 'utils' / 'llm'
+    runtime_import_root = resources / '_up_' / '_up_'
+    nested_utils = runtime_import_root / 'utils' / 'llm'
     python_resources.mkdir(parents=True)
     nested_utils.mkdir(parents=True)
-    (python_resources / 'desktop_runtime_setup.py').write_text('VALUE = "desktop-runtime"\n', encoding='utf-8')
+    (runtime_import_root / 'requirements.txt').write_text('llama-cpp-python==0.3.32\n', encoding='utf-8')
+    (python_resources / 'desktop_runtime_setup.py').write_text(
+        """
+import json
+import os
+from pathlib import Path
+
+RUNTIME_PROBE_ENV = 'TOKEN_PLACE_DESKTOP_RUNTIME_PROBE_JSON'
+
+def ensure_desktop_llama_runtime(mode, *, repo_root=None, context_tier=None):
+    root = Path(repo_root)
+    if mode != 'auto' or context_tier != '64k-full':
+        raise RuntimeError('unexpected runtime arguments')
+    if not (root / 'requirements.txt').is_file():
+        raise RuntimeError('missing packaged requirements metadata')
+    os.environ[RUNTIME_PROBE_ENV] = json.dumps({'private': True})
+    return {'repo_root_name': root.name, 'requirements_found': True}
+""",
+        encoding='utf-8',
+    )
     (python_resources / 'path_bootstrap.py').write_text(
         Path('desktop-tauri/src-tauri/python/path_bootstrap.py').read_text(encoding='utf-8'),
         encoding='utf-8',
@@ -723,6 +743,8 @@ def test_background_probe_bootstraps_nested_tauri_resources_before_utils_import(
     (nested_utils / 'model_manager.py').write_text('BOOTSTRAPPED = True\n', encoding='utf-8')
 
     code = """
+import json
+from pathlib import Path
 import desktop_runtime_setup
 from path_bootstrap import ensure_runtime_import_paths
 
@@ -731,8 +753,22 @@ ensure_runtime_import_paths(
     avoid_llama_cpp_shadowing=True,
 )
 
+from desktop_runtime_setup import ensure_desktop_llama_runtime
 from utils.llm import model_manager
-print(model_manager.BOOTSTRAPPED)
+
+runtime_import_root = Path(model_manager.__file__).resolve().parents[2]
+if not (runtime_import_root / 'requirements.txt').is_file():
+    raise SystemExit('requirements metadata not found')
+setup = ensure_desktop_llama_runtime(
+    'auto',
+    repo_root=runtime_import_root,
+    context_tier='64k-full',
+)
+print(json.dumps({
+    'bootstrapped': model_manager.BOOTSTRAPPED,
+    'repo_root_name': setup['repo_root_name'],
+    'requirements_found': setup['requirements_found'],
+}, sort_keys=True))
 """
     result = subprocess.run(
         [sys.executable, '-c', code],
@@ -747,7 +783,11 @@ print(model_manager.BOOTSTRAPPED)
     )
 
     assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == 'True'
+    assert json.loads(result.stdout.strip()) == {
+        'bootstrapped': True,
+        'repo_root_name': '_up_',
+        'requirements_found': True,
+    }
 
 def test_release_workflow_does_not_rebuild_llama_cpp_on_release_matrix() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
@@ -2007,6 +2047,6 @@ def test_validate_embedded_python_runtime_requires_background_facade_probe(monke
     background['secondary_reprobe_skipped'] = True
     validator._validate_embedded_python_runtime(app)
     assert any('ensure_runtime_import_paths(' in code for code in calls)
-    assert any("ensure_desktop_llama_runtime('auto', context_tier='64k-full')" in code for code in calls)
+    assert any("repo_root=runtime_import_root" in code for code in calls)
     assert any('_runtime_supports_qwen_yarn_rope' in code for code in calls)
     assert any('_import_llama_cpp_subprocess_module' in code for code in calls)

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -705,6 +706,48 @@ def test_validator_sanitized_python_env_replaces_parent_environment(monkeypatch,
     for key in forbidden_parent_env:
         assert key not in captured['env']
 
+
+def test_background_probe_bootstraps_nested_tauri_resources_before_utils_import(tmp_path) -> None:
+    resources = tmp_path / 'token.place desktop.app' / 'Contents' / 'Resources'
+    python_resources = resources / 'python'
+    nested_utils = resources / '_up_' / '_up_' / 'utils' / 'llm'
+    python_resources.mkdir(parents=True)
+    nested_utils.mkdir(parents=True)
+    (python_resources / 'desktop_runtime_setup.py').write_text('VALUE = "desktop-runtime"\n', encoding='utf-8')
+    (python_resources / 'path_bootstrap.py').write_text(
+        Path('desktop-tauri/src-tauri/python/path_bootstrap.py').read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    (nested_utils.parent / '__init__.py').write_text('', encoding='utf-8')
+    (nested_utils / '__init__.py').write_text('', encoding='utf-8')
+    (nested_utils / 'model_manager.py').write_text('BOOTSTRAPPED = True\n', encoding='utf-8')
+
+    code = """
+import desktop_runtime_setup
+from path_bootstrap import ensure_runtime_import_paths
+
+ensure_runtime_import_paths(
+    desktop_runtime_setup.__file__,
+    avoid_llama_cpp_shadowing=True,
+)
+
+from utils.llm import model_manager
+print(model_manager.BOOTSTRAPPED)
+"""
+    result = subprocess.run(
+        [sys.executable, '-c', code],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            'PYTHONPATH': str(python_resources),
+            'PYTHONNOUSERSITE': '1',
+        },
+        cwd=str(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == 'True'
 
 def test_release_workflow_does_not_rebuild_llama_cpp_on_release_matrix() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
@@ -1963,6 +2006,7 @@ def test_validate_embedded_python_runtime_requires_background_facade_probe(monke
         validator._validate_embedded_python_runtime(app)
     background['secondary_reprobe_skipped'] = True
     validator._validate_embedded_python_runtime(app)
+    assert any('ensure_runtime_import_paths(' in code for code in calls)
     assert any("ensure_desktop_llama_runtime('auto', context_tier='64k-full')" in code for code in calls)
     assert any('_runtime_supports_qwen_yarn_rope' in code for code in calls)
     assert any('_import_llama_cpp_subprocess_module' in code for code in calls)

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -868,6 +868,10 @@ def _safe_constructor_capability_payload(facade):
     return {{
         'backend': 'metal',
         'gpu_offload_supported': True,
+        'constructor_kwarg_support': {{name: True for name in (
+            'type_k', 'type_v', 'flash_attn', 'offload_kqv', 'n_batch', 'n_ubatch',
+            'rope_scaling_type', 'yarn_ext_factor', 'yarn_attn_factor', 'yarn_beta_fast',
+            'yarn_beta_slow', 'yarn_orig_ctx', 'rope_freq_base', 'rope_freq_scale')}},
     }}
 
 def _runtime_supports_qwen_yarn_rope(facade, llama_cls):
@@ -876,7 +880,6 @@ def _runtime_supports_qwen_yarn_rope(facade, llama_cls):
         'yarn_resolver_source': 'top_level_enum',
         'constructor_signature_inspectable': True,
         'constructor_kwarg_support': {{name: True for name in (
-            'type_k', 'type_v', 'flash_attn', 'offload_kqv', 'n_batch', 'n_ubatch',
             'rope_scaling_type', 'yarn_ext_factor', 'yarn_attn_factor', 'yarn_beta_fast',
             'yarn_beta_slow', 'yarn_orig_ctx', 'rope_freq_base', 'rope_freq_scale')}},
         'llama_module_identity_match': True,
@@ -929,6 +932,14 @@ def worker():
         'facade_file_discovered': bool(getattr(facade, '__file__', None)),
         'backend': facade_capabilities.get('backend'),
         'gpu_offload_supported': facade_capabilities.get('gpu_offload_supported') is True,
+        'required_kwargs_supported': all(
+            (facade_capabilities.get('constructor_kwarg_support') or {{}}).get(name)
+            for name in (
+                'type_k', 'type_v', 'flash_attn', 'offload_kqv', 'n_batch', 'n_ubatch',
+                'rope_scaling_type', 'yarn_ext_factor', 'yarn_attn_factor', 'yarn_beta_fast',
+                'yarn_beta_slow', 'yarn_orig_ctx', 'rope_freq_base', 'rope_freq_scale'
+            )
+        ),
         'llama_module_identity_match': gate.get('llama_module_identity_match') is True,
         'supported': gate.get('supported') is True,
         'desktop_probe_authoritative': gate.get('desktop_probe_authoritative') is True,
@@ -965,6 +976,7 @@ print(json.dumps(result, sort_keys=True))
         'facade_type': '_SubprocessLlamaCppModule',
         'gpu_offload_supported': True,
         'llama_module_identity_match': True,
+        'required_kwargs_supported': True,
         'runtime_call_count': 1,
         'runtime_probe_keys': [
             'capability_source',
@@ -2240,6 +2252,8 @@ def test_validate_embedded_python_runtime_requires_background_facade_probe(monke
     assert any('_runtime_supports_qwen_yarn_rope' in code for code in calls)
     assert any('_import_llama_cpp_runtime' in code for code in calls)
     assert any('_safe_constructor_capability_payload' in code for code in calls)
+    assert any("facade_capabilities.get('constructor_kwarg_support')" in code for code in calls)
     assert not any("gate.get('backend')" in code for code in calls)
     assert not any("gate.get('gpu_offload_supported')" in code for code in calls)
+    assert not any("gate.get('constructor_kwarg_support')" in code for code in calls)
     assert not any('_import_llama_cpp_subprocess_module' in code for code in calls)

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -1974,6 +1974,93 @@ def test_validator_embedded_runtime_failure_paths(monkeypatch, tmp_path) -> None
     assert any('model_bridge.py' in code for code in calls)
 
 
+def test_validate_embedded_background_probe_failure_diagnostics_are_path_free(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app, _tauri_config, _icon = _minimal_validator_app(validator, tmp_path)
+    runtime = app / 'Contents' / 'Resources' / 'python-runtime'
+    py = runtime / 'bin' / 'python3'
+    py.parent.mkdir(parents=True)
+    py.write_text('python', encoding='utf-8')
+    py.chmod(0o755)
+    for notice in (
+        'embedded_python_runtime_provenance.json',
+        'LICENSE-PYTHON.txt',
+        'LICENSE-python-build-standalone.txt',
+    ):
+        (runtime / notice).write_text('notice', encoding='utf-8')
+    resources = app / 'Contents' / 'Resources' / 'python'
+    resources.mkdir(parents=True)
+    (resources / 'model_bridge.py').write_text('print("inspect")', encoding='utf-8')
+    private_path = str((tmp_path / 'private' / 'llama_cpp' / '__init__.py').resolve())
+    private_digest = 'sha256:' + ('b' * 64)
+
+    payload = {
+        'version': [3, 11],
+        'machine': 'arm64',
+        'executable': str(py),
+        'prefix': str(runtime),
+        'llama_cpp_python_version': '0.3.32',
+    }
+    probe = {
+        'backend': 'metal',
+        'gpu_offload_supported': True,
+        'qwen_64k_yarn_support': 'supported',
+        'rope_scaling_type_supported': True,
+        'rope_freq_scale_supported': True,
+        'yarn_orig_ctx_supported': True,
+        'constructor_kwarg_support': {
+            'flash_attn': True,
+            'offload_kqv': True,
+            'n_batch': True,
+            'n_ubatch': True,
+        },
+    }
+    background = {
+        'runtime_action': 'metal_already_supported',
+        'runtime_action_ok': True,
+        'selected_backend': 'metal',
+        'llama_cpp_python_version_match': 'match',
+        'capability_source': 'desktop_runtime_setup_probe',
+        'incomplete_probe_fields': ['llama_module_identity_match'],
+        'facade_type': '_SubprocessLlamaCppModule',
+        'backend': 'metal',
+        'gpu_offload_supported': True,
+        'version': '0.3.32',
+        'yarn_resolver_source': 'top_level_enum',
+        'constructor_signature_inspectable': True,
+        'required_kwargs_supported': True,
+        'llama_module_identity_match': False,
+        'supported': False,
+        'desktop_probe_authoritative': True,
+        'secondary_reprobe_skipped': True,
+        'llama_module_identity': private_digest,
+        'llama_module_path': private_path,
+    }
+
+    def fake_run_python(_python, code, _app_path):
+        if 'version_info' in code:
+            return json.dumps(payload)
+        if 'token-place-release-qwen64k-probe' in code:
+            return 'probe log without secrets\n' + json.dumps(background)
+        if 'model_bridge.py' in code:
+            return 'model bridge ok'
+        return json.dumps(probe)
+
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator, '_run', lambda cmd: 'arm64')
+    monkeypatch.setattr(validator, '_run_python_sanitized', fake_run_python)
+    monkeypatch.setattr(validator, '_validate_macho_linkage', lambda path, app_path: None)
+
+    with pytest.raises(SystemExit) as excinfo:
+        validator._validate_embedded_python_runtime(app)
+
+    message = str(excinfo.value)
+    assert 'embedded background Qwen 64K facade probe failed llama_module_identity_match: False' in message
+    assert "'capability_source': 'desktop_runtime_setup_probe'" in message
+    assert "'incomplete_probe_fields': ['llama_module_identity_match']" in message
+    assert private_digest not in message
+    assert private_path not in message
+
 def test_run_python_sanitized_disables_bytecode_and_uses_external_writable_locations(monkeypatch, tmp_path) -> None:
     validator = _load_release_artifact_validator()
     app = tmp_path / 'token.place desktop.app'

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -1974,6 +1974,77 @@ def test_validator_embedded_runtime_failure_paths(monkeypatch, tmp_path) -> None
     assert any('model_bridge.py' in code for code in calls)
 
 
+@pytest.mark.parametrize(
+    ('mutate_payload', 'mutate_probe', 'expected'),
+    (
+        (lambda payload: payload.update({'version': [3, 12]}), lambda probe: None, 'embedded Python is not CPython 3.11'),
+        (lambda payload: payload.update({'machine': 'x86_64'}), lambda probe: None, 'embedded Python is not arm64'),
+        (lambda payload: payload.update({'llama_cpp_python_version': '0.3.31'}), lambda probe: None, 'embedded runtime has wrong llama-cpp-python version'),
+        (lambda payload: payload.update({'prefix': '/tmp/outside-python-runtime'}), lambda probe: None, 'embedded Python prefix escaped app bundle'),
+        (lambda payload: None, lambda probe: probe.update({'backend': 'cpu'}), 'embedded runtime probe did not report Metal GPU offload'),
+        (lambda payload: None, lambda probe: probe.update({'qwen_64k_yarn_support': 'unsupported'}), 'embedded runtime probe missing capability: qwen_64k_yarn_support'),
+        (lambda payload: None, lambda probe: probe.update({'rope_freq_scale_supported': False}), 'embedded runtime probe missing capability: rope_freq_scale'),
+        (lambda payload: None, lambda probe: probe.update({'constructor_kwarg_support': {'flash_attn': True, 'offload_kqv': True, 'n_batch': True}}), 'embedded runtime probe missing capability: n_ubatch'),
+    ),
+)
+def test_validate_embedded_python_runtime_safe_capability_failures(
+    monkeypatch, tmp_path, mutate_payload, mutate_probe, expected
+) -> None:
+    validator = _load_release_artifact_validator()
+    app, _tauri_config, _icon = _minimal_validator_app(validator, tmp_path)
+    runtime = app / 'Contents' / 'Resources' / 'python-runtime'
+    py = runtime / 'bin' / 'python3'
+    py.parent.mkdir(parents=True)
+    py.write_text('python', encoding='utf-8')
+    py.chmod(0o755)
+    for notice in (
+        'embedded_python_runtime_provenance.json',
+        'LICENSE-PYTHON.txt',
+        'LICENSE-python-build-standalone.txt',
+    ):
+        (runtime / notice).write_text('notice', encoding='utf-8')
+
+    payload = {
+        'version': [3, 11],
+        'machine': 'arm64',
+        'executable': str(py),
+        'prefix': str(runtime),
+        'llama_cpp_python_version': '0.3.32',
+    }
+    probe = {
+        'backend': 'metal',
+        'gpu_offload_supported': True,
+        'qwen_64k_yarn_support': 'supported',
+        'rope_scaling_type_supported': True,
+        'rope_freq_scale_supported': True,
+        'yarn_orig_ctx_supported': True,
+        'constructor_kwarg_support': {
+            'flash_attn': True,
+            'offload_kqv': True,
+            'n_batch': True,
+            'n_ubatch': True,
+        },
+    }
+    mutate_payload(payload)
+    mutate_probe(probe)
+
+    def fake_run_python(_python, code, _app_path):
+        if 'version_info' in code:
+            return json.dumps(payload)
+        if '_probe_llama_runtime' in code:
+            return json.dumps(probe)
+        return 'ok'
+
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator, '_run', lambda cmd: 'arm64')
+    monkeypatch.setattr(validator, '_run_python_sanitized', fake_run_python)
+
+    with pytest.raises(SystemExit) as excinfo:
+        validator._validate_embedded_python_runtime(app)
+
+    assert expected in str(excinfo.value)
+
+
 def test_validate_embedded_background_probe_failure_diagnostics_are_path_free(monkeypatch, tmp_path) -> None:
     validator = _load_release_artifact_validator()
     app, _tauri_config, _icon = _minimal_validator_app(validator, tmp_path)

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -2132,6 +2132,92 @@ def test_validate_embedded_background_probe_failure_diagnostics_are_path_free(mo
     assert private_digest not in message
     assert private_path not in message
 
+
+@pytest.mark.parametrize(
+    ('missing_key', 'bad_value'),
+    (
+        ('runtime_action_ok', False),
+        ('backend', None),
+        ('gpu_offload_supported', False),
+        ('required_kwargs_supported', False),
+    ),
+)
+def test_validate_embedded_background_probe_reports_each_safe_failure_key(monkeypatch, tmp_path, missing_key, bad_value) -> None:
+    validator = _load_release_artifact_validator()
+    app, _tauri_config, _icon = _minimal_validator_app(validator, tmp_path)
+    runtime = app / 'Contents' / 'Resources' / 'python-runtime'
+    py = runtime / 'bin' / 'python3'
+    py.parent.mkdir(parents=True)
+    py.write_text('python', encoding='utf-8')
+    py.chmod(0o755)
+    for notice in (
+        'embedded_python_runtime_provenance.json',
+        'LICENSE-PYTHON.txt',
+        'LICENSE-python-build-standalone.txt',
+    ):
+        (runtime / notice).write_text('notice', encoding='utf-8')
+    resources = app / 'Contents' / 'Resources' / 'python'
+    resources.mkdir(parents=True)
+    (resources / 'model_bridge.py').write_text('print("inspect")', encoding='utf-8')
+    payload = {
+        'version': [3, 11],
+        'machine': 'arm64',
+        'executable': str(py),
+        'prefix': str(runtime),
+        'llama_cpp_python_version': '0.3.32',
+    }
+    probe = {
+        'backend': 'metal',
+        'gpu_offload_supported': True,
+        'qwen_64k_yarn_support': 'supported',
+        'rope_scaling_type_supported': True,
+        'rope_freq_scale_supported': True,
+        'yarn_orig_ctx_supported': True,
+        'constructor_kwarg_support': {'flash_attn': True, 'offload_kqv': True, 'n_batch': True, 'n_ubatch': True},
+    }
+    background = {
+        'runtime_action_ok': True,
+        'facade_type': '_SubprocessLlamaCppModule',
+        'backend': 'metal',
+        'gpu_offload_supported': True,
+        'version': '0.3.32',
+        'yarn_resolver_source': 'top_level_enum',
+        'constructor_signature_inspectable': True,
+        'required_kwargs_supported': True,
+        'llama_module_identity_match': True,
+        'supported': True,
+        'desktop_probe_authoritative': True,
+        'secondary_reprobe_skipped': True,
+        'runtime_action': 'metal_already_supported',
+        'selected_backend': 'metal',
+        'llama_cpp_python_version_match': True,
+        'capability_source': 'desktop_runtime_setup_probe',
+        'incomplete_probe_fields': [],
+    }
+    background[missing_key] = bad_value
+
+    def fake_run_python(_python, code, _app_path):
+        if 'version_info' in code:
+            return json.dumps(payload)
+        if 'token-place-release-qwen64k-probe' in code:
+            return json.dumps(background)
+        if 'model_bridge.py' in code:
+            return 'model bridge ok'
+        return json.dumps(probe)
+
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Darwin')
+    monkeypatch.setattr(validator, '_run', lambda cmd: 'arm64')
+    monkeypatch.setattr(validator, '_run_python_sanitized', fake_run_python)
+    monkeypatch.setattr(validator, '_validate_macho_linkage', lambda path, app_path: None)
+
+    with pytest.raises(SystemExit) as excinfo:
+        validator._validate_embedded_python_runtime(app)
+
+    message = str(excinfo.value)
+    assert f'embedded background Qwen 64K facade probe failed {missing_key}: {bad_value!r}' in message
+    assert 'desktop_runtime_setup_probe' in message
+    assert 'diagnostics=' in message
+
 def test_run_python_sanitized_disables_bytecode_and_uses_external_writable_locations(monkeypatch, tmp_path) -> None:
     validator = _load_release_artifact_validator()
     app = tmp_path / 'token.place desktop.app'

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -4,6 +4,8 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
+
 WORKFLOW = Path('.github/workflows/desktop-release.yml')
 TAURI_CONFIG = Path('desktop-tauri/src-tauri/tauri.conf.json')
 
@@ -693,6 +695,7 @@ def test_validator_sanitized_python_env_replaces_parent_environment(monkeypatch,
     monkeypatch.setattr(validator.subprocess, 'run', fake_run)
 
     assert validator._run_python_sanitized(py, 'print(1)', app) == 'ok'
+    assert captured['env']['PIP_NO_INDEX'] == '1'
     assert captured['env']['PYTHONNOUSERSITE'] == '1'
     assert captured['env']['PATH'] == '/usr/bin:/bin'
     assert captured['env']['PYTHONPATH'] == subprocess.os.pathsep.join([
@@ -909,6 +912,21 @@ def test_validate_embedded_python_runtime_absolutizes_packaged_model_bridge(monk
                     'n_batch': True,
                     'n_ubatch': True,
                 },
+            })
+        if 'token-place-release-qwen64k-probe' in code:
+            return json.dumps({
+                'runtime_action_ok': True,
+                'facade_type': '_SubprocessLlamaCppModule',
+                'backend': 'metal',
+                'gpu_offload_supported': True,
+                'version': '0.3.32',
+                'yarn_resolver_source': 'top_level_enum',
+                'constructor_signature_inspectable': True,
+                'required_kwargs_supported': True,
+                'llama_module_identity_match': True,
+                'supported': True,
+                'desktop_probe_authoritative': True,
+                'secondary_reprobe_skipped': True,
             })
         return 'ok'
 
@@ -1639,7 +1657,24 @@ def test_validator_embedded_runtime_failure_paths(monkeypatch, tmp_path) -> None
     monkeypatch.setattr(
         validator,
         '_run_python_sanitized',
-        lambda _python, code, app_path: calls.append(code) or json.dumps(payload if 'version_info' in code else probe),
+        lambda _python, code, app_path: calls.append(code) or json.dumps(
+            payload if 'version_info' in code else (
+                {
+                    'runtime_action_ok': True,
+                    'facade_type': '_SubprocessLlamaCppModule',
+                    'backend': 'metal',
+                    'gpu_offload_supported': True,
+                    'version': '0.3.32',
+                    'yarn_resolver_source': 'top_level_enum',
+                    'constructor_signature_inspectable': True,
+                    'required_kwargs_supported': True,
+                    'llama_module_identity_match': True,
+                    'supported': True,
+                    'desktop_probe_authoritative': True,
+                    'secondary_reprobe_skipped': True,
+                } if 'token-place-release-qwen64k-probe' in code else probe
+            )
+        ),
     )
 
     try:
@@ -1863,3 +1898,71 @@ def test_validator_main_macos_dmg_runtime_validation_does_not_probe_source_app(m
     assert dmg_calls == [(dmg, {'expect_signing': False, 'require_embedded_python_runtime': True})]
     assert runtime_apps == []
     assert run_calls.count(['codesign', '--verify', '--deep', '--strict', '--verbose=4', str(app)]) == 2
+
+
+def test_validate_embedded_python_runtime_requires_background_facade_probe(monkeypatch, tmp_path) -> None:
+    validator = _load_release_artifact_validator()
+    app, _tauri_config, _icon = _minimal_validator_app(validator, tmp_path)
+    runtime = app / 'Contents' / 'Resources' / 'python-runtime'
+    py = runtime / 'bin' / 'python3'
+    py.parent.mkdir(parents=True)
+    py.write_text('python')
+    py.chmod(0o755)
+    (runtime / 'embedded_python_runtime_provenance.json').write_text('{}')
+    (runtime / 'LICENSE-PYTHON.txt').write_text('notice')
+    (runtime / 'LICENSE-python-build-standalone.txt').write_text('notice')
+    resources_python = app / 'Contents' / 'Resources' / 'python'
+    resources_python.mkdir()
+    (resources_python / 'model_bridge.py').write_text('print("inspect")')
+    payload = {
+        'version': [3, 11],
+        'machine': 'arm64',
+        'executable': str(py),
+        'prefix': str(runtime),
+        'llama_cpp_python_version': '0.3.32',
+    }
+    probe = {
+        'backend': 'metal',
+        'gpu_offload_supported': True,
+        'qwen_64k_yarn_support': 'supported',
+        'rope_scaling_type_supported': True,
+        'rope_freq_scale_supported': True,
+        'yarn_orig_ctx_supported': True,
+        'constructor_kwarg_support': {'flash_attn': True, 'offload_kqv': True, 'n_batch': True, 'n_ubatch': True},
+    }
+    background = {
+        'runtime_action_ok': True,
+        'facade_type': '_SubprocessLlamaCppModule',
+        'backend': 'metal',
+        'gpu_offload_supported': True,
+        'version': '0.3.32',
+        'yarn_resolver_source': 'top_level_enum',
+        'constructor_signature_inspectable': True,
+        'required_kwargs_supported': True,
+        'llama_module_identity_match': True,
+        'supported': True,
+        'desktop_probe_authoritative': True,
+        'secondary_reprobe_skipped': False,
+    }
+    calls = []
+    monkeypatch.setattr(validator.platform, 'system', lambda: 'Linux')
+    monkeypatch.setattr(validator, '_validate_macho_linkage', lambda path, app_path: None)
+
+    def fake_run_python_sanitized(_python, code, _app_path):
+        calls.append(code)
+        if 'version_info' in code:
+            return json.dumps(payload)
+        if 'token-place-release-qwen64k-probe' in code:
+            return json.dumps(background)
+        if '_probe_llama_runtime' in code:
+            return json.dumps(probe)
+        return 'ok'
+
+    monkeypatch.setattr(validator, '_run_python_sanitized', fake_run_python_sanitized)
+    with pytest.raises(SystemExit, match='secondary_reprobe_skipped'):
+        validator._validate_embedded_python_runtime(app)
+    background['secondary_reprobe_skipped'] = True
+    validator._validate_embedded_python_runtime(app)
+    assert any("ensure_desktop_llama_runtime('auto', context_tier='64k-full')" in code for code in calls)
+    assert any('_runtime_supports_qwen_yarn_rope' in code for code in calls)
+    assert any('_import_llama_cpp_subprocess_module' in code for code in calls)

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -864,10 +864,14 @@ def _import_llama_cpp_runtime(*, require_real_runtime, timeout_seconds, desktop_
         raise AssertionError('raw private module path leaked into runtime setup')
     return _SubprocessLlamaCppModule()
 
+def _safe_constructor_capability_payload(facade):
+    return {{
+        'backend': 'metal',
+        'gpu_offload_supported': True,
+    }}
+
 def _runtime_supports_qwen_yarn_rope(facade, llama_cls):
     return {{
-        'backend': getattr(facade, 'backend', None),
-        'gpu_offload_supported': True,
         'llama_cpp_python_version': '0.3.32',
         'yarn_resolver_source': 'top_level_enum',
         'constructor_signature_inspectable': True,
@@ -919,10 +923,12 @@ def worker():
         desktop_runtime_probe=private_runtime_setup,
     )
     gate = model_manager._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
+    facade_capabilities = model_manager._safe_constructor_capability_payload(facade)
     result.update({
         'facade_type': type(facade).__name__,
         'facade_file_discovered': bool(getattr(facade, '__file__', None)),
-        'backend': gate.get('backend'),
+        'backend': facade_capabilities.get('backend'),
+        'gpu_offload_supported': facade_capabilities.get('gpu_offload_supported') is True,
         'llama_module_identity_match': gate.get('llama_module_identity_match') is True,
         'supported': gate.get('supported') is True,
         'desktop_probe_authoritative': gate.get('desktop_probe_authoritative') is True,
@@ -957,6 +963,7 @@ print(json.dumps(result, sort_keys=True))
         'desktop_probe_authoritative': True,
         'facade_file_discovered': True,
         'facade_type': '_SubprocessLlamaCppModule',
+        'gpu_offload_supported': True,
         'llama_module_identity_match': True,
         'runtime_call_count': 1,
         'runtime_probe_keys': [
@@ -2232,4 +2239,7 @@ def test_validate_embedded_python_runtime_requires_background_facade_probe(monke
     assert any("repo_root=runtime_import_root" in code for code in calls)
     assert any('_runtime_supports_qwen_yarn_rope' in code for code in calls)
     assert any('_import_llama_cpp_runtime' in code for code in calls)
+    assert any('_safe_constructor_capability_payload' in code for code in calls)
+    assert not any("gate.get('backend')" in code for code in calls)
+    assert not any("gate.get('gpu_offload_supported')" in code for code in calls)
     assert not any('_import_llama_cpp_subprocess_module' in code for code in calls)

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -650,7 +650,9 @@ def test_workflow_prepares_and_validates_embedded_macos_runtime() -> None:
 def test_validator_contains_embedded_runtime_guardrails() -> None:
     text = Path('scripts/validate_desktop_tauri_release_artifacts.py').read_text(encoding='utf-8')
     assert 'Contents" / "Resources" / "python-runtime' in text
-    assert '"PYTHONPATH": str(app_for_subprocess / "Contents" / "Resources" / "python")' in text
+    assert '"PYTHONPATH": os.pathsep.join(' in text
+    assert 'str(app_for_subprocess / "Contents" / "Resources" / "python")' in text
+    assert 'str(app_for_subprocess / "Contents" / "Resources")' in text
     assert 'xcode-select' in text
     assert 'otool' in text
     assert 'embedded runtime probe did not report Metal GPU offload' in text
@@ -658,7 +660,9 @@ def test_validator_contains_embedded_runtime_guardrails() -> None:
 
 def test_validator_uses_packaged_python_resources_for_runtime_probe() -> None:
     text = Path('scripts/validate_desktop_tauri_release_artifacts.py').read_text(encoding='utf-8')
-    assert 'PYTHONPATH": str(app_for_subprocess / "Contents" / "Resources" / "python")' in text
+    assert '"PYTHONPATH": os.pathsep.join(' in text
+    assert 'str(app_for_subprocess / "Contents" / "Resources" / "python")' in text
+    assert 'str(app_for_subprocess / "Contents" / "Resources")' in text
     assert "Path.cwd() / 'src-tauri' / 'python'" not in text
     assert "qwen_64k_yarn_support" in text
     assert "model_bridge.py" in text
@@ -691,7 +695,10 @@ def test_validator_sanitized_python_env_replaces_parent_environment(monkeypatch,
     assert validator._run_python_sanitized(py, 'print(1)', app) == 'ok'
     assert captured['env']['PYTHONNOUSERSITE'] == '1'
     assert captured['env']['PATH'] == '/usr/bin:/bin'
-    assert captured['env']['PYTHONPATH'] == str((app / 'Contents' / 'Resources' / 'python').absolute())
+    assert captured['env']['PYTHONPATH'] == subprocess.os.pathsep.join([
+        str((app / 'Contents' / 'Resources' / 'python').absolute()),
+        str((app / 'Contents' / 'Resources').absolute()),
+    ])
     for key in forbidden_parent_env:
         assert key not in captured['env']
 
@@ -1670,7 +1677,10 @@ def test_run_python_sanitized_disables_bytecode_and_uses_external_writable_locat
     assert env['PYTHONDONTWRITEBYTECODE'] == '1'
     assert env['PYTHONNOUSERSITE'] == '1'
     assert env['PATH'] == '/usr/bin:/bin'
-    assert env['PYTHONPATH'] == str(app / 'Contents' / 'Resources' / 'python')
+    assert env['PYTHONPATH'] == subprocess.os.pathsep.join([
+        str(app / 'Contents' / 'Resources' / 'python'),
+        str(app / 'Contents' / 'Resources'),
+    ])
     writable_keys = [
         'PYTHONPYCACHEPREFIX',
         'TMPDIR',

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -789,6 +789,188 @@ print(json.dumps({
         'requirements_found': True,
     }
 
+
+def test_background_probe_uses_production_runtime_import_and_private_identity(tmp_path) -> None:
+    resources = tmp_path / 'token.place desktop.app' / 'Contents' / 'Resources'
+    python_resources = resources / 'python'
+    runtime_import_root = resources / '_up_' / '_up_'
+    nested_utils = runtime_import_root / 'utils' / 'llm'
+    python_resources.mkdir(parents=True)
+    nested_utils.mkdir(parents=True)
+    sentinel_path = str((tmp_path / 'private' / 'llama_cpp' / '__init__.py').resolve())
+    sentinel_digest = 'sha256:' + ('a' * 64)
+    (runtime_import_root / 'requirements.txt').write_text('llama-cpp-python==0.3.32\n', encoding='utf-8')
+    (python_resources / 'desktop_runtime_setup.py').write_text(
+        f"""
+import json
+import os
+from pathlib import Path
+
+RUNTIME_PROBE_ENV = 'TOKEN_PLACE_DESKTOP_RUNTIME_PROBE_JSON'
+
+def ensure_desktop_llama_runtime(mode, *, repo_root=None, context_tier=None):
+    root = Path(repo_root)
+    if mode != 'auto' or context_tier != '64k-full':
+        raise RuntimeError('unexpected runtime arguments')
+    if not (root / 'requirements.txt').is_file():
+        raise RuntimeError('missing packaged requirements metadata')
+    os.environ[RUNTIME_PROBE_ENV] = json.dumps({{
+        'llama_module_identity': {sentinel_digest!r},
+        'llama_module_path': {sentinel_path!r},
+    }})
+    return {{
+        'runtime_action': 'metal_already_supported',
+        'selected_backend': 'metal',
+        'llama_cpp_python_version_match': 'match',
+        'llama_module_path_present': True,
+        'capability_source': 'desktop_runtime_setup_probe',
+    }}
+""",
+        encoding='utf-8',
+    )
+    (python_resources / 'path_bootstrap.py').write_text(
+        Path('desktop-tauri/src-tauri/python/path_bootstrap.py').read_text(encoding='utf-8'),
+        encoding='utf-8',
+    )
+    (nested_utils.parent / '__init__.py').write_text('', encoding='utf-8')
+    (nested_utils / '__init__.py').write_text('', encoding='utf-8')
+    (nested_utils / 'model_manager.py').write_text(
+        f"""
+from pathlib import Path
+import threading
+
+RUNTIME_CALLS = []
+SUBPROCESS_CALLS = []
+
+class _SubprocessLlamaCppModule:
+    __file__ = {sentinel_path!r}
+    backend = 'metal'
+    class Llama:
+        pass
+
+def _import_llama_cpp_subprocess_module(*args, **kwargs):
+    SUBPROCESS_CALLS.append((args, kwargs))
+    raise AssertionError('direct subprocess facade constructor must not be used')
+
+def _import_llama_cpp_runtime(*, require_real_runtime, timeout_seconds, desktop_runtime_probe):
+    if threading.current_thread() is threading.main_thread():
+        raise AssertionError('runtime import did not run in background thread')
+    RUNTIME_CALLS.append(dict(desktop_runtime_probe))
+    if require_real_runtime is not True or timeout_seconds != 10:
+        raise AssertionError('unexpected import arguments')
+    if desktop_runtime_probe.get('llama_module_identity') != {sentinel_digest!r}:
+        raise AssertionError('private identity was not merged')
+    if 'llama_module_path' in desktop_runtime_probe:
+        raise AssertionError('raw private module path leaked into runtime setup')
+    return _SubprocessLlamaCppModule()
+
+def _runtime_supports_qwen_yarn_rope(facade, llama_cls):
+    return {{
+        'backend': getattr(facade, 'backend', None),
+        'gpu_offload_supported': True,
+        'llama_cpp_python_version': '0.3.32',
+        'yarn_resolver_source': 'top_level_enum',
+        'constructor_signature_inspectable': True,
+        'constructor_kwarg_support': {{name: True for name in (
+            'type_k', 'type_v', 'flash_attn', 'offload_kqv', 'n_batch', 'n_ubatch',
+            'rope_scaling_type', 'yarn_ext_factor', 'yarn_attn_factor', 'yarn_beta_fast',
+            'yarn_beta_slow', 'yarn_orig_ctx', 'rope_freq_base', 'rope_freq_scale')}},
+        'llama_module_identity_match': True,
+        'supported': True,
+        'desktop_probe_authoritative': True,
+        'child_probe_reprobe_skipped_reason': 'desktop_probe_authoritative',
+        'capability_source': 'desktop_runtime_setup_probe',
+        'incomplete_probe_fields': [],
+    }}
+""",
+        encoding='utf-8',
+    )
+
+    code = """
+import json, os, threading
+import desktop_runtime_setup
+from path_bootstrap import ensure_runtime_import_paths
+
+ensure_runtime_import_paths(
+    desktop_runtime_setup.__file__,
+    avoid_llama_cpp_shadowing=True,
+)
+
+from desktop_runtime_setup import RUNTIME_PROBE_ENV, ensure_desktop_llama_runtime
+from pathlib import Path
+from utils.llm import model_manager
+
+runtime_import_root = Path(model_manager.__file__).resolve().parents[2]
+if not (runtime_import_root / 'requirements.txt').is_file():
+    raise SystemExit('packaged runtime metadata missing: requirements.txt')
+
+result = {}
+
+def worker():
+    setup = ensure_desktop_llama_runtime('auto', repo_root=runtime_import_root, context_tier='64k-full')
+    private_runtime_setup = dict(setup)
+    private_probe = json.loads(os.environ.get(RUNTIME_PROBE_ENV) or '{}')
+    private_identity = private_probe.get('llama_module_identity')
+    if isinstance(private_identity, str):
+        private_runtime_setup['llama_module_identity'] = private_identity
+    facade = model_manager._import_llama_cpp_runtime(
+        require_real_runtime=True,
+        timeout_seconds=10,
+        desktop_runtime_probe=private_runtime_setup,
+    )
+    gate = model_manager._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
+    result.update({
+        'facade_type': type(facade).__name__,
+        'facade_file_discovered': bool(getattr(facade, '__file__', None)),
+        'backend': gate.get('backend'),
+        'llama_module_identity_match': gate.get('llama_module_identity_match') is True,
+        'supported': gate.get('supported') is True,
+        'desktop_probe_authoritative': gate.get('desktop_probe_authoritative') is True,
+        'runtime_call_count': len(model_manager.RUNTIME_CALLS),
+        'subprocess_call_count': len(model_manager.SUBPROCESS_CALLS),
+        'runtime_probe_keys': sorted(model_manager.RUNTIME_CALLS[0]),
+    })
+
+thread = threading.Thread(target=worker, name='token-place-release-qwen64k-probe')
+thread.start()
+thread.join(timeout=30)
+if thread.is_alive():
+    raise SystemExit('background facade probe timed out')
+print(json.dumps(result, sort_keys=True))
+"""
+    result = subprocess.run(
+        [sys.executable, '-c', code],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={'PYTHONPATH': str(python_resources), 'PYTHONNOUSERSITE': '1'},
+        cwd=str(tmp_path),
+    )
+
+    captured = result.stdout + result.stderr
+    assert result.returncode == 0, result.stderr
+    assert sentinel_path not in captured
+    assert sentinel_digest not in captured
+    payload = json.loads(result.stdout.strip())
+    assert payload == {
+        'backend': 'metal',
+        'desktop_probe_authoritative': True,
+        'facade_file_discovered': True,
+        'facade_type': '_SubprocessLlamaCppModule',
+        'llama_module_identity_match': True,
+        'runtime_call_count': 1,
+        'runtime_probe_keys': [
+            'capability_source',
+            'llama_cpp_python_version_match',
+            'llama_module_identity',
+            'llama_module_path_present',
+            'runtime_action',
+            'selected_backend',
+        ],
+        'subprocess_call_count': 0,
+        'supported': True,
+    }
+
 def test_release_workflow_does_not_rebuild_llama_cpp_on_release_matrix() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
     install_step = text.split('- name: Install desktop llama-cpp runtime with platform GPU backend', 1)[1]
@@ -2049,4 +2231,5 @@ def test_validate_embedded_python_runtime_requires_background_facade_probe(monke
     assert any('ensure_runtime_import_paths(' in code for code in calls)
     assert any("repo_root=runtime_import_root" in code for code in calls)
     assert any('_runtime_supports_qwen_yarn_rope' in code for code in calls)
-    assert any('_import_llama_cpp_subprocess_module' in code for code in calls)
+    assert any('_import_llama_cpp_runtime' in code for code in calls)
+    assert not any('_import_llama_cpp_subprocess_module' in code for code in calls)

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -2391,3 +2391,44 @@ def test_qwen_64k_bootstrap_disabled_version_mismatch_failed_without_module_path
     assert sentinel not in result['fallback_reason']
     assert sentinel not in json.dumps(result, sort_keys=True)
     assert sentinel not in emitted
+
+
+def test_probe_result_payload_carries_private_identity_but_public_result_redacts(monkeypatch, tmp_path):
+    support = {name: True for name in desktop_runtime_setup.LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS}
+    module_path = tmp_path / 'site-packages' / 'llama_cpp' / '__init__.py'
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text('# mock')
+    probe = desktop_runtime_setup.RuntimeProbe(
+        backend='metal', gpu_offload_supported=True, detected_device='metal',
+        interpreter=sys.executable, prefix=sys.prefix, llama_module_path=str(module_path),
+        llama_cpp_python_version='0.3.32', yarn_rope_supported=True,
+        yarn_resolver_source='top_level_enum', constructor_kwarg_support=support,
+        constructor_signature_inspectable=True, qwen_64k_yarn_support='supported', yarn_enum_value=2,
+    )
+    payload = desktop_runtime_setup._probe_result_payload(probe)
+    identity = payload['llama_module_identity']
+    assert identity.startswith('sha256:') and len(identity) == 71
+    assert payload['llama_module_path_present'] is True
+    assert 'llama_module_path' not in payload
+
+    monkeypatch.setattr(desktop_runtime_setup, '_ensure_desktop_llama_runtime_impl', lambda *_, **__: dict(payload, selected_backend='metal', runtime_action='metal_already_supported'))
+    result = desktop_runtime_setup.ensure_desktop_llama_runtime('auto', repo_root=tmp_path, context_tier='64k-full')
+    assert 'llama_module_identity' not in result
+    assert str(module_path) not in json.dumps(result)
+    private_env = json.loads(os.environ[desktop_runtime_setup.RUNTIME_PROBE_ENV])
+    assert private_env['llama_module_identity'] == identity
+    assert str(module_path) not in os.environ[desktop_runtime_setup.RUNTIME_PROBE_ENV]
+
+
+def test_llama_module_identity_canonicalizes_symlink_dotdot(tmp_path):
+    real = tmp_path / 'real' / 'llama_cpp' / '__init__.py'
+    real.parent.mkdir(parents=True)
+    real.write_text('# mock')
+    link_dir = tmp_path / 'link'
+    link_dir.symlink_to(real.parent.parent, target_is_directory=True)
+    via_link = link_dir / 'llama_cpp' / '..' / 'llama_cpp' / '__init__.py'
+    assert desktop_runtime_setup.llama_module_identity_from_path(real) == desktop_runtime_setup.llama_module_identity_from_path(via_link)
+    other = tmp_path / 'other' / 'llama_cpp' / '__init__.py'
+    other.parent.mkdir(parents=True)
+    other.write_text('# other')
+    assert desktop_runtime_setup.llama_module_identity_from_path(real) != desktop_runtime_setup.llama_module_identity_from_path(other)

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -2438,6 +2438,37 @@ def test_llama_module_identity_rejects_raw_path_sentinels():
     assert desktop_runtime_setup.llama_module_identity_from_path('unknown') is None
     assert desktop_runtime_setup.llama_module_identity_from_path('missing') is None
     assert desktop_runtime_setup.llama_module_identity_from_path('') is None
+    assert desktop_runtime_setup._canonical_llama_module_identity_input(None) is None
+    assert desktop_runtime_setup._canonical_llama_module_identity_input('  UNKNOWN  ') is None
+
+
+def test_shared_llama_module_identity_helper_requires_string_identity(tmp_path):
+    from utils.llm import llama_module_identity as shared_identity
+
+    module_path = tmp_path / 'llama_cpp' / '__init__.py'
+    module_path.parent.mkdir()
+    module_path.write_text('# mock')
+
+    identity = shared_identity.llama_module_identity_from_path(module_path)
+    assert shared_identity.valid_llama_module_identity(identity) == identity
+    assert shared_identity.valid_llama_module_identity(identity.upper()) is None
+    assert shared_identity.valid_llama_module_identity(123) is None
+    assert shared_identity.llama_module_identity_supplied(identity) is True
+    assert shared_identity.llama_module_identity_supplied('  ') is False
+    assert shared_identity.llama_module_identity_supplied(123) is False
+
+
+def test_shared_llama_module_identity_helper_fallback_paths(monkeypatch, tmp_path):
+    from utils.llm import llama_module_identity as shared_identity
+
+    module_path = tmp_path / 'llama_cpp' / '__init__.py'
+    module_path.parent.mkdir()
+    module_path.write_text('# mock')
+
+    monkeypatch.setattr(shared_identity.os.path, 'abspath', lambda _path: (_ for _ in ()).throw(OSError('blocked')))
+    canonical = shared_identity.canonical_llama_module_identity_input(module_path)
+    assert canonical.endswith('/llama_cpp/__init__.py')
+    assert shared_identity.canonical_llama_module_identity_input(None) is None
 
 
 def test_llama_module_identity_windows_normalization_is_deterministic():

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -52,6 +52,37 @@ def test_packaged_runtime_setup_imports_utils_from_resources_root(tmp_path) -> N
     assert result.stdout.strip() == 'desktop_runtime_setup'
 
 
+def test_packaged_runtime_setup_imports_without_bundled_utils(tmp_path) -> None:
+    resources_root = tmp_path / 'token.place desktop.app' / 'Contents' / 'Resources'
+    python_dir = resources_root / 'python'
+    python_dir.mkdir(parents=True)
+
+    for name in ('desktop_runtime_setup.py', 'desktop_gpu_packaging.py'):
+        source = PYTHON_MODULE_DIR / name
+        (python_dir / name).write_text(source.read_text(encoding='utf-8'), encoding='utf-8')
+
+    env = {'PYTHONPATH': str(python_dir), 'PATH': os.environ.get('PATH', '')}
+    result = subprocess.run(
+        [
+            sys.executable,
+            '-B',
+            '-c',
+            (
+                'import desktop_runtime_setup as d; '
+                'print(d.llama_module_identity_from_path("/tmp/llama_cpp/__init__.py").startswith("sha256:"))'
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == 'True'
+
+
 class _SysStub:
     platform = 'win32'
     executable = sys.executable

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -18,6 +19,37 @@ desktop_runtime_setup = importlib.util.module_from_spec(SPEC)
 assert SPEC and SPEC.loader
 sys.modules['desktop_runtime_setup'] = desktop_runtime_setup
 SPEC.loader.exec_module(desktop_runtime_setup)
+
+
+
+def test_packaged_runtime_setup_imports_utils_from_resources_root(tmp_path) -> None:
+    resources_root = tmp_path / 'token.place desktop.app' / 'Contents' / 'Resources'
+    python_dir = resources_root / 'python'
+    utils_llm_dir = resources_root / 'utils' / 'llm'
+    python_dir.mkdir(parents=True)
+    utils_llm_dir.mkdir(parents=True)
+
+    for name in ('desktop_runtime_setup.py', 'desktop_gpu_packaging.py'):
+        source = PYTHON_MODULE_DIR / name
+        (python_dir / name).write_text(source.read_text(encoding='utf-8'), encoding='utf-8')
+    (resources_root / 'utils' / '__init__.py').write_text('', encoding='utf-8')
+    (utils_llm_dir / '__init__.py').write_text('', encoding='utf-8')
+    helper = REPO_ROOT / 'utils' / 'llm' / 'llama_module_identity.py'
+    (utils_llm_dir / 'llama_module_identity.py').write_text(helper.read_text(encoding='utf-8'), encoding='utf-8')
+
+    env = os.environ.copy()
+    env['PYTHONPATH'] = str(python_dir)
+    result = subprocess.run(
+        [sys.executable, '-B', '-c', 'import desktop_runtime_setup; print(desktop_runtime_setup.__name__)'],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == 'desktop_runtime_setup'
 
 
 class _SysStub:

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -2432,3 +2432,17 @@ def test_llama_module_identity_canonicalizes_symlink_dotdot(tmp_path):
     other.parent.mkdir(parents=True)
     other.write_text('# other')
     assert desktop_runtime_setup.llama_module_identity_from_path(real) != desktop_runtime_setup.llama_module_identity_from_path(other)
+
+
+def test_llama_module_identity_rejects_raw_path_sentinels():
+    assert desktop_runtime_setup.llama_module_identity_from_path('unknown') is None
+    assert desktop_runtime_setup.llama_module_identity_from_path('missing') is None
+    assert desktop_runtime_setup.llama_module_identity_from_path('') is None
+
+
+def test_llama_module_identity_windows_normalization_is_deterministic():
+    base = r'C:\Users\Alice\AppData\Local\token.place\runtime\Lib\site-packages\llama_cpp\__init__.py'
+    prefixed = r'\\?\C:\Users\Alice\AppData\Local\token.place\runtime\Lib\site-packages\llama_cpp\..\llama_cpp\__init__.py'
+    mixed = r'c:/users/alice/appdata/local/token.place/runtime/lib/site-packages/LLAMA_CPP/__init__.py'
+    assert desktop_runtime_setup.llama_module_identity_from_path(base) == desktop_runtime_setup.llama_module_identity_from_path(prefixed)
+    assert desktop_runtime_setup.llama_module_identity_from_path(base) == desktop_runtime_setup.llama_module_identity_from_path(mixed)

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -2600,3 +2600,55 @@ def test_packaged_identity_fallback_matches_shared_helper_in_subprocess(tmp_path
     assert fallback['posix_real'] == fallback['posix_dotdot_symlink']
     assert fallback['windows_extended'] == fallback['windows_mixed_case']
     assert fallback['posix_real'] != fallback['other']
+
+
+def test_packaged_identity_inline_fallback_is_covered_without_utils(
+    monkeypatch, tmp_path
+) -> None:
+    original_is_file = Path.is_file
+
+    def packaged_helper_absent(path: Path) -> bool:
+        if str(path).replace('\\', '/').endswith('/utils/llm/llama_module_identity.py'):
+            return False
+        return original_is_file(path)
+
+    monkeypatch.setattr(Path, 'is_file', packaged_helper_absent)
+
+    module_name = 'desktop_runtime_setup_inline_identity_fallback_test'
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+
+    real = tmp_path / 'real' / 'llama_cpp' / '__init__.py'
+    real.parent.mkdir(parents=True)
+    real.write_text('# mock', encoding='utf-8')
+    link_root = tmp_path / 'linked'
+    link_root.symlink_to(real.parent.parent, target_is_directory=True)
+    via_dotdot = link_root / 'llama_cpp' / '..' / 'llama_cpp' / '__init__.py'
+    windows_prefixed = (
+        r'\\?\C:\Users\Alice\AppData\Local\token.place\runtime\Lib'
+        r'\site-packages\llama_cpp\__init__.py'
+    )
+    windows_mixed = (
+        'c:/users/alice/appdata/local/token.place/runtime/lib/site-packages/'
+        'LLAMA_CPP/__init__.py'
+    )
+
+    assert module.llama_module_identity_from_path(
+        real
+    ) == module.llama_module_identity_from_path(via_dotdot)
+    assert module.llama_module_identity_from_path(
+        windows_prefixed
+    ) == module.llama_module_identity_from_path(windows_mixed)
+    assert module.llama_module_identity_from_path('unknown') is None
+    assert module.llama_module_identity_from_path('missing') is None
+    assert module.llama_module_identity_from_path('') is None
+    good = 'sha256:' + 'a' * 64
+    assert module._valid_llama_module_identity(good) == good
+    assert module._valid_llama_module_identity('sha256:' + 'A' * 64) is None
+    assert module._valid_llama_module_identity(123) is None

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -2556,6 +2556,36 @@ def test_shared_llama_module_identity_helper_edge_paths(monkeypatch):
     assert shared_identity.valid_llama_module_identity(f' {good} ') == good
 
 
+def test_shared_llama_module_identity_helper_fail_closed_normalization_paths(monkeypatch, tmp_path):
+    from utils.llm import llama_module_identity as shared_identity
+
+    module_path = tmp_path / 'llama_cpp' / '__init__.py'
+    module_path.parent.mkdir()
+    module_path.write_text('# mock', encoding='utf-8')
+
+    identity = shared_identity.llama_module_identity_from_path(module_path)
+    assert identity is not None
+    assert shared_identity.valid_llama_module_identity(identity) == identity
+    assert shared_identity.llama_module_identity_supplied(identity) is True
+
+    with monkeypatch.context() as path_errors:
+        path_errors.setattr(
+            shared_identity.os.path,
+            'abspath',
+            lambda _path: (_ for _ in ()).throw(OSError('primary blocked')),
+        )
+        path_errors.setattr(
+            shared_identity.os.path,
+            'normpath',
+            lambda _path: (_ for _ in ()).throw(ValueError('fallback blocked')),
+        )
+
+        assert shared_identity.canonical_llama_module_identity_input(module_path) is None
+        assert shared_identity.llama_module_identity_from_path(module_path) is None
+    assert shared_identity.valid_llama_module_identity(object()) is None
+    assert shared_identity.llama_module_identity_supplied(object()) is False
+
+
 def test_llama_module_identity_windows_normalization_is_deterministic():
     base = r'C:\Users\Alice\AppData\Local\token.place\runtime\Lib\site-packages\llama_cpp\__init__.py'
     prefixed = r'\\?\C:\Users\Alice\AppData\Local\token.place\runtime\Lib\site-packages\llama_cpp\..\llama_cpp\__init__.py'

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -2534,6 +2534,28 @@ def test_shared_llama_module_identity_helper_fallback_paths(monkeypatch, tmp_pat
     assert shared_identity.canonical_llama_module_identity_input(None) is None
 
 
+def test_shared_llama_module_identity_helper_edge_paths(monkeypatch):
+    from utils.llm import llama_module_identity as shared_identity
+
+    assert shared_identity.strip_windows_extended_path_prefix(
+        r'\\?\UNC\server\share\llama_cpp\__init__.py'
+    ) == r'\\server\share\llama_cpp\__init__.py'
+    assert shared_identity.strip_windows_extended_path_prefix(
+        r'\\?\C:\runtime\llama_cpp\__init__.py'
+    ) == r'C:\runtime\llama_cpp\__init__.py'
+    assert shared_identity.llama_module_identity_from_path('unknown') is None
+    assert shared_identity.llama_module_identity_from_path('missing') is None
+
+    class UnstringablePath:
+        def __str__(self):
+            raise ValueError('blocked')
+
+    assert shared_identity.canonical_llama_module_identity_input(UnstringablePath()) is None
+
+    good = 'sha256:' + 'b' * 64
+    assert shared_identity.valid_llama_module_identity(f' {good} ') == good
+
+
 def test_llama_module_identity_windows_normalization_is_deterministic():
     base = r'C:\Users\Alice\AppData\Local\token.place\runtime\Lib\site-packages\llama_cpp\__init__.py'
     prefixed = r'\\?\C:\Users\Alice\AppData\Local\token.place\runtime\Lib\site-packages\llama_cpp\..\llama_cpp\__init__.py'

--- a/tests/unit/test_desktop_runtime_setup.py
+++ b/tests/unit/test_desktop_runtime_setup.py
@@ -2540,3 +2540,63 @@ def test_llama_module_identity_windows_normalization_is_deterministic():
     mixed = r'c:/users/alice/appdata/local/token.place/runtime/lib/site-packages/LLAMA_CPP/__init__.py'
     assert desktop_runtime_setup.llama_module_identity_from_path(base) == desktop_runtime_setup.llama_module_identity_from_path(prefixed)
     assert desktop_runtime_setup.llama_module_identity_from_path(base) == desktop_runtime_setup.llama_module_identity_from_path(mixed)
+
+
+def test_packaged_identity_fallback_matches_shared_helper_in_subprocess(tmp_path) -> None:
+    resources_root = tmp_path / 'token.place desktop.app' / 'Contents' / 'Resources'
+    python_dir = resources_root / 'python'
+    python_dir.mkdir(parents=True)
+    for name in ('desktop_runtime_setup.py', 'desktop_gpu_packaging.py'):
+        source = PYTHON_MODULE_DIR / name
+        (python_dir / name).write_text(source.read_text(encoding='utf-8'), encoding='utf-8')
+
+    real = tmp_path / 'real' / 'llama_cpp' / '__init__.py'
+    real.parent.mkdir(parents=True)
+    real.write_text('# mock')
+    link_root = tmp_path / 'link-root'
+    link_root.symlink_to(real.parent.parent, target_is_directory=True)
+    via_dotdot = link_root / 'llama_cpp' / '..' / 'llama_cpp' / '__init__.py'
+    other = tmp_path / 'other' / 'llama_cpp' / '__init__.py'
+    other.parent.mkdir(parents=True)
+    other.write_text('# other')
+    cases = {
+        'posix_real': str(real),
+        'posix_dotdot_symlink': str(via_dotdot),
+        'windows_extended': r'\\?\C:\Users\Alice\AppData\Local\token.place\runtime\Lib\site-packages\llama_cpp\__init__.py',
+        'windows_mixed_case': r'c:/users/alice/appdata/local/token.place/runtime/lib/site-packages/LLAMA_CPP/__init__.py',
+        'other': str(other),
+        'unknown': 'unknown',
+        'missing': 'missing',
+        'empty': '',
+    }
+    code = (
+        'import json, desktop_runtime_setup as d; '
+        f'cases = {cases!r}; '
+        'print(json.dumps({k: d.llama_module_identity_from_path(v) for k, v in cases.items()} | {'
+        '"valid_good": d._valid_llama_module_identity("sha256:" + "a" * 64), '
+        '"valid_bad": d._valid_llama_module_identity("sha256:" + "g" * 64), '
+        '"valid_non_string": d._valid_llama_module_identity(123)}))'
+    )
+    result = subprocess.run(
+        [sys.executable, '-B', '-c', code],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={'PYTHONPATH': str(python_dir), 'PATH': os.environ.get('PATH', '')},
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, result.stderr
+    fallback = json.loads(result.stdout)
+
+    from utils.llm import llama_module_identity as shared_identity
+
+    shared = {k: desktop_runtime_setup.llama_module_identity_from_path(v) for k, v in cases.items()}
+    assert fallback == {
+        **shared,
+        'valid_good': 'sha256:' + 'a' * 64,
+        'valid_bad': None,
+        'valid_non_string': None,
+    }
+    assert fallback['posix_real'] == fallback['posix_dotdot_symlink']
+    assert fallback['windows_extended'] == fallback['windows_mixed_case']
+    assert fallback['posix_real'] != fallback['other']

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -9938,6 +9938,8 @@ def test_complete_cuda_desktop_probe_is_authoritative_without_reprobe(monkeypatc
             'gpu_offload_supported': True,
             'runtime_action': 'already_supported',
             'llama_module_path': 'C:/Users/Alice/AppData/Local/Programs/Python/Python311/Lib/site-packages/llama_cpp/__init__.py',
+            'llama_module_path_present': True,
+            'llama_module_identity': model_manager_module.llama_module_identity_from_path('C:/Users/Alice/AppData/Local/Programs/Python/Python311/Lib/site-packages/llama_cpp/__init__.py'),
             'constructor_kwarg_support': support,
             'constructor_signature_inspectable': True,
             'constructor_has_var_kwargs': False,
@@ -9987,6 +9989,8 @@ def test_desktop_probe_module_path_mismatch_fails_closed_without_reprobe(monkeyp
             'backend': 'cuda',
             'gpu_offload_supported': True,
             'llama_module_path': '/runtime/other/llama_cpp/__init__.py',
+            'llama_module_path_present': True,
+            'llama_module_identity': model_manager_module.llama_module_identity_from_path('/runtime/actual/llama_cpp/__init__.py'),
             'constructor_kwarg_support': support,
             'constructor_signature_inspectable': True,
             'qwen_64k_yarn_support': 'supported',
@@ -10004,7 +10008,7 @@ def test_desktop_probe_module_path_mismatch_fails_closed_without_reprobe(monkeyp
 
     assert diagnostics['supported'] is False
     assert diagnostics['missing_reason'] == 'runtime_desktop_capability_probe_incomplete'
-    assert 'llama_module_path' in diagnostics['missing_required_kwargs']
+    assert 'llama_module_identity_match' in diagnostics['missing_required_kwargs']
     assert diagnostics['child_probe_reprobe_attempted'] is False
 
 
@@ -10214,3 +10218,71 @@ def test_qwen_yarn_diagnostics_preserve_false_and_empty_values():
     assert 'child_probe_reprobe_attempted=False' in formatted
     assert 'constructor_kwargs_attempted=[]' in formatted
     assert "incomplete_probe_fields=['llama_module_identity']" in formatted
+
+
+def test_modern_probe_rejects_concrete_path_fallback_when_identity_missing(monkeypatch, tmp_path):
+    from utils.llm import model_manager as model_manager_module
+
+    module_path = tmp_path / 'site-packages' / 'llama_cpp' / '__init__.py'
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text('# mock')
+    support = {name: True for name in model_manager_module.LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS}
+    monkeypatch.setattr(model_manager_module, '_probe_llama_cpp_capabilities_in_subprocess', lambda **_: (_ for _ in ()).throw(AssertionError('unexpected secondary probe')))
+    facade = model_manager_module._SubprocessLlamaCppModule(str(module_path), desktop_runtime_probe={
+        'backend': 'metal',
+        'gpu_offload_supported': True,
+        'runtime_action': 'metal_already_supported',
+        'llama_module_path': str(module_path),
+        'llama_module_path_present': True,
+        'constructor_kwarg_support': support,
+        'constructor_signature_inspectable': True,
+        'qwen_64k_yarn_support': 'supported',
+        'yarn_enum_value': 2,
+        'capability_source': 'desktop_runtime_setup_probe',
+    })
+
+    diagnostics = model_manager_module._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
+
+    assert diagnostics['supported'] is False
+    assert diagnostics['child_probe_reprobe_attempted'] is False
+    assert diagnostics['incomplete_probe_fields'] == ['llama_module_identity']
+
+
+def test_legacy_probe_allows_concrete_path_only_match(monkeypatch, tmp_path):
+    from utils.llm import model_manager as model_manager_module
+
+    module_path = tmp_path / 'site-packages' / 'llama_cpp' / '__init__.py'
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text('# mock')
+    support = {name: True for name in model_manager_module.LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS}
+    monkeypatch.setattr(model_manager_module, '_probe_llama_cpp_capabilities_in_subprocess', lambda **_: (_ for _ in ()).throw(AssertionError('unexpected secondary probe')))
+    facade = model_manager_module._SubprocessLlamaCppModule(str(module_path), desktop_runtime_probe={
+        'backend': 'metal',
+        'gpu_offload_supported': True,
+        'runtime_action': 'metal_already_supported',
+        'llama_module_path': str(module_path),
+        'llama_module_path_present': True,
+        'constructor_kwarg_support': support,
+        'constructor_signature_inspectable': True,
+        'qwen_64k_yarn_support': 'supported',
+        'yarn_enum_value': 2,
+        'capability_source': 'desktop_runtime_setup_probe_legacy',
+    })
+
+    diagnostics = model_manager_module._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
+
+    assert diagnostics['supported'] is True
+    assert diagnostics['desktop_probe_authoritative'] is True
+    assert diagnostics['child_probe_reprobe_attempted'] is False
+
+
+def test_llama_module_identity_consumer_rejects_sentinels_and_normalizes_windows():
+    from utils.llm import model_manager as model_manager_module
+
+    assert model_manager_module.llama_module_identity_from_path('unknown') is None
+    assert model_manager_module.llama_module_identity_from_path('missing') is None
+    base = r'C:\Users\Alice\Runtime\Lib\site-packages\llama_cpp\__init__.py'
+    prefixed = r'\\?\C:\Users\Alice\Runtime\Lib\site-packages\llama_cpp\..\llama_cpp\__init__.py'
+    mixed = r'c:/users/alice/runtime/lib/site-packages/LLAMA_CPP/__init__.py'
+    assert model_manager_module.llama_module_identity_from_path(base) == model_manager_module.llama_module_identity_from_path(prefixed)
+    assert model_manager_module.llama_module_identity_from_path(base) == model_manager_module.llama_module_identity_from_path(mixed)

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -6006,7 +6006,7 @@ def test_qwen_64k_runtime_fails_when_yarn_kwargs_unsupported(tmp_path):
     assert 'Qwen 64K requires YaRN/RoPE support in llama-cpp-python' in manager.last_runtime_init_error
     assert 'active_profile_id=qwen3-8b-q4-k-m' in manager.last_runtime_init_error
     assert 'active_context_tier=64k-full' in manager.last_runtime_init_error
-    assert 'llama_module_path_present=unknown' in manager.last_runtime_init_error
+    assert 'llama_module_path_present=False' in manager.last_runtime_init_error
     assert 'llama_cpp_python_version=' in manager.last_runtime_init_error
     assert 'missing constructor kwargs' in manager.last_runtime_init_error
 
@@ -10180,6 +10180,27 @@ def test_modern_desktop_probe_identity_negative_cases_fail_closed(monkeypatch, t
             assert identity not in formatted
         assert 'child_probe_reprobe_attempted=False' in formatted
         assert 'incomplete_probe_fields=' in formatted
+        if identity == 'sha256:not-valid':
+            assert 'llama_module_identity' in diagnostics['incomplete_probe_fields']
+            assert 'llama_module_identity_match' not in diagnostics['incomplete_probe_fields']
+
+
+def test_coerce_desktop_runtime_probe_preserves_malformed_identity_state():
+    from utils.llm import model_manager as model_manager_module
+
+    probe = model_manager_module._coerce_desktop_runtime_probe({
+        'backend': 'metal',
+        'gpu_offload_supported': True,
+        'runtime_action': 'metal_already_supported',
+        'llama_module_path': '/private/redacted/llama_cpp/__init__.py',
+        'llama_module_path_present': False,
+        'llama_module_identity': 'sha256:not-valid',
+    })
+
+    assert probe is not None
+    assert probe['llama_module_path_present'] is False
+    assert probe['llama_module_identity_malformed'] is True
+    assert 'llama_module_identity' not in probe
 
 
 def test_qwen_yarn_diagnostics_preserve_false_and_empty_values():

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -6006,7 +6006,7 @@ def test_qwen_64k_runtime_fails_when_yarn_kwargs_unsupported(tmp_path):
     assert 'Qwen 64K requires YaRN/RoPE support in llama-cpp-python' in manager.last_runtime_init_error
     assert 'active_profile_id=qwen3-8b-q4-k-m' in manager.last_runtime_init_error
     assert 'active_context_tier=64k-full' in manager.last_runtime_init_error
-    assert 'llama_module_path=unknown' in manager.last_runtime_init_error
+    assert 'llama_module_path_present=unknown' in manager.last_runtime_init_error
     assert 'llama_cpp_python_version=' in manager.last_runtime_init_error
     assert 'missing constructor kwargs' in manager.last_runtime_init_error
 
@@ -10120,3 +10120,76 @@ def test_legacy_flat_desktop_probe_exported_enum_without_value_fails_closed(monk
     assert 'yarn_enum_value' in diagnostics['missing_required_kwargs']
     assert diagnostics['child_probe_reprobe_attempted'] is False
     assert diagnostics['child_probe_reprobe_skipped_reason'] == 'desktop_probe_incomplete_fail_closed'
+
+
+def test_modern_desktop_probe_identity_authoritative_without_path_or_reprobe(monkeypatch, tmp_path):
+    from utils.llm import model_manager as model_manager_module
+
+    module_path = tmp_path / 'site-packages' / 'llama_cpp' / '__init__.py'
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text('# mock')
+    support = {name: True for name in model_manager_module.LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS}
+    facade = model_manager_module._SubprocessLlamaCppModule(
+        str(module_path),
+        desktop_runtime_probe={
+            'backend': 'metal', 'gpu_offload_supported': True, 'runtime_action': 'metal_already_supported',
+            'llama_module_path_present': True,
+            'llama_module_identity': model_manager_module.llama_module_identity_from_path(module_path),
+            'constructor_kwarg_support': support, 'constructor_signature_inspectable': True,
+            'constructor_has_var_kwargs': False, 'qwen_64k_yarn_support': 'supported',
+            'yarn_enum_value': 2, 'q8_kv_cache_type_value': 8, 'q4_kv_cache_type_value': 2,
+            'f16_kv_cache_type_value': 1, 'capability_source': 'desktop_runtime_setup_probe',
+            'llama_cpp_python_version': '0.3.32',
+        },
+    )
+    monkeypatch.setattr(model_manager_module, '_probe_llama_cpp_capabilities_in_subprocess', lambda **_: (_ for _ in ()).throw(AssertionError('unexpected secondary probe')))
+    diagnostics = model_manager_module._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
+    assert diagnostics['supported'] is True
+    assert diagnostics['desktop_probe_authoritative'] is True
+    assert diagnostics['llama_module_identity_match'] is True
+    assert diagnostics['child_probe_reprobe_attempted'] is False
+
+
+def test_modern_desktop_probe_identity_negative_cases_fail_closed(monkeypatch, tmp_path):
+    from utils.llm import model_manager as model_manager_module
+
+    module_path = tmp_path / 'site-packages' / 'llama_cpp' / '__init__.py'
+    other_path = tmp_path / 'other' / 'llama_cpp' / '__init__.py'
+    module_path.parent.mkdir(parents=True); other_path.parent.mkdir(parents=True)
+    module_path.write_text('# mock'); other_path.write_text('# other')
+    support = {name: True for name in model_manager_module.LLAMA_CPP_CONSTRUCTOR_CAPABILITY_KWARGS}
+    base = {
+        'backend': 'metal', 'gpu_offload_supported': True, 'runtime_action': 'metal_already_supported',
+        'llama_module_path_present': True, 'constructor_kwarg_support': support,
+        'constructor_signature_inspectable': True, 'qwen_64k_yarn_support': 'supported',
+        'yarn_enum_value': 2, 'capability_source': 'desktop_runtime_setup_probe',
+    }
+    monkeypatch.setattr(model_manager_module, '_probe_llama_cpp_capabilities_in_subprocess', lambda **_: (_ for _ in ()).throw(AssertionError('unexpected secondary probe')))
+    for identity in (None, 'sha256:not-valid', model_manager_module.llama_module_identity_from_path(other_path)):
+        probe = dict(base)
+        if identity is not None:
+            probe['llama_module_identity'] = identity
+        facade = model_manager_module._SubprocessLlamaCppModule(str(module_path), desktop_runtime_probe=probe)
+        diagnostics = model_manager_module._runtime_supports_qwen_yarn_rope(facade, facade.Llama)
+        assert diagnostics['supported'] is False
+        assert diagnostics['missing_reason'] == 'runtime_desktop_capability_probe_incomplete'
+        assert diagnostics['child_probe_reprobe_attempted'] is False
+        formatted = model_manager_module._format_qwen_yarn_unsupported_diagnostics(diagnostics)
+        assert str(module_path) not in formatted
+        if identity:
+            assert identity not in formatted
+        assert 'child_probe_reprobe_attempted=False' in formatted
+        assert 'incomplete_probe_fields=' in formatted
+
+
+def test_qwen_yarn_diagnostics_preserve_false_and_empty_values():
+    from utils.llm import model_manager as model_manager_module
+
+    formatted = model_manager_module._format_qwen_yarn_unsupported_diagnostics({
+        'child_probe_reprobe_attempted': False,
+        'constructor_kwargs_attempted': [],
+        'incomplete_probe_fields': ['llama_module_identity'],
+    })
+    assert 'child_probe_reprobe_attempted=False' in formatted
+    assert 'constructor_kwargs_attempted=[]' in formatted
+    assert "incomplete_probe_fields=['llama_module_identity']" in formatted

--- a/utils/llm/llama_module_identity.py
+++ b/utils/llm/llama_module_identity.py
@@ -42,9 +42,11 @@ def llama_module_identity_from_path(module_path: Any) -> Optional[str]:
 
 
 def valid_llama_module_identity(value: Any) -> Optional[str]:
-    text = str(value or '').strip()
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
     return text if LLAMA_MODULE_IDENTITY_RE.fullmatch(text) else None
 
 
 def llama_module_identity_supplied(value: Any) -> bool:
-    return str(value or '').strip() != ''
+    return isinstance(value, str) and value.strip() != ''

--- a/utils/llm/llama_module_identity.py
+++ b/utils/llm/llama_module_identity.py
@@ -1,0 +1,50 @@
+"""Privacy-preserving llama_cpp module identity helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from typing import Any, Optional
+
+LLAMA_MODULE_IDENTITY_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+LLAMA_MODULE_IDENTITY_DOMAIN = "token.place.llama_cpp.module_path.v1"
+
+
+def strip_windows_extended_path_prefix(path_text: str) -> str:
+    if path_text.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + path_text[8:]
+    if path_text.startswith("\\\\?\\"):
+        return path_text[4:]
+    return path_text
+
+
+def canonical_llama_module_identity_input(module_path: Any) -> Optional[str]:
+    if not module_path:
+        return None
+    try:
+        path_text = strip_windows_extended_path_prefix(str(module_path))
+        canonical = os.path.normcase(os.path.normpath(os.path.realpath(os.path.abspath(path_text))))
+    except (TypeError, ValueError, OSError):
+        try:
+            canonical = os.path.normcase(os.path.normpath(strip_windows_extended_path_prefix(str(module_path))))
+        except (TypeError, ValueError, OSError):
+            return None
+    return canonical.replace('\\', '/')
+
+
+def llama_module_identity_from_path(module_path: Any) -> Optional[str]:
+    canonical = canonical_llama_module_identity_input(module_path)
+    if not canonical or canonical in {'missing', 'unknown'}:
+        return None
+    digest = hashlib.sha256(f"{LLAMA_MODULE_IDENTITY_DOMAIN}\0{canonical}".encode('utf-8')).hexdigest()
+    return f"sha256:{digest}"
+
+
+def valid_llama_module_identity(value: Any) -> Optional[str]:
+    text = str(value or '').strip()
+    return text if LLAMA_MODULE_IDENTITY_RE.fullmatch(text) else None
+
+
+def llama_module_identity_supplied(value: Any) -> bool:
+    return str(value or '').strip() != ''

--- a/utils/llm/llama_module_identity.py
+++ b/utils/llm/llama_module_identity.py
@@ -23,11 +23,17 @@ def canonical_llama_module_identity_input(module_path: Any) -> Optional[str]:
     if not module_path:
         return None
     try:
-        path_text = strip_windows_extended_path_prefix(str(module_path))
+        raw_path = str(module_path).strip()
+        if raw_path.lower() in {'missing', 'unknown'}:
+            return None
+        path_text = strip_windows_extended_path_prefix(raw_path)
+    except (TypeError, ValueError, OSError):
+        return None
+    try:
         canonical = os.path.normcase(os.path.normpath(os.path.realpath(os.path.abspath(path_text))))
     except (TypeError, ValueError, OSError):
         try:
-            canonical = os.path.normcase(os.path.normpath(strip_windows_extended_path_prefix(str(module_path))))
+            canonical = os.path.normcase(os.path.normpath(path_text))
         except (TypeError, ValueError, OSError):
             return None
     return canonical.replace('\\', '/')

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -2,14 +2,14 @@
 Model manager module for handling LLM model downloading, initialization and inference.
 """
 import os
+import ntpath
 import time
 import logging
 import math
 import hashlib
 import uuid
 from utils.llm.llama_module_identity import (
-    canonical_llama_module_identity_input,
-    llama_module_identity_from_path,
+    canonical_llama_module_identity_input as _shared_canonical_llama_module_identity_input,
     llama_module_identity_supplied,
     valid_llama_module_identity,
 )
@@ -228,6 +228,11 @@ def _safe_constructor_capability_payload(llama_cpp_module: Any) -> Dict[str, Any
         value = capabilities.get(key)
         if isinstance(value, int) and not isinstance(value, bool):
             payload[key] = value
+    valid_identity = _valid_llama_module_identity(capabilities.get('llama_module_identity'))
+    if valid_identity is not None:
+        payload['llama_module_identity'] = valid_identity
+    elif llama_module_identity_supplied(capabilities.get('llama_module_identity')) or capabilities.get('llama_module_identity_malformed') is True:
+        payload['llama_module_identity_malformed'] = True
     for field in (
         'capability_source',
         'backend',
@@ -238,10 +243,8 @@ def _safe_constructor_capability_payload(llama_cpp_module: Any) -> Dict[str, Any
         'qwen_64k_yarn_support',
         'yarn_resolver_source',
         'llama_module_path',
-        'llama_module_identity',
         'llama_module_path_present',
         'llama_module_identity_match',
-        'llama_module_identity_malformed',
         'child_probe_reprobe_attempted',
         'child_probe_reprobe_skipped_reason',
     ):
@@ -929,7 +932,12 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
         identities_match = bool(capability_identity and facade_identity and capability_identity == facade_identity)
         if capability_identity and capability_module_path and str(capability_module_path).strip() not in {'missing', 'unknown'}:
             identities_match = identities_match and capability_identity == llama_module_identity_from_path(capability_module_path)
-        module_paths_match = identities_match or (not capability_identity_supplied and concrete_paths_match)
+        legacy_path_fallback_allowed = (
+            source == 'desktop_runtime_setup_probe_legacy'
+            and not capability_identity_supplied
+            and not capability_identity_malformed
+        )
+        module_paths_match = identities_match or (legacy_path_fallback_allowed and concrete_paths_match)
         capabilities['llama_module_identity_match'] = identities_match
         capabilities['llama_module_identity_malformed'] = capability_identity_malformed
         try:
@@ -966,7 +974,7 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
             if capabilities.get('constructor_signature_inspectable') is not True:
                 missing.append('constructor_signature_inspectable')
             if not module_paths_match:
-                if capability_identity_malformed:
+                if capability_identity_malformed or (source == 'desktop_runtime_setup_probe' and not capability_identity_supplied):
                     missing.append('llama_module_identity')
                 elif capability_identity_supplied:
                     missing.append('llama_module_identity_match')
@@ -1160,11 +1168,58 @@ def _sanitize_subprocess_path_env(env: Dict[str, str], pythonpath_entries: list[
 
 
 
+def _raw_path_sentinel(module_path: Any) -> bool:
+    if module_path is None:
+        return True
+    try:
+        text = str(module_path).strip()
+    except (TypeError, ValueError, OSError):
+        return True
+    return text == '' or text.lower() in {'missing', 'unknown'}
+
+
+def _looks_like_windows_path(path_text: str) -> bool:
+    stripped = path_text.strip()
+    return (
+        stripped.startswith("\\")
+        or stripped.startswith("\\?\\")
+        or (len(stripped) >= 3 and stripped[1] == ":" and stripped[2] in {"\\", "/"})
+    )
+
+def _canonical_windows_path_for_identity(path_text: str) -> str:
+    stripped = _strip_windows_extended_path_prefix(path_text.strip())
+    if stripped.startswith('\\?/'):
+        stripped = stripped[3:]
+    if stripped.startswith('/'):
+        canonical = _shared_canonical_llama_module_identity_input(stripped)
+        return canonical or os.path.normpath(stripped).replace("\\", "/")
+    normalized = ntpath.normpath(stripped).replace("\\", "/")
+    return normalized.lower()
+
+
 def _canonical_path_for_compare(module_path: Any) -> Optional[str]:
-    return canonical_llama_module_identity_input(module_path)
+    if _raw_path_sentinel(module_path):
+        return None
+    path_text = str(module_path)
+    if _looks_like_windows_path(path_text):
+        return _canonical_windows_path_for_identity(path_text)
+    canonical = _shared_canonical_llama_module_identity_input(module_path)
+    if not canonical or canonical.strip().lower() in {'missing', 'unknown'}:
+        return None
+    return canonical
+
+
+def llama_module_identity_from_path(module_path: Any) -> Optional[str]:
+    canonical = _canonical_path_for_compare(module_path)
+    if not canonical:
+        return None
+    digest = hashlib.sha256(f"token.place.llama_cpp.module_path.v1\0{canonical}".encode('utf-8')).hexdigest()
+    return f"sha256:{digest}"
 
 
 def _valid_llama_module_identity(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
     return valid_llama_module_identity(value)
 
 def _is_repo_llama_cpp_shim(module_path: Any) -> bool:

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -7,6 +7,12 @@ import logging
 import math
 import hashlib
 import uuid
+from utils.llm.llama_module_identity import (
+    canonical_llama_module_identity_input,
+    llama_module_identity_from_path,
+    llama_module_identity_supplied,
+    valid_llama_module_identity,
+)
 from utils.networking.http_requests_compat import requests
 import json
 import re
@@ -235,6 +241,7 @@ def _safe_constructor_capability_payload(llama_cpp_module: Any) -> Dict[str, Any
         'llama_module_identity',
         'llama_module_path_present',
         'llama_module_identity_match',
+        'llama_module_identity_malformed',
         'child_probe_reprobe_attempted',
         'child_probe_reprobe_skipped_reason',
     ):
@@ -875,7 +882,11 @@ def _qwen_64k_rope_support_diagnostics(llama_cpp_module: Any, llama_cls: Any) ->
         'missing_required_kwargs': missing_kwargs,
         'missing_reason': '; '.join(missing_reasons) if missing_reasons else None,
         'llama_module_path': worker_capabilities.get('llama_module_path') or getattr(llama_cpp_module, '__file__', None),
-        'llama_module_path_present': bool(worker_capabilities.get('llama_module_path_present') or worker_capabilities.get('llama_module_path')),
+        'llama_module_path_present': (
+            worker_capabilities.get('llama_module_path_present')
+            if isinstance(worker_capabilities.get('llama_module_path_present'), bool)
+            else bool(worker_capabilities.get('llama_module_path'))
+        ),
         'llama_module_identity_match': worker_capabilities.get('llama_module_identity_match'),
         'llama_cpp_python_version': worker_capabilities.get('llama_cpp_python_version') or _llama_cpp_python_version(llama_cpp_module),
         'constructor_has_var_kwargs': constructor_has_var_kwargs,
@@ -900,7 +911,12 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
         required_supported = isinstance(kwarg_support, dict) and all(kwarg_support.get(name) is True for name in required)
         authoritative_backend = str(capabilities.get('backend') or '').lower() in {'cuda', 'metal'}
         capability_module_path = capabilities.get('llama_module_path')
-        capability_identity = _valid_llama_module_identity(capabilities.get('llama_module_identity'))
+        raw_capability_identity = capabilities.get('llama_module_identity')
+        capability_identity_supplied = llama_module_identity_supplied(raw_capability_identity)
+        capability_identity = _valid_llama_module_identity(raw_capability_identity)
+        capability_identity_malformed = (
+            capability_identity_supplied and capability_identity is None
+        ) or capabilities.get('llama_module_identity_malformed') is True
         facade_module_path = getattr(llama_cpp_module, '__file__', None)
         facade_identity = llama_module_identity_from_path(facade_module_path)
         concrete_paths_match = (
@@ -913,8 +929,9 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
         identities_match = bool(capability_identity and facade_identity and capability_identity == facade_identity)
         if capability_identity and capability_module_path and str(capability_module_path).strip() not in {'missing', 'unknown'}:
             identities_match = identities_match and capability_identity == llama_module_identity_from_path(capability_module_path)
-        module_paths_match = identities_match or (not capability_identity and concrete_paths_match)
+        module_paths_match = identities_match or (not capability_identity_supplied and concrete_paths_match)
         capabilities['llama_module_identity_match'] = identities_match
+        capabilities['llama_module_identity_malformed'] = capability_identity_malformed
         try:
             llama_cpp_module.__token_place_worker_capabilities__['llama_module_identity_match'] = identities_match
         except Exception:
@@ -949,7 +966,12 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
             if capabilities.get('constructor_signature_inspectable') is not True:
                 missing.append('constructor_signature_inspectable')
             if not module_paths_match:
-                missing.append('llama_module_path' if capabilities.get('llama_module_identity') is None else 'llama_module_identity_match')
+                if capability_identity_malformed:
+                    missing.append('llama_module_identity')
+                elif capability_identity_supplied:
+                    missing.append('llama_module_identity_match')
+                else:
+                    missing.append('llama_module_path')
             if not authoritative_backend:
                 missing.append('backend')
             if capabilities.get('gpu_offload_supported') is not True:
@@ -1137,36 +1159,13 @@ def _sanitize_subprocess_path_env(env: Dict[str, str], pythonpath_entries: list[
     return sanitized
 
 
-_LLAMA_MODULE_IDENTITY_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
-_LLAMA_MODULE_IDENTITY_DOMAIN = "token.place.llama_cpp.module_path.v1"
-
 
 def _canonical_path_for_compare(module_path: Any) -> Optional[str]:
-    if not module_path:
-        return None
-    try:
-        path_text = _strip_windows_extended_path_prefix(str(module_path))
-        return os.path.normcase(os.path.normpath(os.path.realpath(os.path.abspath(path_text))))
-    except (TypeError, ValueError, OSError):
-        try:
-            return os.path.normcase(os.path.normpath(_strip_windows_extended_path_prefix(str(module_path))))
-        except (TypeError, ValueError, OSError):
-            return None
-
-
-def llama_module_identity_from_path(module_path: Any) -> Optional[str]:
-    canonical = _canonical_path_for_compare(module_path)
-    if not canonical or canonical in {'missing', 'unknown'}:
-        return None
-    canonical = canonical.replace('\\', '/')
-    digest = hashlib.sha256(f"{_LLAMA_MODULE_IDENTITY_DOMAIN}\0{canonical}".encode('utf-8')).hexdigest()
-    return f"sha256:{digest}"
+    return canonical_llama_module_identity_input(module_path)
 
 
 def _valid_llama_module_identity(value: Any) -> Optional[str]:
-    text = str(value or '').strip()
-    return text if _LLAMA_MODULE_IDENTITY_RE.fullmatch(text) else None
-
+    return valid_llama_module_identity(value)
 
 def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
     """Return True when llama_cpp resolves to the repository-local shim."""
@@ -4064,7 +4063,9 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
     gpu_bool = _coerce_strict_bool(probe.get('gpu_offload_supported', True if backend in {'cuda', 'metal'} else False))
     gpu_supported = bool(gpu_bool)
     module_path = str(probe.get('llama_module_path') or '').strip()
-    module_identity = _valid_llama_module_identity(probe.get('llama_module_identity'))
+    raw_module_identity = probe.get('llama_module_identity')
+    module_identity_supplied = llama_module_identity_supplied(raw_module_identity)
+    module_identity = _valid_llama_module_identity(raw_module_identity)
     if not backend or backend == 'missing' or action in {'failed', 'unavailable', 'shadowed_repo_llama_cpp'}:
         return None
     if error and action not in {'already_supported', 'metal_already_supported'}:
@@ -4076,12 +4077,18 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
         'interpreter': str(probe.get('interpreter') or sys.executable),
         'prefix': str(probe.get('prefix') or sys.prefix),
         'llama_module_path': module_path or 'unknown',
-        'llama_module_path_present': bool(module_path and module_path not in {'missing', 'unknown'}),
+        'llama_module_path_present': (
+            _coerce_strict_bool(probe.get('llama_module_path_present'))
+            if _coerce_strict_bool(probe.get('llama_module_path_present')) is not None
+            else bool(module_path and module_path not in {'missing', 'unknown'})
+        ),
         'error': None,
         'runtime_action': action or 'unknown',
     }
     if module_identity is not None:
         coerced['llama_module_identity'] = module_identity
+    elif module_identity_supplied:
+        coerced['llama_module_identity_malformed'] = True
     support: Dict[str, bool] = {}
     raw_support = probe.get('constructor_kwarg_support')
     if isinstance(raw_support, dict):
@@ -4601,6 +4608,9 @@ class ModelManager:
                 'constructor_has_var_kwargs': yarn_probe.get('constructor_has_var_kwargs'),
                 'parent_facade_type': yarn_probe.get('parent_facade_type'),
                 'child_probe_reprobe_attempted': yarn_probe.get('child_probe_reprobe_attempted'),
+                'llama_module_path_present': yarn_probe.get('llama_module_path_present'),
+                'llama_module_identity_match': yarn_probe.get('llama_module_identity_match'),
+                'incomplete_probe_fields': yarn_probe.get('incomplete_probe_fields'),
                 'constructor_kwargs_attempted': (
                     ['rope_scaling_type', 'rope_freq_scale', 'yarn_orig_ctx']
                     if yarn_probe.get('supported') else []

--- a/utils/llm/model_manager.py
+++ b/utils/llm/model_manager.py
@@ -232,6 +232,9 @@ def _safe_constructor_capability_payload(llama_cpp_module: Any) -> Dict[str, Any
         'qwen_64k_yarn_support',
         'yarn_resolver_source',
         'llama_module_path',
+        'llama_module_identity',
+        'llama_module_path_present',
+        'llama_module_identity_match',
         'child_probe_reprobe_attempted',
         'child_probe_reprobe_skipped_reason',
     ):
@@ -787,7 +790,9 @@ def _format_qwen_yarn_unsupported_diagnostics(diagnostics: Dict[str, Any]) -> st
     safe_fields = (
         'active_profile_id',
         'active_context_tier',
-        'llama_module_path',
+        'llama_module_path_present',
+        'llama_module_identity_match',
+        'incomplete_probe_fields',
         'llama_cpp_python_version',
         'missing_reason',
         'yarn_resolver_source',
@@ -796,10 +801,16 @@ def _format_qwen_yarn_unsupported_diagnostics(diagnostics: Dict[str, Any]) -> st
         'child_probe_reprobe_attempted',
         'constructor_kwargs_attempted',
     )
-    return ', '.join(
-        f'{field}={diagnostics.get(field) or "unknown"}'
-        for field in safe_fields
-    )
+    parts = []
+    missing = object()
+    for field in safe_fields:
+        value = diagnostics.get(field, missing)
+        if value is missing or value is None:
+            rendered = 'unknown'
+        else:
+            rendered = repr(value) if isinstance(value, (list, dict, tuple)) else str(value)
+        parts.append(f'{field}={rendered}')
+    return ', '.join(parts)
 
 
 def _qwen_64k_rope_support_diagnostics(llama_cpp_module: Any, llama_cls: Any) -> Dict[str, Any]:
@@ -864,6 +875,8 @@ def _qwen_64k_rope_support_diagnostics(llama_cpp_module: Any, llama_cls: Any) ->
         'missing_required_kwargs': missing_kwargs,
         'missing_reason': '; '.join(missing_reasons) if missing_reasons else None,
         'llama_module_path': worker_capabilities.get('llama_module_path') or getattr(llama_cpp_module, '__file__', None),
+        'llama_module_path_present': bool(worker_capabilities.get('llama_module_path_present') or worker_capabilities.get('llama_module_path')),
+        'llama_module_identity_match': worker_capabilities.get('llama_module_identity_match'),
         'llama_cpp_python_version': worker_capabilities.get('llama_cpp_python_version') or _llama_cpp_python_version(llama_cpp_module),
         'constructor_has_var_kwargs': constructor_has_var_kwargs,
         'constructor_signature_inspectable': worker_capabilities.get('constructor_signature_inspectable'),
@@ -887,13 +900,25 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
         required_supported = isinstance(kwarg_support, dict) and all(kwarg_support.get(name) is True for name in required)
         authoritative_backend = str(capabilities.get('backend') or '').lower() in {'cuda', 'metal'}
         capability_module_path = capabilities.get('llama_module_path')
+        capability_identity = _valid_llama_module_identity(capabilities.get('llama_module_identity'))
         facade_module_path = getattr(llama_cpp_module, '__file__', None)
-        module_paths_match = (
+        facade_identity = llama_module_identity_from_path(facade_module_path)
+        concrete_paths_match = (
             bool(capability_module_path)
+            and str(capability_module_path).strip() not in {'missing', 'unknown'}
             and bool(facade_module_path)
             and _canonical_path_for_compare(capability_module_path)
             == _canonical_path_for_compare(facade_module_path)
         )
+        identities_match = bool(capability_identity and facade_identity and capability_identity == facade_identity)
+        if capability_identity and capability_module_path and str(capability_module_path).strip() not in {'missing', 'unknown'}:
+            identities_match = identities_match and capability_identity == llama_module_identity_from_path(capability_module_path)
+        module_paths_match = identities_match or (not capability_identity and concrete_paths_match)
+        capabilities['llama_module_identity_match'] = identities_match
+        try:
+            llama_cpp_module.__token_place_worker_capabilities__['llama_module_identity_match'] = identities_match
+        except Exception:
+            pass
         authoritative = (
             source in {'desktop_runtime_setup_probe', 'desktop_runtime_setup_probe_legacy'}
             and authoritative_backend
@@ -924,7 +949,7 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
             if capabilities.get('constructor_signature_inspectable') is not True:
                 missing.append('constructor_signature_inspectable')
             if not module_paths_match:
-                missing.append('llama_module_path')
+                missing.append('llama_module_path' if capabilities.get('llama_module_identity') is None else 'llama_module_identity_match')
             if not authoritative_backend:
                 missing.append('backend')
             if capabilities.get('gpu_offload_supported') is not True:
@@ -934,6 +959,7 @@ def _runtime_supports_qwen_yarn_rope(llama_cpp_module: Any, llama_cls: Any) -> D
                 'supported': False,
                 'missing_reason': 'runtime_desktop_capability_probe_incomplete',
                 'missing_required_kwargs': sorted(set(missing)),
+                'incomplete_probe_fields': sorted(set(missing)),
                 'child_probe_reprobe_attempted': False,
                 'child_probe_reprobe_skipped_reason': 'desktop_probe_incomplete_fail_closed',
                 'desktop_probe_authoritative': False,
@@ -1111,6 +1137,10 @@ def _sanitize_subprocess_path_env(env: Dict[str, str], pythonpath_entries: list[
     return sanitized
 
 
+_LLAMA_MODULE_IDENTITY_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_LLAMA_MODULE_IDENTITY_DOMAIN = "token.place.llama_cpp.module_path.v1"
+
+
 def _canonical_path_for_compare(module_path: Any) -> Optional[str]:
     if not module_path:
         return None
@@ -1122,6 +1152,20 @@ def _canonical_path_for_compare(module_path: Any) -> Optional[str]:
             return os.path.normcase(os.path.normpath(_strip_windows_extended_path_prefix(str(module_path))))
         except (TypeError, ValueError, OSError):
             return None
+
+
+def llama_module_identity_from_path(module_path: Any) -> Optional[str]:
+    canonical = _canonical_path_for_compare(module_path)
+    if not canonical or canonical in {'missing', 'unknown'}:
+        return None
+    canonical = canonical.replace('\\', '/')
+    digest = hashlib.sha256(f"{_LLAMA_MODULE_IDENTITY_DOMAIN}\0{canonical}".encode('utf-8')).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _valid_llama_module_identity(value: Any) -> Optional[str]:
+    text = str(value or '').strip()
+    return text if _LLAMA_MODULE_IDENTITY_RE.fullmatch(text) else None
 
 
 def _is_repo_llama_cpp_shim(module_path: Any) -> bool:
@@ -3986,6 +4030,7 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
                 'interpreter': sys.executable,
                 'prefix': sys.prefix,
                 'llama_module_path': module_path or 'unknown',
+                'llama_module_path_present': bool(module_path and module_path not in {'missing', 'unknown'}),
                 'error': _format_runtime_stage_timeout(exc),
             }
         except Exception:
@@ -4006,6 +4051,7 @@ def detect_llama_runtime_capabilities() -> Dict[str, Any]:
         'interpreter': sys.executable,
         'prefix': sys.prefix,
         'llama_module_path': module_path or 'unknown',
+        'llama_module_path_present': bool(module_path and module_path not in {'missing', 'unknown'}),
         'error': None,
     }
 
@@ -4018,6 +4064,7 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
     gpu_bool = _coerce_strict_bool(probe.get('gpu_offload_supported', True if backend in {'cuda', 'metal'} else False))
     gpu_supported = bool(gpu_bool)
     module_path = str(probe.get('llama_module_path') or '').strip()
+    module_identity = _valid_llama_module_identity(probe.get('llama_module_identity'))
     if not backend or backend == 'missing' or action in {'failed', 'unavailable', 'shadowed_repo_llama_cpp'}:
         return None
     if error and action not in {'already_supported', 'metal_already_supported'}:
@@ -4029,9 +4076,12 @@ def _coerce_desktop_runtime_probe(probe: Any) -> Optional[Dict[str, Any]]:
         'interpreter': str(probe.get('interpreter') or sys.executable),
         'prefix': str(probe.get('prefix') or sys.prefix),
         'llama_module_path': module_path or 'unknown',
+        'llama_module_path_present': bool(module_path and module_path not in {'missing', 'unknown'}),
         'error': None,
         'runtime_action': action or 'unknown',
     }
+    if module_identity is not None:
+        coerced['llama_module_identity'] = module_identity
     support: Dict[str, bool] = {}
     raw_support = probe.get('constructor_kwarg_support')
     if isinstance(raw_support, dict):


### PR DESCRIPTION
### Motivation

Packaged macOS could report a healthy bundled runtime but still fail the Qwen 64K capability gate because the raw module path was redacted before the producer-to-consumer handoff. The runtime needed a verifiable, path-free identity that could correlate the desktop probe with the background subprocess facade without exposing local filesystem paths.

### Summary

- Add `utils/llm/llama_module_identity.py` as the shared implementation for canonical module-path normalization, versioned SHA-256 identity generation, serialized identity validation, and supplied-identity detection.
- Provide a compatible packaged fallback in `desktop_runtime_setup.py` for bundle layouts where the repository-level `utils` package is unavailable.
- Include the private `llama_module_identity` in `TOKEN_PLACE_DESKTOP_RUNTIME_PROBE_JSON` while keeping raw module paths and identity digests out of the public `ensure_desktop_llama_runtime()` result.
- Restore only the private identity into `ModelManager.desktop_runtime_probe` in `compute_node_bridge.py`.
- Require exact identity matching for modern desktop probes and fail closed for missing, malformed, or mismatched identities. Preserve concrete-path matching only for probes explicitly marked as legacy.
- Preserve malformed-identity state through probe coercion so downstream validation cannot accidentally treat malformed modern data as legacy.
- Improve Qwen YaRN/RoPE diagnostics so explicit `False` and empty-list values remain truthful, incomplete fields are identified, and operator-visible output remains path- and digest-free.
- Extend the macOS release-artifact validator with a background Qwen 64K probe that follows the production runtime-import path and verifies Metal, GPU offload, constructor capabilities, identity matching, authoritative probe use, and suppression of secondary native reprobes.
- Update packaged operator fixtures and parity checks to exercise the 64K handoff consistently across macOS, Windows, and dependency-isolated bundle layouts.
- Add focused regression coverage for canonicalization, symlinks and `..`, Windows extended prefixes and case normalization, sentinel and malformed inputs, private/public redaction, legacy compatibility, packaged fallback imports, failure diagnostics, and the complete background-facade handoff.

### Compatibility and security

- No API migration or configuration migration is required.
- Modern probes now fail closed unless their module identity is valid and matches the imported facade.
- Explicitly legacy probes retain their concrete-path compatibility behavior.
- Raw module paths and identity digests are not emitted in public runtime results, operator events, or validator failure diagnostics.
- Windows provisioning behavior remains outside this PR’s scope.
- macOS preview artifacts continue to support ad-hoc signing when Developer ID credentials are unavailable; this PR does not add a notarization requirement.

### Testing

Focused verification reported during development included:

- `python -m pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_release_artifacts.py tests/unit/test_model_manager.py -q`
- `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py tests/integration/test_macos_release_probe.py -q`
- `pre-commit run --all-files`
- `git diff --check`

At final head `097749c3`, GitHub reported:

- CI test and real desktop-bridge guardrail: passed
- Linux and macOS `run_all_tests.sh`: passed
- Packaged desktop operator checks on macOS and Windows: passed
- macOS Python 3.9 packaged-inspect check: passed
- Desktop Tauri release artifact builds on macOS and Windows: passed
- macOS staged artifact and embedded Qwen 64K validation: passed
- Helm and relay image validation: passed
- Codecov patch coverage: 90.17%, above the 90.00% target
- Greptile final review: passed

Release publishing, relay publishing, and Helm publishing jobs were skipped as expected for a pull-request run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57fc51c5d0832f976233ac81c02fd2)