### PR TITLE
Enforce API v1 message abuse ceiling in UTF-8 bytes (512 KiB) and add regression tests

### DIFF
--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4564,8 +4564,134 @@ def test_api_v1_invalid_messages_are_rejected_before_worker(messages):
     assert (manager.worker_health, manager.recovery_count) == before
 
 
+
+
+def _deterministic_natural_payload(target_bytes=248 * 1024):
+    phrase = (
+        "This neutral validation sentence describes calm weather, ordinary numbers, "
+        "and predictable spacing for a deterministic prompt fixture. "
+    )
+    repeats = (target_bytes // len(phrase.encode("utf-8"))) + 1
+    payload = (phrase * repeats)[:target_bytes]
+    assert len(payload.encode("utf-8")) == target_bytes
+    return payload
+
+
+class _QwenAdmissionRuntime:
+    def __init__(self, prompt_tokens):
+        self.prompt_tokens = prompt_tokens
+        self.render_and_tokenize_calls = []
+        self.completion_calls = []
+
+    def render_and_tokenize_chat(self, messages, **kwargs):
+        self.render_and_tokenize_calls.append((messages, kwargs))
+        return {"prompt_tokens": self.prompt_tokens}
+
+    def create_chat_completion_from_rendered_prompt(self, messages, **kwargs):
+        self.completion_calls.append((messages, kwargs))
+        return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+
+    def create_chat_completion(self, **kwargs):  # pragma: no cover - qwen path must not use this
+        raise AssertionError("chat completion fallback must not be used for qwen")
+
+
+class _QwenAdmissionManager:
+    api_model_id = "qwen3-8b-instruct"
+    use_mock_llm = False
+
+    def __init__(self, *, tier, window, prompt_tokens):
+        self.context_tier = tier
+        self.context_window_tokens = window
+        self.config = _AdmissionConfig(16)
+        self.model_profile = {
+            "provider": "qwen",
+            "thinking_mode": "disabled",
+            "profile_id": "qwen3-8b-q4-k-m",
+        }
+        self.runtime = _QwenAdmissionRuntime(prompt_tokens)
+        self.worker_restart_count = 0
+
+    def get_llm_instance(self):
+        return self.runtime
+
+
+def test_api_v1_natural_payload_over_old_char_limit_passes_abuse_validation():
+    payload = _deterministic_natural_payload()
+    assert 240 * 1024 <= len(payload.encode("utf-8")) <= 260 * 1024
+    assert len(payload) > 131072
+
+    result = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": payload}]
+    )
+
+    assert result.valid is True
+    assert result.total_content_chars == len(payload)
+    assert result.total_content_utf8_bytes == len(payload.encode("utf-8"))
+
+
+def test_api_v1_qwen_242kb_payload_reaches_exact_admission_and_completes_on_64k():
+    payload = _deterministic_natural_payload()
+    manager = _QwenAdmissionManager(tier="64k-full", window=65536, prompt_tokens=55229)
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-large-64k",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": payload}],
+        options={"max_tokens": 512, "stream": False},
+        requested_context_tier="64k-full",
+    )
+
+    assert envelope["api_v1_response"]["message"] == {"role": "assistant", "content": "ok"}
+    assert len(manager.runtime.render_and_tokenize_calls) == 1
+    assert len(manager.runtime.completion_calls) == 1
+    assert manager.runtime.completion_calls[0][1]["max_tokens"] == 512
+    assert "compute_node_request_too_large" not in json.dumps(envelope)
+
+
+def test_api_v1_qwen_242kb_payload_reaches_exact_admission_and_rejects_on_8k():
+    payload = _deterministic_natural_payload()
+    manager = _QwenAdmissionManager(tier="8k-fast", window=8192, prompt_tokens=55229)
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-large-8k",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": payload}],
+        options={"max_tokens": 512, "stream": False},
+        requested_context_tier="8k-fast",
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["prompt_tokens"] == 55229
+    assert error["requested_output_tokens"] == 512
+    assert len(manager.runtime.render_and_tokenize_calls) == 1
+    assert manager.runtime.completion_calls == []
+    assert error["code"] != "compute_node_request_too_large"
+
+
+def test_api_v1_qwen_64k_exact_overflow_rejects_by_token_admission():
+    payload = _deterministic_natural_payload()
+    manager = _QwenAdmissionManager(tier="64k-full", window=65536, prompt_tokens=65025)
+    client = _api_v1_validation_client(manager)
+
+    envelope = client._generate_api_v1_response_with_runtime_model(
+        request_id="req-qwen-large-64k-overflow",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": payload}],
+        options={"max_tokens": 512, "stream": False},
+        requested_context_tier="64k-full",
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["required_total_tokens"] == 65537
+    assert len(manager.runtime.render_and_tokenize_calls) == 1
+    assert manager.runtime.completion_calls == []
+
 def test_api_v1_large_messages_reach_structural_validation_boundaries():
-    limit = RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    limit = RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
 
     for length in (32769, 65536, limit):
         messages = [{"role": "user", "content": "x" * length}]
@@ -4573,19 +4699,21 @@ def test_api_v1_large_messages_reach_structural_validation_boundaries():
         assert result.valid is True
         assert RelayClient._messages_are_valid_api_v1_chat(messages) is True
         assert result.total_content_chars == length
+        assert result.total_content_utf8_bytes == length
 
     too_large = RelayClient._validate_api_v1_chat_messages(
         [{"role": "user", "content": "x" * (limit + 1)}]
     )
     assert too_large.valid is False
     assert too_large.code == "compute_node_request_too_large"
+    assert too_large.total_content_utf8_bytes == limit + 1
     assert RelayClient._messages_are_valid_api_v1_chat(
         [{"role": "user", "content": "x" * (limit + 1)}]
     ) is False
 
 
 def test_api_v1_text_blocks_use_aggregate_limit_without_lower_message_cap():
-    limit = RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    limit = RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
     valid_blocks = [
         {"type": "text", "text": "a" * 20000},
         {"type": "input_text", "text": "b" * 20000},
@@ -4596,6 +4724,21 @@ def test_api_v1_text_blocks_use_aggregate_limit_without_lower_message_cap():
     )
     assert result.valid is True
     assert result.total_content_chars == 40000
+    assert result.total_content_utf8_bytes == 40000
+
+    exact_boundary_blocks = RelayClient._validate_api_v1_chat_messages(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "x" * (limit // 2)},
+                    {"type": "input_text", "text": "y" * (limit - (limit // 2))},
+                ],
+            }
+        ]
+    )
+    assert exact_boundary_blocks.valid is True
+    assert exact_boundary_blocks.total_content_utf8_bytes == limit
 
     assert RelayClient._validate_api_v1_chat_messages(
         [{"role": "user", "content": [{"type": "text", "text": "x"}] * 33}]
@@ -4620,6 +4763,30 @@ def test_api_v1_text_blocks_use_aggregate_limit_without_lower_message_cap():
     )
     assert too_large.valid is False
     assert too_large.code == "compute_node_request_too_large"
+    assert too_large.total_content_utf8_bytes == limit + 1
+
+
+def test_api_v1_abuse_limit_counts_utf8_bytes_not_code_points():
+    limit = RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
+    character = "雪"
+    char_bytes = len(character.encode("utf-8"))
+    exact_count = limit // char_bytes
+    accepted_text = character * exact_count
+    accepted = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": accepted_text}]
+    )
+    assert accepted.valid is True
+    assert accepted.total_content_chars == exact_count
+    assert accepted.total_content_utf8_bytes == exact_count * char_bytes
+
+    rejected_text = accepted_text + character
+    rejected = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": rejected_text}]
+    )
+    assert rejected.valid is False
+    assert rejected.code == "compute_node_request_too_large"
+    assert rejected.total_content_chars == exact_count + 1
+    assert rejected.total_content_utf8_bytes == (exact_count + 1) * char_bytes
 
 
 def test_api_v1_oversize_request_returns_specific_safe_error_and_logs_counts(caplog):
