### PR TITLE
Fix API v1 compute-node message byte ceiling

### DIFF
--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -4274,7 +4274,10 @@ def test_api_v1_qwen_generation_uses_render_then_complete_not_chat_completion():
         requested_context_tier="64k-full",
     )
 
-    assert envelope["api_v1_response"]["message"] == {"role": "assistant", "content": "ok"}
+    assert envelope["api_v1_response"]["message"] == {
+        "role": "assistant",
+        "content": "ok",
+    }
     manager.runtime.create_chat_completion.assert_not_called()
     kwargs = manager.runtime.create_chat_completion_from_rendered_prompt.call_args.kwargs
     assert kwargs == {
@@ -4646,6 +4649,11 @@ def test_api_v1_oversize_request_returns_specific_safe_error_and_logs_counts(cap
     assert error["type"] == "validation_error"
     assert error["message_count"] == 1
     assert error["maximum_total_content_chars"] == RelayClient._API_V1_MAX_TOTAL_REQUEST_CHARS
+    assert (
+        error["maximum_total_content_utf8_bytes"]
+        == RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
+    )
+    assert error["total_content_utf8_bytes"] > error["maximum_total_content_utf8_bytes"]
     assert error["retryable"] is False
     assert distinctive_text not in json.dumps(error)
     assert distinctive_text not in caplog.text
@@ -4768,6 +4776,174 @@ def _admission_envelope(client, manager, content, *, options=None, requested_tie
         requested_context_tier=requested_tier or manager.context_tier,
     )
 
+
+def _neutral_ascii_payload_between_240kb_and_260kb():
+    sentence = (
+        "This neutral deterministic sentence describes ordinary validation behavior "
+        "without carrying private data or special tokenizer fixtures. "
+    )
+    target = 242 * 1024
+    payload = (sentence * ((target // len(sentence)) + 1))[:target]
+    assert 240 * 1024 <= len(payload.encode("utf-8")) <= 260 * 1024
+    assert len(payload) > 131072
+    return payload
+
+
+class _FixedTokenRuntime(_AdmissionRuntime):
+    def __init__(self, prompt_tokens):
+        super().__init__()
+        self.prompt_tokens = prompt_tokens
+        self.render_and_tokenize_calls = []
+
+    def render_and_tokenize_chat(
+        self, messages, tokenize=False, add_generation_prompt=True, **kwargs
+    ):
+        assert tokenize is False
+        assert add_generation_prompt is True
+        self.render_and_tokenize_calls.append(
+            {"messages": messages, "template_kwargs": kwargs}
+        )
+        return {"prompt_tokens": self.prompt_tokens}
+
+    def apply_chat_template(
+        self, *args, **kwargs
+    ):  # pragma: no cover - bridge must be authoritative
+        raise AssertionError("parent render/tokenize fallback should not run")
+
+
+class _FixedTokenManager(_AdmissionManager):
+    def __init__(self, *, tier, window, prompt_tokens, default_max_tokens=512):
+        super().__init__(tier=tier, window=window, default_max_tokens=default_max_tokens)
+        self.runtime = _FixedTokenRuntime(prompt_tokens)
+
+
+def test_api_v1_240kb_natural_language_payload_passes_abuse_validation():
+    payload = _neutral_ascii_payload_between_240kb_and_260kb()
+
+    result = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": payload}]
+    )
+
+    assert result.valid is True
+    assert result.total_content_chars == len(payload)
+    assert result.total_content_utf8_bytes == len(payload.encode("utf-8"))
+    assert (
+        result.total_content_utf8_bytes
+        <= RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
+    )
+
+
+def test_api_v1_240kb_payload_reaches_authoritative_admission_on_64k_full():
+    payload = _neutral_ascii_payload_between_240kb_and_260kb()
+    manager = _FixedTokenManager(
+        tier="64k-full", window=65536, prompt_tokens=55229, default_max_tokens=512
+    )
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(
+        client, manager, payload, options={"max_tokens": 512}, requested_tier="64k-full"
+    )
+
+    assert manager.runtime.render_and_tokenize_calls
+    assert manager.runtime.calls
+    assert manager.runtime.calls[-1]["max_tokens"] == 512
+    assert envelope["api_v1_response"]["message"] == {
+        "role": "assistant",
+        "content": "ok",
+    }
+    assert "error" not in envelope["api_v1_response"]
+
+
+def test_api_v1_240kb_payload_uses_context_window_error_on_8k_fast():
+    payload = _neutral_ascii_payload_between_240kb_and_260kb()
+    manager = _FixedTokenManager(
+        tier="8k-fast", window=8192, prompt_tokens=55229, default_max_tokens=512
+    )
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(
+        client, manager, payload, options={"max_tokens": 512}, requested_tier="8k-fast"
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    assert manager.runtime.render_and_tokenize_calls
+    assert manager.runtime.calls == []
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["prompt_tokens"] == 55229
+    assert error["requested_output_tokens"] == 512
+    assert error["required_total_tokens"] == 55741
+
+
+def test_api_v1_64k_exact_admission_rejects_one_token_over_window():
+    manager = _FixedTokenManager(
+        tier="64k-full", window=65536, prompt_tokens=65025, default_max_tokens=512
+    )
+    client = _api_v1_validation_client(manager)
+
+    envelope = _admission_envelope(
+        client,
+        manager,
+        "small request",
+        options={"max_tokens": 512},
+        requested_tier="64k-full",
+    )
+
+    error = envelope["api_v1_response"]["error"]
+    assert manager.runtime.render_and_tokenize_calls
+    assert manager.runtime.calls == []
+    assert error["code"] == "compute_node_context_window_exceeded"
+    assert error["required_total_tokens"] == 65537
+
+
+def test_api_v1_utf8_abuse_ceiling_boundaries_and_text_blocks():
+    limit = RelayClient._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
+
+    exact = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": "x" * limit}]
+    )
+    assert exact.valid is True
+    assert exact.total_content_utf8_bytes == limit
+
+    one_over = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": "x" * (limit + 1)}]
+    )
+    assert one_over.code == "compute_node_request_too_large"
+    assert one_over.total_content_utf8_bytes == limit + 1
+
+    blocks = RelayClient._validate_api_v1_chat_messages(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "a" * (limit // 2)},
+                    {"type": "input_text", "text": "b" * (limit - (limit // 2))},
+                ],
+            }
+        ]
+    )
+    assert blocks.valid is True
+    assert blocks.total_content_utf8_bytes == limit
+
+    block_over = RelayClient._validate_api_v1_chat_messages(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "a" * (limit // 2)},
+                    {"type": "text", "text": "b" * (limit - (limit // 2) + 1)},
+                ],
+            }
+        ]
+    )
+    assert block_over.code == "compute_node_request_too_large"
+
+    multibyte = "雪" * ((limit // len("雪".encode("utf-8"))) + 1)
+    multibyte_result = RelayClient._validate_api_v1_chat_messages(
+        [{"role": "user", "content": multibyte}]
+    )
+    assert len(multibyte) < limit
+    assert multibyte_result.code == "compute_node_request_too_large"
+    assert multibyte_result.total_content_utf8_bytes > limit
 
 def test_api_v1_context_admission_includes_template_overhead_and_explicit_budget():
     manager = _AdmissionManager(window=32)
@@ -5200,7 +5376,9 @@ def test_qwen_context_admission_preserves_messages_without_no_think_injection():
 
 def test_qwen_context_admission_uses_packaged_render_tokenize_bridge():
     class Runtime(_AdmissionRuntime):
-        def render_and_tokenize_chat(self, messages, tokenize=False, add_generation_prompt=True, **kwargs):
+        def render_and_tokenize_chat(
+        self, messages, tokenize=False, add_generation_prompt=True, **kwargs
+    ):
             self.calls.append({
                 'bridge': 'render_and_tokenize_chat',
                 'messages': messages,
@@ -5334,7 +5512,9 @@ def test_qwen_context_admission_fails_closed_when_fallback_render_rejects_enable
             super().__init__()
             self.render_calls = []
 
-        def render_and_tokenize_chat(self, messages, tokenize=False, add_generation_prompt=True, **kwargs):
+        def render_and_tokenize_chat(
+        self, messages, tokenize=False, add_generation_prompt=True, **kwargs
+    ):
             self.render_calls.append({'bridge': kwargs, 'messages': messages})
             return None
 
@@ -5385,7 +5565,9 @@ def test_api_v1_qwen_paths_never_send_enable_thinking_true():
             super().__init__()
             self.render_calls = []
 
-        def render_and_tokenize_chat(self, messages, tokenize=False, add_generation_prompt=True, **kwargs):
+        def render_and_tokenize_chat(
+        self, messages, tokenize=False, add_generation_prompt=True, **kwargs
+    ):
             self.render_calls.append(kwargs)
             assert kwargs['enable_thinking'] is False
             return {'prompt_tokens': 7}

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -36,6 +36,8 @@ class _ApiV1ChatValidationResult(NamedTuple):
     message_index: Optional[int] = None
     message_content_chars: Optional[int] = None
     total_content_chars: int = 0
+    message_content_utf8_bytes: Optional[int] = None
+    total_content_utf8_bytes: int = 0
 
 
 def _is_llama_cpp_inference_request_error(exc: BaseException) -> bool:
@@ -864,7 +866,9 @@ class RelayClient:
     _API_V1_MAX_MESSAGES = 64
     _API_V1_MAX_TEXT_BLOCKS = 32
     # Aggregate plaintext abuse/transport safety ceiling, not a token estimate.
-    _API_V1_MAX_TOTAL_REQUEST_CHARS = 131072
+    # Exact rendered-template token admission remains the sole context-fit authority.
+    _API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES = 512 * 1024
+    _API_V1_MAX_TOTAL_REQUEST_CHARS = _API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES
     _API_V1_MAX_STOP_SEQUENCES = 16
     _API_V1_MAX_STOP_CHARS = 256
     _API_V1_MAX_TOKENS_LIMIT = 8192
@@ -2253,6 +2257,7 @@ class RelayClient:
                 message_count,
             )
         total_content_chars = 0
+        total_content_utf8_bytes = 0
         for index, message in enumerate(messages):
             if not isinstance(message, dict):
                 return _ApiV1ChatValidationResult(
@@ -2262,6 +2267,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             allowed_keys = {"role", "content", "name"}
             if set(message) - allowed_keys:
@@ -2272,6 +2278,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             role = message.get("role")
             if (
@@ -2285,6 +2292,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             name = message.get("name")
             if name is not None and (not isinstance(name, str) or len(name) > 128):
@@ -2295,6 +2303,7 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
             if "content" not in message:
                 return _ApiV1ChatValidationResult(
@@ -2304,9 +2313,12 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
-            content_size = cls._api_v1_content_validation_size(message.get("content"))
-            if content_size is None:
+            content_metrics = cls._api_v1_content_validation_metrics(
+                message.get("content")
+            )
+            if content_metrics is None:
                 return _ApiV1ChatValidationResult(
                     False,
                     "compute_node_invalid_request",
@@ -2314,22 +2326,28 @@ class RelayClient:
                     len(messages),
                     index,
                     total_content_chars=total_content_chars,
+                    total_content_utf8_bytes=total_content_utf8_bytes,
                 )
-            total_content_chars += content_size
-            if total_content_chars > cls._API_V1_MAX_TOTAL_REQUEST_CHARS:
+            content_chars, content_utf8_bytes = content_metrics
+            total_content_chars += content_chars
+            total_content_utf8_bytes += content_utf8_bytes
+            if total_content_utf8_bytes > cls._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES:
                 return _ApiV1ChatValidationResult(
                     False,
                     "compute_node_request_too_large",
                     "aggregate_content_too_large",
                     len(messages),
                     index,
-                    content_size,
+                    content_chars,
                     total_content_chars,
+                    content_utf8_bytes,
+                    total_content_utf8_bytes,
                 )
         return _ApiV1ChatValidationResult(
             True,
             message_count=len(messages),
             total_content_chars=total_content_chars,
+            total_content_utf8_bytes=total_content_utf8_bytes,
         )
 
     @classmethod
@@ -2340,7 +2358,9 @@ class RelayClient:
             (
                 "api_v1.chat_validation_rejected safe_error_code={} reason={} "
                 "message_count={} message_index={} message_content_chars={} "
-                "total_content_chars={} maximum_total_content_chars={}"
+                "total_content_chars={} maximum_total_content_chars={} "
+                "message_content_utf8_bytes={} total_content_utf8_bytes={} "
+                "maximum_total_content_utf8_bytes={}"
             ),
             result.code or "compute_node_invalid_request",
             result.reason or "unknown",
@@ -2353,6 +2373,13 @@ class RelayClient:
             ),
             result.total_content_chars,
             cls._API_V1_MAX_TOTAL_REQUEST_CHARS,
+            (
+                result.message_content_utf8_bytes
+                if result.message_content_utf8_bytes is not None
+                else "unknown"
+            ),
+            result.total_content_utf8_bytes,
+            cls._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES,
         )
 
     @classmethod
@@ -2367,6 +2394,8 @@ class RelayClient:
                 "message_count": result.message_count,
                 "total_content_chars": result.total_content_chars,
                 "maximum_total_content_chars": cls._API_V1_MAX_TOTAL_REQUEST_CHARS,
+                "total_content_utf8_bytes": result.total_content_utf8_bytes,
+                "maximum_total_content_utf8_bytes": cls._API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES,
                 "retryable": False,
             }
         return {
@@ -2852,16 +2881,17 @@ class RelayClient:
         return True, None, None, normalised
 
     @classmethod
-    def _api_v1_content_validation_size(cls, content: Any) -> Optional[int]:
+    def _api_v1_content_validation_metrics(cls, content: Any) -> Optional[Tuple[int, int]]:
         if isinstance(content, str):
-            return len(content)
+            return len(content), len(content.encode("utf-8"))
         if (
             not isinstance(content, list)
             or not content
             or len(content) > cls._API_V1_MAX_TEXT_BLOCKS
         ):
             return None
-        total = 0
+        total_chars = 0
+        total_utf8_bytes = 0
         for item in content:
             if not isinstance(item, dict) or set(item) - {"type", "text"}:
                 return None
@@ -2871,8 +2901,14 @@ class RelayClient:
             text = item.get("text")
             if not isinstance(text, str) or not text:
                 return None
-            total += len(text)
-        return total
+            total_chars += len(text)
+            total_utf8_bytes += len(text.encode("utf-8"))
+        return total_chars, total_utf8_bytes
+
+    @classmethod
+    def _api_v1_content_validation_size(cls, content: Any) -> Optional[int]:
+        metrics = cls._api_v1_content_validation_metrics(content)
+        return metrics[0] if metrics is not None else None
 
 
     @staticmethod


### PR DESCRIPTION
### Motivation

- Prevent legitimate large natural-language prompts from being rejected by a pre-tokenization character ceiling while preserving a bounded abuse/transport guard.
- Ensure exact rendered-template token admission remains the sole authority for context-window fit (8k/64k) while providing UTF-8 byte diagnostics for operators and clients.

### Description

- Replace the old character-based pre-tokenization ceiling with a UTF-8 byte ceiling by adding `_API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES = 512 * 1024` and aliasing the legacy character constant to it (`_API_V1_MAX_TOTAL_REQUEST_CHARS = _API_V1_MAX_TOTAL_MESSAGE_UTF8_BYTES`).
- Track aggregate content incrementally in both Python characters and UTF-8 bytes inside `RelayClient._validate_api_v1_chat_messages`, using a new helper `._api_v1_content_validation_metrics` that returns `(chars, utf8_bytes)` and preserving `._api_v1_content_validation_size` for compatibility.
- Surface privacy-safe UTF-8 diagnostics in logs and structured validation errors (add `total_content_utf8_bytes` and `maximum_total_content_utf8_bytes` to the `compute_node_request_too_large` response and add `message_content_utf8_bytes`/`total_content_utf8_bytes` to log lines) while continuing to avoid any plaintext prompt material in logs or errors.
- Keep validation outcomes distinct (malformed -> `compute_node_invalid_request`, abuse-ceiling -> `compute_node_request_too_large`, exact token overflow -> `compute_node_context_window_exceeded`) and do not change runtime tokenization/admission logic.
- Files changed: `utils/networking/relay_client.py` (core validation, constants, diagnostics) and `tests/unit/test_relay_client.py` (focused regressions and UTF-8 boundary tests).

### Testing

- Installed focused verification deps with `pip install -r config/requirements_codex_verification.txt` and ran the test suite slices described below.
- Ran `python -m pytest tests/unit/test_relay_client.py -q` and observed the full unit suite pass (313 tests passed).
- Ran `python -m pytest tests/unit/test_touch_ui.py -q` and observed all tests pass (14 passed).
- Ran `python -m pytest tests/integration/test_api_v1_desktop_bridge_e2ee.py -q` and observed integration tests pass (10 passed, with expected warnings).
- Ran `git diff --check` and `pre-commit run --all-files` and both checks completed without failures.

All added tests exercise: a neutral deterministic ~242 KiB ASCII payload that is above the old 131,072-char limit but below the new 512 KiB byte ceiling; admission flow on a mocked 64k-full runtime that reports 55,229 prompt tokens (admitted with `max_tokens=512`); the same payload on an 8k-fast runtime (returns `compute_node_context_window_exceeded`); exact 64k overflow rejection case (65,537 total tokens); UTF-8 byte boundary acceptance/rejection including multibyte characters and text-block aggregation; and preservation of the privacy-safe oversize regression asserting no prompt content leaks and that no completion/tokenization is called when the abuse ceiling is exceeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59a9259eb0832fa7089e083ba9f4b9)