### PR TITLE
Enforce API v1 message abuse guard in UTF-8 bytes (512 KiB)

### DIFF
--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4684,6 +4684,43 @@ def test_api_v1_rejects_unpaired_surrogates_before_utf8_byte_counting():
     assert block_result.code == "compute_node_invalid_request"
     assert block_result.reason == "invalid_content"
 
+    input_text_block_result = RelayClient._validate_api_v1_chat_messages(
+        [
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "bad surrogate: \ud800"}],
+            }
+        ]
+    )
+    assert input_text_block_result.valid is False
+    assert input_text_block_result.code == "compute_node_invalid_request"
+    assert input_text_block_result.reason == "invalid_content"
+
+
+def test_api_v1_unpaired_surrogate_full_path_fails_closed_without_plaintext(caplog):
+    manager = _ApiV1RuntimeManager()
+    client = _api_v1_validation_client(manager)
+    sentinel = "PRIVATE_SURROGATE_SENTINEL"
+
+    with caplog.at_level("ERROR", logger="relay_client"):
+        envelope = client._generate_api_v1_response_with_runtime_model(
+            request_id="req-invalid-surrogate",
+            model_id="llama-3-8b-instruct",
+            messages=[{"role": "user", "content": sentinel + "\ud800"}],
+            options={},
+        )
+
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_invalid_request"
+    assert error["message"] == "Invalid chat message format"
+    assert sentinel not in json.dumps(error)
+    assert sentinel not in caplog.text
+    assert "invalid_content" in caplog.text
+    manager.runtime.render_and_tokenize_chat.assert_not_called()
+    manager.runtime.apply_chat_template.assert_not_called()
+    manager.runtime.tokenize.assert_not_called()
+    manager.runtime.create_chat_completion.assert_not_called()
+
 
 def test_api_v1_oversize_request_returns_specific_safe_error_and_logs_counts(caplog):
     manager = _ApiV1RuntimeManager()