@@ -4635,7 +4802,7 @@ def test_api_v1_oversize_request_returns_specific_safe_error_and_logs_counts(cap
                 {
                     "role": "user",
                     "content": distinctive_text
-                    + ("x" * RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS),
+                    + ("x" * RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES),
                 }
             ],
             options={},
@@ -4645,7 +4812,9 @@ def test_api_v1_oversize_request_returns_specific_safe_error_and_logs_counts(cap
     assert error["code"] == "compute_node_request_too_large"
     assert error["type"] == "validation_error"
     assert error["message_count"] == 1
-    assert error["maximum_total_content_chars"] == RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    assert error["maximum_total_content_chars"] == RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
+    assert error["maximum_total_content_utf8_bytes"] == RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
+    assert error["total_content_utf8_bytes"] > RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
     assert error["retryable"] is False
     assert distinctive_text not in json.dumps(error)
     assert distinctive_text not in caplog.text

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -36,6 +36,8 @@ class _ApiV1ChatValidationResult(NamedTuple):
     message_index: Optional[int] = None
     message_content_chars: Optional[int] = None
     total_content_chars: int = 0
+    message_content_utf8_bytes: Optional[int] = None
+    total_content_utf8_bytes: int = 0
 
 
 def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
@@ -864,7 +866,11 @@ class RelayClient:
     _API_V1_MAX_MESSAGES = 64
     _API_V1_MAX_TEXT_BLOCKS = 32
     # Aggregate plaintext abuse/transport safety ceiling, not a token estimate.
-    _API_V1_MAX_TOTAL_REQUEST_CHARS = 131072
+    # Enforced in UTF-8 bytes so multibyte input is bounded by transport size,
+    # while exact runtime rendering/tokenization remains the sole context authority.
+    _API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES = 512 * 1024
+    # Backward-compatible diagnostic alias for clients that read char-limit fields.
+    _API_V1_MAX_TOTAL_REQUEST_CHARS = _API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
     _API_V1_MAX_STOP_SEQUENCES = 16
     _API_V1_MAX_STOP_CHARS = 256
     _API_V1_MAX_TOKENS_LIMIT = 8192
@@ -2253,6 +2259,7 @@ class RelayClient:
                 message_count,
             )
         total_content_chars = 0
