### PR TITLE
Raise API v1 message ceiling to 512 KiB (UTF-8 bytes) and add byte-based validation + tests

### DIFF
--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4564,15 +4564,28 @@ def test_api_v1_invalid_messages_are_rejected_before_worker(messages):
     assert (manager.worker_health, manager.recovery_count) == before
 
 
-def test_api_v1_large_messages_reach_structural_validation_boundaries():
-    limit = RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+def _neutral_ascii_payload(target_bytes=248 * 1024):
+    sentence = (
+        "This neutral deterministic validation sentence describes ordinary "
+        "weather, trees, roads, and notebooks without private content. "
+    )
+    repeats = (target_bytes // len(sentence)) + 1
+    return (sentence * repeats)[:target_bytes]
 
-    for length in (32769, 65536, limit):
-        messages = [{"role": "user", "content": "x" * length}]
+
+def test_api_v1_large_messages_reach_structural_validation_boundaries():
+    limit = RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
+    observed_payload = _neutral_ascii_payload()
+    assert 240 * 1024 <= len(observed_payload.encode("utf-8")) <= 260 * 1024
+    assert len(observed_payload) > 131072
+
+    for content in ("x" * 32769, "x" * 65536, observed_payload, "x" * limit):
+        messages = [{"role": "user", "content": content}]
         result = RelayClient._validate_api_v1_chat_messages(messages)
         assert result.valid is True
         assert RelayClient._messages_are_valid_api_v1_chat(messages) is True
-        assert result.total_content_chars == length
+        assert result.total_content_chars == len(content)
+        assert result.total_content_utf8_bytes == len(content.encode("utf-8"))
 
     too_large = RelayClient._validate_api_v1_chat_messages(
         [{"role": "user", "content": "x" * (limit + 1)}]
@@ -4585,7 +4598,7 @@ def test_api_v1_large_messages_reach_structural_validation_boundaries():
 
 
 def test_api_v1_text_blocks_use_aggregate_limit_without_lower_message_cap():
-    limit = RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    limit = RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
     valid_blocks = [
         {"type": "text", "text": "a" * 20000},
         {"type": "input_text", "text": "b" * 20000},
@@ -4596,6 +4609,7 @@ def test_api_v1_text_blocks_use_aggregate_limit_without_lower_message_cap():
     )
     assert result.valid is True
     assert result.total_content_chars == 40000
+    assert result.total_content_utf8_bytes == 40000
 
     assert RelayClient._validate_api_v1_chat_messages(
         [{"role": "user", "content": [{"type": "text", "text": "x"}] * 33}]
@@ -4622,6 +4636,68 @@ def test_api_v1_text_blocks_use_aggregate_limit_without_lower_message_cap():
     assert too_large.code == "compute_node_request_too_large"
 
 
+
+def test_api_v1_utf8_abuse_ceiling_boundaries_and_multibyte_text_blocks():
+    limit = RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
+
+    at_limit = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": "a" * limit}]
+    )
+    assert at_limit.valid is True
+    assert at_limit.total_content_chars == limit
+    assert at_limit.total_content_utf8_bytes == limit
+
+    one_over = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": "a" * (limit + 1)}]
+    )
+    assert one_over.valid is False
+    assert one_over.code == "compute_node_request_too_large"
+    assert one_over.total_content_utf8_bytes == limit + 1
+
+    block_boundary = RelayClient._validate_api_v1_chat_messages(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "b" * (limit - 1)},
+                    {"type": "input_text", "text": "c"},
+                ],
+            }
+        ]
+    )
+    assert block_boundary.valid is True
+    assert block_boundary.total_content_utf8_bytes == limit
+
+    block_over = RelayClient._validate_api_v1_chat_messages(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "b" * limit},
+                    {"type": "input_text", "text": "c"},
+                ],
+            }
+        ]
+    )
+    assert block_over.valid is False
+    assert block_over.code == "compute_node_request_too_large"
+
+    multibyte = ("雪" * (limit // 3)) + ("a" * (limit % 3))
+    multibyte_at_limit = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": multibyte}]
+    )
+    assert multibyte_at_limit.valid is True
+    assert multibyte_at_limit.total_content_chars == (limit // 3) + (limit % 3)
+    assert multibyte_at_limit.total_content_utf8_bytes == limit
+
+    multibyte_over = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": multibyte + "a"}]
+    )
+    assert multibyte_over.valid is False
+    assert multibyte_over.code == "compute_node_request_too_large"
+    assert multibyte_over.total_content_chars < limit
+    assert multibyte_over.total_content_utf8_bytes == limit + 1
+
 def test_api_v1_oversize_request_returns_specific_safe_error_and_logs_counts(caplog):
     manager = _ApiV1RuntimeManager()
     client = _api_v1_validation_client(manager)
@@ -4646,6 +4722,8 @@ def test_api_v1_oversize_request_returns_specific_safe_error_and_logs_counts(cap
     assert error["type"] == "validation_error"
     assert error["message_count"] == 1
     assert error["maximum_total_content_chars"] == RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    assert error["total_content_utf8_bytes"] > RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
+    assert error["maximum_total_content_utf8_bytes"] == RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
     assert error["retryable"] is False
     assert distinctive_text not in json.dumps(error)
     assert distinctive_text not in caplog.text
@@ -4767,6 +4845,102 @@ def _admission_envelope(client, manager, content, *, options=None, requested_tie
         options=options or {},
         requested_context_tier=requested_tier or manager.context_tier,
     )
+
+
+class _QwenLikeRuntime(_AdmissionRuntime):
+    def __init__(self, prompt_tokens):
+        super().__init__()
+        self.prompt_tokens = prompt_tokens
+        self.render_and_tokenize_calls = []
+
+    def render_and_tokenize_chat(self, messages, **kwargs):
+        self.render_and_tokenize_calls.append({"messages": messages, "kwargs": kwargs})
+        return {"prompt_tokens": self.prompt_tokens}
+
+
+class _QwenLikeAdmissionManager(_AdmissionManager):
+    def __init__(self, *, tier, window, prompt_tokens, default_max_tokens=512):
+        super().__init__(tier=tier, window=window, default_max_tokens=default_max_tokens)
+        self.runtime = _QwenLikeRuntime(prompt_tokens)
+        self.model_profile = {
+            "family": "qwen3",
+            "provider": "qwen",
+            "chat_template_policy": "qwen3_non_thinking",
+        }
+
+
+def test_api_v1_qwen_like_242kb_prompt_reaches_authoritative_64k_admission():
+    payload = _neutral_ascii_payload()
+    assert len(payload) > 131072
+    manager = _QwenLikeAdmissionManager(
+        tier="64k-full", window=65536, prompt_tokens=55229, default_max_tokens=512
+    )
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(
+        client,
+        manager,
+        payload,
+        options={"max_tokens": 512},
+        requested_tier="64k-full",
+    )
+
+    assert manager.runtime.render_and_tokenize_calls
+    assert 55229 + 512 <= manager.context_window_tokens
+    assert manager.runtime.calls
+    assert manager.runtime.calls[-1]["max_tokens"] == 512
+    assert envelope["api_v1_response"]["message"] == {
+        "role": "assistant",
+        "content": "ok",
+    }
+    assert "error" not in envelope["api_v1_response"]
+
+
+def test_api_v1_qwen_like_242kb_prompt_reaches_8k_exact_context_rejection():
+    payload = _neutral_ascii_payload()
+    manager = _QwenLikeAdmissionManager(
+        tier="8k-fast", window=8192, prompt_tokens=55229, default_max_tokens=512
+    )
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(
+        client,
+        manager,
+        payload,
+        options={"max_tokens": 512},
+        requested_tier="8k-fast",
+    )
+
+    assert manager.runtime.render_and_tokenize_calls
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["prompt_tokens"] == 55229
+    assert error["requested_output_tokens"] == 512
+    assert error["required_total_tokens"] == 55741
+    assert error["code"] != "compute_node_request_too_large"
+    assert manager.runtime.calls == []
+
+
+def test_api_v1_qwen_like_exact_64k_overflow_rejects_by_tokens():
+    payload = _neutral_ascii_payload()
+    manager = _QwenLikeAdmissionManager(
+        tier="64k-full", window=65536, prompt_tokens=65025, default_max_tokens=512
+    )
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(
+        client,
+        manager,
+        payload,
+        options={"max_tokens": 512},
+        requested_tier="64k-full",
+    )
+
+    assert manager.runtime.render_and_tokenize_calls
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["required_total_tokens"] == 65537
+    assert manager.runtime.calls == []
 
 
 def test_api_v1_context_admission_includes_template_overhead_and_explicit_budget():

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -36,6 +36,8 @@ class _ApiV1ChatValidationResult(NamedTuple):
     message_index: Optional[int] = None
     message_content_chars: Optional[int] = None
     total_content_chars: int = 0
+    message_content_utf8_bytes: Optional[int] = None
+    total_content_utf8_bytes: int = 0
 
 
 def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
@@ -864,7 +866,9 @@ class RelayClient:
     _API_V1_MAX_MESSAGES = 64
     _API_V1_MAX_TEXT_BLOCKS = 32
     # Aggregate plaintext abuse/transport safety ceiling, not a token estimate.
-    _API_V1_MAX_TOTAL_REQUEST_CHARS = 131072
+    _API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES = 512 * 1024
+    # Backwards-compatible diagnostic alias; UTF-8 bytes are authoritative.
+    _API_V1_MAX_TOTAL_REQUEST_CHARS = _API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
     _API_V1_MAX_STOP_SEQUENCES = 16
     _API_V1_MAX_STOP_CHARS = 256
     _API_V1_MAX_TOKENS_LIMIT = 8192
@@ -2253,6 +2257,7 @@ class RelayClient:
                 message_count,
             )
         total_content_chars = 0
+        total_content_utf8_bytes = 0
         for index, message in enumerate(messages):
             if not isinstance(message, dict):
                 return _ApiV1ChatValidationResult(
@@ -2262,6 +2267,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             allowed_keys = {"role", "content", "name"}
             if set(message) - allowed_keys:
@@ -2272,6 +2278,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             role = message.get("role")
             if (
@@ -2285,6 +2292,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             name = message.get("name")
             if name is not None and (not isinstance(name, str) or len(name) > 128):
@@ -2295,6 +2303,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             if "content" not in message:
                 return _ApiV1ChatValidationResult(
@@ -2304,6 +2313,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             content_size = cls._api_v1_content_validation_size(message.get("content"))
             if content_size is None:
@@ -2314,22 +2324,28 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
-            total_content_chars += content_size
-            if total_content_chars > cls._API_V1_MAX_TOTAL_REQUEST_CHARS:
+            content_chars, content_utf8_bytes = content_size
+            total_content_chars += content_chars
+            total_content_utf8_bytes += content_utf8_bytes
+            if total_content_utf8_bytes > cls._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES:
                 return _ApiV1ChatValidationResult(
                     False,
                     "compute_node_request_too_large",
                     "aggregate_content_too_large",
                     len(messages),
                     index,
-                    content_size,
+                    content_chars,
                     total_content_chars,
+                    content_utf8_bytes,
+                    total_content_utf8_bytes,
                 )
         return _ApiV1ChatValidationResult(
             True,
             message_count=len(messages),
             total_content_chars=total_content_chars,
+            total_content_utf8_bytes=total_content_utf8_bytes,
         )
 
     @classmethod
@@ -2340,7 +2356,9 @@ class RelayClient:
             (
                 "api_v1.chat_validation_rejected safe_error_code={} reason={} "
                 "message_count={} message_index={} message_content_chars={} "
-                "total_content_chars={} maximum_total_content_chars={}"
+                "total_content_chars={} maximum_total_content_chars={} "
+                "message_content_utf8_bytes={} total_content_utf8_bytes={} "
+                "maximum_total_content_utf8_bytes={}"
             ),
             result.code or "compute_node_invalid_request",
             result.reason or "unknown",
@@ -2353,6 +2371,13 @@ class RelayClient:
             ),
             result.total_content_chars,
             cls._API_V1_MAX_TOTAL_REQUEST_CHARS,
+            (
+                result.message_content_utf8_bytes
+                if result.message_content_utf8_bytes is not None
+                else "unknown"
+            ),
+            result.total_content_utf8_bytes,
+            cls._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES,
         )
 
     @classmethod
@@ -2367,6 +2392,8 @@ class RelayClient:
                 "message_count": result.message_count,
                 "total_content_chars": result.total_content_chars,
                 "maximum_total_content_chars": cls._API_V1_MAX_TOTAL_REQUEST_CHARS,
+                "total_content_utf8_bytes": result.total_content_utf8_bytes,
+                "maximum_total_content_utf8_bytes": cls._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES,
                 "retryable": False,
             }
         return {
@@ -2852,16 +2879,17 @@ class RelayClient:
         return True, None, None, normalised
 
     @classmethod
-    def _api_v1_content_validation_size(cls, content: Any) -> Optional[int]:
+    def _api_v1_content_validation_size(cls, content: Any) -> Optional[Tuple[int, int]]:
         if isinstance(content, str):
-            return len(content)
+            return len(content), len(content.encode("utf-8"))
         if (
             not isinstance(content, list)
             or not content
             or len(content) > cls._API_V1_MAX_TEXT_BLOCKS
         ):
             return None
-        total = 0
+        total_chars = 0
+        total_utf8_bytes = 0
         for item in content:
             if not isinstance(item, dict) or set(item) - {"type", "text"}:
                 return None
@@ -2871,8 +2899,9 @@ class RelayClient:
             text = item.get("text")
             if not isinstance(text, str) or not text:
                 return None
-            total += len(text)
-        return total
+            total_chars += len(text)
+            total_utf8_bytes += len(text.encode("utf-8"))
+        return total_chars, total_utf8_bytes
 
 
     @staticmethod


### PR DESCRIPTION
### Motivation
- Structural validation used a 131,072 Python-character ceiling (len(text)) which rejected large-but-token-valid prompts before authoritative runtime rendering/tokenization could admit them.
- The safety/transport guard must remain bounded but use UTF-8 bytes so large natural-language prompts that fit a 64k token window are not incorrectly blocked.
- Keep exact runtime rendering/tokenization as the sole authority for context-window admission while preserving privacy-safe diagnostics and error semantics.

### Description
- Introduce a byte-based abuse ceiling ` _API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES = 512 * 1024` and keep the previous ` _API_V1_MAX_TOTAL_REQUEST_CHARS` as a backwards-compatible alias. 
- Extend `_ApiV1ChatValidationResult` and `_api_v1_content_validation_size` to track both character counts and UTF-8 byte counts, and change validation to incrementally aggregate UTF-8 bytes (without concatenating full conversation) and enforce the new ceiling. 
- Add UTF-8 byte diagnostics to logging and structured API v1 validation error payloads (`total_content_utf8_bytes`, `maximum_total_content_utf8_bytes`) while preserving existing safe character diagnostics and error codes (`compute_node_invalid_request`, `compute_node_request_too_large`, `compute_node_context_window_exceeded`).
- Add focused unit tests in `tests/unit/test_relay_client.py` that generate a neutral deterministic ~248 KiB ASCII payload and cover: the new byte ceiling boundaries, multibyte Unicode behavior, aggregated text-block handling, Qwen-like runtime admission for 64k vs 8k tiers, and exact-token overflow behavior, while preserving privacy invariants (no plaintext prompts in errors/logs).

### Testing
- Ran unit tests with `python -m pytest tests/unit/test_relay_client.py -q` and observed all tests in that file pass.
- Ran touch UI tests with `python -m pytest tests/unit/test_touch_ui.py -q` and observed all tests pass.
- Ran the integration desktop-bridge test with `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` and observed all tests pass.
- Ran repository checks `git diff --check` and `pre-commit run --all-files` and they passed in this environment.

Verification notes: the root cause was a character-count pre-check too small for UTF-8 transport; it is now a 512 KiB UTF-8 byte ceiling so a ~242 KB ASCII natural-language prompt can reach authoritative token admission, exact runtime token admission remains the authority for 8k/64k window enforcement, E2EE/privacy invariants were preserved, and added tests exercise the admission paths (64k accept, 8k reject, exact 64k overflow) plus UTF-8 boundary conditions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59a93f91d8832fa0c57b8b5773a800)