@@ -4708,7 +4745,7 @@ def test_api_v1_oversize_request_returns_specific_safe_error_and_logs_counts(cap
     assert error["code"] == "compute_node_request_too_large"
     assert error["type"] == "validation_error"
     assert error["message_count"] == 1
-    assert error["maximum_total_content_chars"] is None
+    assert error["maximum_total_content_chars"] == RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
     assert error["total_content_utf8_bytes"] > RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
     assert error["maximum_total_content_utf8_bytes"] == RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
     assert error["retryable"] is False
@@ -4837,15 +4874,17 @@ def _admission_envelope(client, manager, content, *, options=None, requested_tie
     )
 
 
-def _large_natural_language_payload(target_chars=248 * 1024):
+def _large_natural_language_payload(target_bytes=248 * 1024):
     sentence = (
-        "A calm deterministic paragraph describes relay-safe token admission, "
-        "context windows, and neutral validation behavior for repeatable tests. "
+        b"A calm deterministic paragraph describes relay-safe token admission, "
+        b"context windows, and neutral validation behavior for repeatable tests. "
     )
-    repeats = (target_chars // len(sentence)) + 1
-    payload = (sentence * repeats)[:target_chars]
+    repeats = (target_bytes // len(sentence)) + 1
+    payload_bytes = (sentence * repeats)[:target_bytes]
+    payload = payload_bytes.decode("ascii")
+    assert len(payload_bytes) == target_bytes
     assert 240 * 1024 <= len(payload.encode("utf-8")) <= 260 * 1024
-    assert len(payload) > 131072
+    assert len(payload) > RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
     return payload
 
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4565,23 +4565,65 @@ def test_api_v1_invalid_messages_are_rejected_before_worker(messages):
 
 
 def test_api_v1_large_messages_reach_structural_validation_boundaries():
-    limit = RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    limit = RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
 
-    for length in (32769, 65536, limit):
+    for length in (32769, 65536, 131073, limit):
         messages = [{"role": "user", "content": "x" * length}]
         result = RelayClient._validate_api_v1_chat_messages(messages)
         assert result.valid is True
         assert RelayClient._messages_are_valid_api_v1_chat(messages) is True
         assert result.total_content_chars == length
+        assert result.total_content_utf8_bytes == length
 
     too_large = RelayClient._validate_api_v1_chat_messages(
         [{"role": "user", "content": "x" * (limit + 1)}]
     )
     assert too_large.valid is False
     assert too_large.code == "compute_node_request_too_large"
+    assert too_large.total_content_utf8_bytes == limit + 1
     assert RelayClient._messages_are_valid_api_v1_chat(
         [{"role": "user", "content": "x" * (limit + 1)}]
     ) is False
+
+
+def test_api_v1_abuse_ceiling_uses_utf8_bytes_for_blocks_and_unicode():
+    limit = RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
+
+    exact_blocks = RelayClient._validate_api_v1_chat_messages(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "a" * (limit // 2)},
+                    {"type": "input_text", "text": "b" * (limit - (limit // 2))},
+                ],
+            }
+        ]
+    )
+    assert exact_blocks.valid is True
+    assert exact_blocks.total_content_utf8_bytes == limit
+
+    one_over_blocks = RelayClient._validate_api_v1_chat_messages(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "a" * (limit // 2)},
+                    {"type": "input_text", "text": "b" * (limit - (limit // 2) + 1)},
+                ],
+            }
+        ]
+    )
+    assert one_over_blocks.code == "compute_node_request_too_large"
+    assert one_over_blocks.total_content_utf8_bytes == limit + 1
+
+    multibyte = "雪" * ((limit // len("雪".encode("utf-8"))) + 1)
+    unicode_result = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": multibyte}]
+    )
+    assert unicode_result.code == "compute_node_request_too_large"
+    assert unicode_result.total_content_chars < limit
+    assert unicode_result.total_content_utf8_bytes > limit
 
 
 def test_api_v1_text_blocks_use_aggregate_limit_without_lower_message_cap():
@@ -4646,10 +4688,15 @@ def test_api_v1_oversize_request_returns_specific_safe_error_and_logs_counts(cap
     assert error["type"] == "validation_error"
     assert error["message_count"] == 1
     assert error["maximum_total_content_chars"] == RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    assert error["total_content_utf8_bytes"] > RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
+    assert error["maximum_total_content_utf8_bytes"] == RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
     assert error["retryable"] is False
     assert distinctive_text not in json.dumps(error)
     assert distinctive_text not in caplog.text
     assert "aggregate_content_too_large" in caplog.text
+    manager.runtime.render_and_tokenize_chat.assert_not_called()
+    manager.runtime.apply_chat_template.assert_not_called()
+    manager.runtime.tokenize.assert_not_called()
     manager.runtime.create_chat_completion.assert_not_called()
 
 
@@ -4767,6 +4814,114 @@ def _admission_envelope(client, manager, content, *, options=None, requested_tie
         options=options or {},
         requested_context_tier=requested_tier or manager.context_tier,
     )
+
+
+def _large_natural_language_payload(target_bytes=248 * 1024):
+    sentence = (
+        "A calm deterministic paragraph describes relay-safe token admission, "
+        "context windows, and neutral validation behavior for repeatable tests. "
+    )
+    repeats = (target_bytes // len(sentence.encode("utf-8"))) + 1
+    payload = (sentence * repeats)[:target_bytes]
+    assert 240 * 1024 <= len(payload.encode("utf-8")) <= 260 * 1024
+    assert len(payload) > 131072
+    return payload
+
+
+class _QwenLikeAdmissionRuntime(_AdmissionRuntime):
+    def __init__(self, prompt_tokens):
+        super().__init__()
+        self.prompt_tokens = prompt_tokens
+        self.render_and_tokenize_calls = []
+
+    def render_and_tokenize_chat(self, messages, tokenize=False, add_generation_prompt=True, **kwargs):
+        self.render_and_tokenize_calls.append(
+            {
+                "messages": messages,
+                "tokenize": tokenize,
+                "add_generation_prompt": add_generation_prompt,
+                "kwargs": kwargs,
+            }
+        )
+        return {"prompt_tokens": self.prompt_tokens}
+
+
+class _QwenLikeAdmissionManager(_AdmissionManager):
+    api_model_id = "qwen3-8b-instruct"
+
+    def __init__(self, *, tier, window, prompt_tokens):
+        super().__init__(tier=tier, window=window, default_max_tokens=512)
+        self.model_profile = {
+            "provider": "qwen",
+            "thinking_mode": "disabled",
+            "profile_id": "qwen3-8b-q4-k-m",
+        }
+        self.runtime = _QwenLikeAdmissionRuntime(prompt_tokens)
+
+
+def _qwen_large_payload_envelope(manager, payload):
+    client = _api_v1_validation_client(manager)
+    return client._generate_api_v1_response_with_runtime_model(
+        request_id="req-large-qwen",
+        model_id="qwen3-8b-instruct",
+        messages=[{"role": "user", "content": payload}],
+        options={"max_tokens": 512, "stream": False},
+        requested_context_tier=manager.context_tier,
+    )
+
+
+def test_api_v1_242kb_prompt_passes_abuse_validation_for_exact_admission():
+    payload = _large_natural_language_payload()
+
+    result = RelayClient._validate_api_v1_chat_messages([{"role": "user", "content": payload}])
+
+    assert result.valid is True
+    assert result.total_content_chars == len(payload)
+    assert result.total_content_utf8_bytes == len(payload.encode("utf-8"))
+    assert result.total_content_utf8_bytes > 131072
+    assert result.total_content_utf8_bytes < RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
+
+
+def test_api_v1_large_qwen_prompt_reaches_exact_64k_admission_and_completes():
+    payload = _large_natural_language_payload()
+    manager = _QwenLikeAdmissionManager(tier="64k-full", window=65536, prompt_tokens=55229)
+
+    envelope = _qwen_large_payload_envelope(manager, payload)
+
+    assert manager.runtime.render_and_tokenize_calls
+    assert 55229 + 512 <= manager.context_window_tokens
+    assert envelope["api_v1_response"]["message"] == {"role": "assistant", "content": "ok"}
+    assert "error" not in envelope["api_v1_response"]
+    assert manager.runtime.calls
+    assert manager.runtime.calls[-1]["max_tokens"] == 512
+
+
+def test_api_v1_large_qwen_prompt_reaches_8k_admission_before_context_rejection():
+    payload = _large_natural_language_payload()
+    manager = _QwenLikeAdmissionManager(tier="8k-fast", window=8192, prompt_tokens=55229)
+
+    envelope = _qwen_large_payload_envelope(manager, payload)
+
+    assert manager.runtime.render_and_tokenize_calls
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["prompt_tokens"] == 55229
+    assert error["requested_output_tokens"] == 512
+    assert error["required_total_tokens"] == 55741
+    assert manager.runtime.calls == []
+
+
+def test_api_v1_large_qwen_prompt_exact_64k_overflow_uses_context_error():
+    payload = _large_natural_language_payload()
+    manager = _QwenLikeAdmissionManager(tier="64k-full", window=65536, prompt_tokens=65025)
+
+    envelope = _qwen_large_payload_envelope(manager, payload)
+
+    assert manager.runtime.render_and_tokenize_calls
+    error = envelope["api_v1_response"]["error"]
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["required_total_tokens"] == 65537
+    assert manager.runtime.calls == []
 
 
 def test_api_v1_context_admission_includes_template_overhead_and_explicit_budget():

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4627,7 +4627,7 @@ def test_api_v1_abuse_ceiling_uses_utf8_bytes_for_blocks_and_unicode():
 
 
 def test_api_v1_text_blocks_use_aggregate_limit_without_lower_message_cap():
-    limit = RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    limit = RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
     valid_blocks = [
         {"type": "text", "text": "a" * 20000},
         {"type": "input_text", "text": "b" * 20000},
@@ -4664,6 +4664,27 @@ def test_api_v1_text_blocks_use_aggregate_limit_without_lower_message_cap():
     assert too_large.code == "compute_node_request_too_large"
 
 
+def test_api_v1_rejects_unpaired_surrogates_before_utf8_byte_counting():
+    result = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": "bad surrogate: \ud800"}]
+    )
+    assert result.valid is False
+    assert result.code == "compute_node_invalid_request"
+    assert result.reason == "invalid_content"
+
+    block_result = RelayClient._validate_api_v1_chat_messages(
+        [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "bad surrogate: \ud800"}],
+            }
+        ]
+    )
+    assert block_result.valid is False
+    assert block_result.code == "compute_node_invalid_request"
+    assert block_result.reason == "invalid_content"
+
+
 def test_api_v1_oversize_request_returns_specific_safe_error_and_logs_counts(caplog):
     manager = _ApiV1RuntimeManager()
     client = _api_v1_validation_client(manager)
@@ -4677,7 +4698,7 @@ def test_api_v1_oversize_request_returns_specific_safe_error_and_logs_counts(cap
                 {
                     "role": "user",
                     "content": distinctive_text
-                    + ("x" * RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS),
+                    + ("x" * RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES),
                 }
             ],
             options={},
@@ -4687,7 +4708,7 @@ def test_api_v1_oversize_request_returns_specific_safe_error_and_logs_counts(cap
     assert error["code"] == "compute_node_request_too_large"
     assert error["type"] == "validation_error"
     assert error["message_count"] == 1
-    assert error["maximum_total_content_chars"] == RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    assert error["maximum_total_content_chars"] is None
     assert error["total_content_utf8_bytes"] > RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
     assert error["maximum_total_content_utf8_bytes"] == RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
     assert error["retryable"] is False
@@ -4816,13 +4837,13 @@ def _admission_envelope(client, manager, content, *, options=None, requested_tie
     )
 
 
-def _large_natural_language_payload(target_bytes=248 * 1024):
+def _large_natural_language_payload(target_chars=248 * 1024):
     sentence = (
         "A calm deterministic paragraph describes relay-safe token admission, "
         "context windows, and neutral validation behavior for repeatable tests. "
     )
-    repeats = (target_bytes // len(sentence.encode("utf-8"))) + 1
-    payload = (sentence * repeats)[:target_bytes]
+    repeats = (target_chars // len(sentence)) + 1
+    payload = (sentence * repeats)[:target_chars]
     assert 240 * 1024 <= len(payload.encode("utf-8")) <= 260 * 1024
     assert len(payload) > 131072
     return payload

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -869,10 +869,11 @@ class RelayClient:
     # Enforced in UTF-8 bytes so multi-byte payloads are bounded by transport size
     # while exact runtime token admission remains the only context-fit authority.
     _API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES = 512 * 1024
-    # API v1 no longer enforces an aggregate character ceiling; keep the
-    # legacy diagnostic field explicit as null instead of reporting a byte
-    # limit under a character-oriented name.
-    _API_V1_MAX_TOTAL_REQUEST_CHARS = None
+    # API v1 no longer enforces this legacy aggregate character ceiling; keep
+    # the conservative value only for the backward-compatible
+    # maximum_total_content_chars diagnostic. UTF-8 bytes below are the sole
+    # pre-tokenization abuse/transport ceiling.
+    _API_V1_MAX_TOTAL_REQUEST_CHARS = 131072
     _API_V1_MAX_STOP_SEQUENCES = 16
     _API_V1_MAX_STOP_CHARS = 256
     _API_V1_MAX_TOKENS_LIMIT = 8192

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -36,6 +36,8 @@ class _ApiV1ChatValidationResult(NamedTuple):
     message_index: Optional[int] = None
     message_content_chars: Optional[int] = None
     total_content_chars: int = 0
+    message_content_utf8_bytes: Optional[int] = None
+    total_content_utf8_bytes: int = 0
 
 
 def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
@@ -864,7 +866,11 @@ class RelayClient:
     _API_V1_MAX_MESSAGES = 64
     _API_V1_MAX_TEXT_BLOCKS = 32
     # Aggregate plaintext abuse/transport safety ceiling, not a token estimate.
-    _API_V1_MAX_TOTAL_REQUEST_CHARS = 131072
+    # Enforced in UTF-8 bytes so multi-byte payloads are bounded by transport size
+    # while exact runtime token admission remains the only context-fit authority.
+    _API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES = 512 * 1024
+    # Backward-compatible diagnostic alias for privacy-safe character counters.
+    _API_V1_MAX_TOTAL_REQUEST_CHARS = _API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
     _API_V1_MAX_STOP_SEQUENCES = 16
     _API_V1_MAX_STOP_CHARS = 256
     _API_V1_MAX_TOKENS_LIMIT = 8192
@@ -2253,6 +2259,7 @@ class RelayClient:
                 message_count,
             )
         total_content_chars = 0
+        total_content_utf8_bytes = 0
         for index, message in enumerate(messages):
             if not isinstance(message, dict):
                 return _ApiV1ChatValidationResult(
@@ -2262,6 +2269,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             allowed_keys = {"role", "content", "name"}
             if set(message) - allowed_keys:
@@ -2272,6 +2280,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             role = message.get("role")
             if (
@@ -2285,6 +2294,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             name = message.get("name")
             if name is not None and (not isinstance(name, str) or len(name) > 128):
@@ -2295,6 +2305,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             if "content" not in message:
                 return _ApiV1ChatValidationResult(
@@ -2304,6 +2315,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             content_size = cls._api_v1_content_validation_size(message.get("content"))
             if content_size is None:
@@ -2314,22 +2326,28 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
-            total_content_chars += content_size
-            if total_content_chars > cls._API_V1_MAX_TOTAL_REQUEST_CHARS:
+            content_chars, content_utf8_bytes = content_size
+            total_content_chars += content_chars
+            total_content_utf8_bytes += content_utf8_bytes
+            if total_content_utf8_bytes > cls._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES:
                 return _ApiV1ChatValidationResult(
                     False,
                     "compute_node_request_too_large",
                     "aggregate_content_too_large",
                     len(messages),
                     index,
-                    content_size,
+                    content_chars,
                     total_content_chars,
+                    content_utf8_bytes,
+                    total_content_utf8_bytes,
                 )
         return _ApiV1ChatValidationResult(
             True,
             message_count=len(messages),
             total_content_chars=total_content_chars,
+            total_content_utf8_bytes=total_content_utf8_bytes,
         )
 
     @classmethod
@@ -2340,7 +2358,9 @@ class RelayClient:
             (
                 "api_v1.chat_validation_rejected safe_error_code={} reason={} "
                 "message_count={} message_index={} message_content_chars={} "
-                "total_content_chars={} maximum_total_content_chars={}"
+                "total_content_chars={} maximum_total_content_chars={} "
+                "message_content_utf8_bytes={} total_content_utf8_bytes={} "
+                "maximum_total_content_utf8_bytes={}"
             ),
             result.code or "compute_node_invalid_request",
             result.reason or "unknown",
@@ -2353,6 +2373,13 @@ class RelayClient:
             ),
             result.total_content_chars,
             cls._API_V1_MAX_TOTAL_REQUEST_CHARS,
+            (
+                result.message_content_utf8_bytes
+                if result.message_content_utf8_bytes is not None
+                else "unknown"
+            ),
+            result.total_content_utf8_bytes,
+            cls._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES,
         )
 
     @classmethod
@@ -2367,6 +2394,8 @@ class RelayClient:
                 "message_count": result.message_count,
                 "total_content_chars": result.total_content_chars,
                 "maximum_total_content_chars": cls._API_V1_MAX_TOTAL_REQUEST_CHARS,
+                "total_content_utf8_bytes": result.total_content_utf8_bytes,
+                "maximum_total_content_utf8_bytes": cls._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES,
                 "retryable": False,
             }
         return {
@@ -2852,16 +2881,17 @@ class RelayClient:
         return True, None, None, normalised
 
     @classmethod
-    def _api_v1_content_validation_size(cls, content: Any) -> Optional[int]:
+    def _api_v1_content_validation_size(cls, content: Any) -> Optional[Tuple[int, int]]:
         if isinstance(content, str):
-            return len(content)
+            return len(content), len(content.encode("utf-8"))
         if (
             not isinstance(content, list)
             or not content
             or len(content) > cls._API_V1_MAX_TEXT_BLOCKS
         ):
             return None
-        total = 0
+        total_chars = 0
+        total_utf8_bytes = 0
         for item in content:
             if not isinstance(item, dict) or set(item) - {"type", "text"}:
                 return None
@@ -2871,8 +2901,9 @@ class RelayClient:
             text = item.get("text")
             if not isinstance(text, str) or not text:
                 return None
-            total += len(text)
-        return total
+            total_chars += len(text)
+            total_utf8_bytes += len(text.encode("utf-8"))
+        return total_chars, total_utf8_bytes
 
 
     @staticmethod

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -869,8 +869,10 @@ class RelayClient:
     # Enforced in UTF-8 bytes so multi-byte payloads are bounded by transport size
     # while exact runtime token admission remains the only context-fit authority.
     _API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES = 512 * 1024
-    # Backward-compatible diagnostic alias for privacy-safe character counters.
-    _API_V1_MAX_TOTAL_REQUEST_CHARS = _API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
+    # API v1 no longer enforces an aggregate character ceiling; keep the
+    # legacy diagnostic field explicit as null instead of reporting a byte
+    # limit under a character-oriented name.
+    _API_V1_MAX_TOTAL_REQUEST_CHARS = None
     _API_V1_MAX_STOP_SEQUENCES = 16
     _API_V1_MAX_STOP_CHARS = 256
     _API_V1_MAX_TOKENS_LIMIT = 8192
@@ -2883,7 +2885,10 @@ class RelayClient:
     @classmethod
     def _api_v1_content_validation_size(cls, content: Any) -> Optional[Tuple[int, int]]:
         if isinstance(content, str):
-            return len(content), len(content.encode("utf-8"))
+            try:
+                return len(content), len(content.encode("utf-8"))
+            except UnicodeEncodeError:
+                return None
         if (
             not isinstance(content, list)
             or not content
@@ -2901,8 +2906,12 @@ class RelayClient:
             text = item.get("text")
             if not isinstance(text, str) or not text:
                 return None
+            try:
+                text_utf8_bytes = len(text.encode("utf-8"))
+            except UnicodeEncodeError:
+                return None
             total_chars += len(text)
-            total_utf8_bytes += len(text.encode("utf-8"))
+            total_utf8_bytes += text_utf8_bytes
         return total_chars, total_utf8_bytes
 
 


### PR DESCRIPTION
### Motivation

- Fix the API v1 pre-tokenization guard that rejected prompts above 131,072 Python characters before authoritative runtime token admission.
- Allow the observed roughly 242 KiB, 55,229-token Qwen3 prompt to reach the 64k context check while retaining a bounded abuse/transport safeguard.

### Changes

- Added `_API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES = 512 * 1024` as the sole enforced aggregate message-content ceiling.
- Count UTF-8 bytes incrementally across message strings and supported `text`/`input_text` blocks without concatenating the conversation.
- Preserved `_API_V1_MAX_TOTAL_REQUEST_CHARS = 131072` only as a conservative backward-compatible diagnostic for `maximum_total_content_chars`; it is no longer enforced.
- Preserved character-count diagnostics and added `message_content_utf8_bytes`, `total_content_utf8_bytes`, and `maximum_total_content_utf8_bytes`.
- Catch `UnicodeEncodeError` for unpaired surrogates and return the safe `compute_node_invalid_request`/`invalid_content` outcome before tokenization.
- Kept exact runtime rendering/tokenization as the sole authority for context fit:
  - malformed content → `compute_node_invalid_request`
  - UTF-8 abuse-ceiling violation → `compute_node_request_too_large`
  - rendered prompt plus output overflow → `compute_node_context_window_exceeded`
- Preserved relay-blind E2EE, privacy-safe logging, non-streaming API v1 behavior, model configuration, context tiers, YaRN, scheduling, registration, and heartbeat behavior.

### Regression coverage

Tests in `tests/unit/test_relay_client.py` now cover:

- A deterministic 248 KiB ASCII payload generated at runtime that exceeds the former character ceiling but remains below 512 KiB.
- A Qwen-like runtime reporting 55,229 prompt tokens:
  - admitted on `64k-full` with `max_tokens=512`, followed by completion;
  - rejected on `8k-fast` by authoritative token admission;
  - rejected at exactly 65,537 required tokens on `64k-full`.
- Exact UTF-8 ceiling acceptance and one-byte-over rejection for strings and aggregate text blocks.
- Multibyte Unicode enforcement by UTF-8 bytes rather than code points.
- Unpaired surrogates in direct content, `text` blocks, and `input_text` blocks.
- Full-path malformed-Unicode rejection with no rendering, tokenization, completion, or plaintext leakage.
- True abuse-ceiling rejection with safe count-only diagnostics and no model invocation.

No large text fixtures, tokenizer assets, model downloads, ingress changes, or `static/chat.js` changes were added.

### Deployment caveat

The Helm ingress template supports annotations, but the repository’s default values do not configure a request-body-size override. No lower conflicting in-repository limit was found, and the reported request already crossed staging ingress. Deployments should nevertheless ensure any external ingress or proxy accepts the resulting encrypted request body.

### Verification

The final head passed:

- `python -m pytest tests/unit/test_relay_client.py -q`
- `python -m pytest tests/unit/test_touch_ui.py -q`
- `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q`
- `git diff --check`
- `pre-commit run --all-files`

All latest-head GitHub workflows succeeded:

- CI
- `run_all_tests.sh PR` on Linux and macOS
- Desktop operator app E2E
- GHCR relay image build
- Helm chart publication

Codecov reports all modified coverable lines are covered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59a937db74832f969f1bd6c97523d4)