+        total_content_utf8_bytes = 0
         for index, message in enumerate(messages):
             if not isinstance(message, dict):
                 return _ApiV1ChatValidationResult(
@@ -2262,6 +2269,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             allowed_keys = {"role", "content", "name"}
             if set(message) - allowed_keys:
@@ -2272,6 +2280,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             role = message.get("role")
             if (
@@ -2285,6 +2294,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             name = message.get("name")
             if name is not None and (not isinstance(name, str) or len(name) > 128):
@@ -2295,6 +2305,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             if "content" not in message:
                 return _ApiV1ChatValidationResult(
@@ -2304,6 +2315,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             content_size = cls._api_v1_content_validation_size(message.get("content"))
             if content_size is None:
@@ -2314,22 +2326,28 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
-            total_content_chars += content_size
-            if total_content_chars > cls._API_V1_MAX_TOTAL_REQUEST_CHARS:
+            content_chars, content_utf8_bytes = content_size
+            total_content_chars += content_chars
+            total_content_utf8_bytes += content_utf8_bytes
+            if total_content_utf8_bytes > cls._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES:
                 return _ApiV1ChatValidationResult(
                     False,
                     "compute_node_request_too_large",
                     "aggregate_content_too_large",
                     len(messages),
                     index,
-                    content_size,
+                    content_chars,
                     total_content_chars,
+                    content_utf8_bytes,
+                    total_content_utf8_bytes,
                 )
         return _ApiV1ChatValidationResult(
             True,
             message_count=len(messages),
             total_content_chars=total_content_chars,
+            total_content_utf8_bytes=total_content_utf8_bytes,
         )
 
     @classmethod
@@ -2340,7 +2358,9 @@ class RelayClient:
             (
                 "api_v1.chat_validation_rejected safe_error_code={} reason={} "
                 "message_count={} message_index={} message_content_chars={} "
-                "total_content_chars={} maximum_total_content_chars={}"
+                "total_content_chars={} maximum_total_content_chars={} "
+                "message_content_utf8_bytes={} total_content_utf8_bytes={} "
+                "maximum_total_content_utf8_bytes={}"
             ),
             result.code or "compute_node_invalid_request",
             result.reason or "unknown",
@@ -2353,6 +2373,13 @@ class RelayClient:
             ),
             result.total_content_chars,
             cls._API_V1_MAX_TOTAL_REQUEST_CHARS,
+            (
+                result.message_content_utf8_bytes
+                if result.message_content_utf8_bytes is not None
+                else "unknown"
+            ),
+            result.total_content_utf8_bytes,
+            cls._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES,
         )
 
     @classmethod
@@ -2367,6 +2394,8 @@ class RelayClient:
                 "message_count": result.message_count,
                 "total_content_chars": result.total_content_chars,
                 "maximum_total_content_chars": cls._API_V1_MAX_TOTAL_REQUEST_CHARS,
+                "total_content_utf8_bytes": result.total_content_utf8_bytes,
+                "maximum_total_content_utf8_bytes": cls._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES,
                 "retryable": False,
             }
         return {
@@ -2852,16 +2881,17 @@ class RelayClient:
         return True, None, None, normalised
 
     @classmethod
-    def _api_v1_content_validation_size(cls, content: Any) -> Optional[int]:
+    def _api_v1_content_validation_size(cls, content: Any) -> Optional[Tuple[int, int]]:
         if isinstance(content, str):
-            return len(content)
+            return len(content), len(content.encode("utf-8"))
         if (
             not isinstance(content, list)
             or not content
             or len(content) > cls._API_V1_MAX_TEXT_BLOCKS
         ):
             return None
-        total = 0
+        total_chars = 0
+        total_utf8_bytes = 0
         for item in content:
             if not isinstance(item, dict) or set(item) - {"type", "text"}:
                 return None
@@ -2871,8 +2901,9 @@ class RelayClient:
             text = item.get("text")
             if not isinstance(text, str) or not text:
                 return None
-            total += len(text)
-        return total
+            total_chars += len(text)
+            total_utf8_bytes += len(text.encode("utf-8"))
+        return total_chars, total_utf8_bytes
 
 
     @staticmethod


### PR DESCRIPTION
### Motivation
- The structural API v1 guard previously used a 131,072 Python-character ceiling and rejected very large natural-language prompts before authoritative token admission could run, blocking valid ~242 KB prompts that fit a 64k Qwen context.
- We need a bounded pre-tokenization abuse/transport guard but it must be expressed in transport bytes (UTF-8) and be large enough to let legitimate large prompts reach the runtime tokenizer for exact admission.

### Description
- Raised the aggregate abuse ceiling and changed units by adding `
_API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES = 512 * 1024
` and keeping a backward-compatible alias `
_API_V1_MAX_TOTAL_REQUEST_CHARS = _API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
` in `utils/networking/relay_client.py`.
- Switched validation to count incremental UTF-8 bytes instead of Python `len()` codepoints by returning `(char_count, utf8_bytes)` from `_api_v1_content_validation_size()` and summing `total_content_utf8_bytes` during `_validate_api_v1_chat_messages()` while preserving `total_content_chars` for compatibility.
- Added safe diagnostics and logging fields (`total_content_utf8_bytes`, `maximum_total_content_utf8_bytes`, `message_content_utf8_bytes`) and surfaced them on `compute_node_request_too_large` errors without exposing plaintext content, preserving relay-blind E2EE and privacy invariants.
- Left exact runtime rendering/tokenization as the sole authority for context admission (`compute_node_context_window_exceeded` remains the definitive rejection when tokens overflow the active tier).
- Added focused regression tests in `tests/unit/test_relay_client.py` that generate a deterministic 240–260 KiB ASCII/natural-language payload at runtime and exercise a lightweight Qwen-like runtime bridge to assert: completion succeeds on `64k-full` (55,229 prompt tokens + 512 output tokens admitted), fails with `compute_node_context_window_exceeded` on `8k-fast`, and that token-overflow cases continue to be rejected by token admission rather than the byte ceiling; tests also cover exact UTF-8-byte boundary and multibyte character behavior.

### Testing
- Installed focused verification deps with `pip install -r config/requirements_codex_verification.txt` (success).
- Ran unit tests: `python -m pytest tests/unit/test_relay_client.py -q` — all selected/additional tests passed (full suite: `313 passed`).
- Ran touch UI unit tests: `python -m pytest tests/unit/test_touch_ui.py -q` — `14 passed`.
- Ran integration tests: `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` — `10 passed`.
- Ran repository checks: `git diff --check` and `pre-commit run --all-files` — pre-commit hooks passed.

Verification summary: the change raises the abuse ceiling to `512 KiB` measured in aggregate UTF-8 bytes, preserves character-count diagnostics, adds explicit UTF-8 byte diagnostics in errors/logs, keeps runtime tokenization as the admission authority, preserves relay-blind E2EE and non-streaming API v1 invariants, and is covered by new regression tests which passed locally along with the existing test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59a921ca54832f81d5b28d3af036cf)