### PR TITLE
Bundle Windows CUDA desktop runtime and require bundled CPython in packaged builds

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -231,6 +231,21 @@ jobs:
           test -x src-tauri/python-runtime/bin/python3
           src-tauri/python-runtime/bin/python3 -m pip check
 
+      - name: Cache embedded Windows Python archive and wheels
+        if: runner.os == 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/token-place/embedded-python
+          key: embedded-python-${{ runner.os }}-${{ hashFiles('desktop-tauri/src-tauri/python/embedded_python_runtime_windows_manifest.json', 'desktop-tauri/src-tauri/python/requirements_desktop_runtime.txt') }}
+
+      - name: Prepare embedded Windows Python runtime
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          python scripts/prepare_windows_embedded_python_runtime.py
+          src-tauri\python-runtime\python.exe -m pip check
+
       - name: Build frontend assets
         # Keep this explicit pre-build. Some CI failures reported frontendDist validation
         # before Tauri's internal beforeBuildCommand hook on clean runners.

--- a/desktop-tauri/package-lock.json
+++ b/desktop-tauri/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-place-desktop-tauri",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "token-place-desktop-tauri",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/desktop-tauri/package.json
+++ b/desktop-tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "token-place-desktop-tauri",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop-tauri/scripts/prepare_windows_embedded_python_runtime.py
+++ b/desktop-tauri/scripts/prepare_windows_embedded_python_runtime.py
@@ -1,0 +1,111 @@
+"""Prepare the deterministic Windows x86_64 CPython + CUDA llama-cpp runtime."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC_TAURI = ROOT / "desktop-tauri" / "src-tauri"
+MANIFEST = SRC_TAURI / "python" / "embedded_python_runtime_windows_manifest.json"
+RUNTIME = SRC_TAURI / "python-runtime"
+PROVENANCE = "embedded_python_runtime_provenance.json"
+CACHE = Path(os.environ.get("TOKEN_PLACE_EMBEDDED_PYTHON_CACHE", Path.home() / ".cache" / "token-place" / "embedded-python"))
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _download(url: str, expected_sha256: str, dest: Path) -> None:
+    if not expected_sha256 or expected_sha256.startswith("TO_BE_FILLED"):
+        raise RuntimeError(f"missing immutable sha256 pin for {url}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if not dest.exists():
+        urllib.request.urlretrieve(url, dest)
+    actual = _sha256(dest)
+    if actual.lower() != expected_sha256.lower():
+        dest.unlink(missing_ok=True)
+        raise RuntimeError(f"sha256 mismatch for {dest.name}: expected {expected_sha256}, got {actual}")
+
+
+def _assert_wheel_flavor(path: Path, manifest: dict) -> None:
+    wheel = manifest["llama_cpp_python_wheel"]
+    if path.name != wheel["filename"]:
+        raise RuntimeError(f"unexpected wheel filename: {path.name}")
+    if "win_amd64" not in path.name or "0.3.32" not in path.name:
+        raise RuntimeError(f"wrong Windows/version wheel flavor: {path.name}")
+    if wheel.get("backend") != "cu124":
+        raise RuntimeError("Windows runtime manifest must pin CUDA 12.4/cu124")
+
+
+def main() -> None:
+    if platform.system() != "Windows":
+        raise RuntimeError("Windows embedded runtime preparation must run on Windows")
+    if platform.machine().lower() not in {"amd64", "x86_64"}:
+        raise RuntimeError(f"unsupported Windows architecture: {platform.machine()}")
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    if manifest["target_triple"] != "x86_64-pc-windows-msvc":
+        raise RuntimeError("wrong CPython target triple")
+    if manifest["cpython_version"] != "3.11.13":
+        raise RuntimeError("wrong CPython version")
+    wheel_meta = manifest["llama_cpp_python_wheel"]
+    if wheel_meta["version"] != manifest["required_packages"]["llama-cpp-python"]:
+        raise RuntimeError("llama-cpp-python version mismatch in manifest")
+
+    CACHE.mkdir(parents=True, exist_ok=True)
+    py_archive = CACHE / Path(manifest["archive_url"].split("/")[-1].replace("%2B", "+"))
+    wheel = CACHE / wheel_meta["filename"]
+    _download(manifest["archive_url"], manifest["sha256"], py_archive)
+    _download(wheel_meta["url"], wheel_meta["sha256"], wheel)
+    _assert_wheel_flavor(wheel, manifest)
+
+    staging = Path(tempfile.mkdtemp(prefix="token-place-win-runtime-"))
+    try:
+        with tarfile.open(py_archive, "r:gz") as tf:
+            tf.extractall(staging)
+        extracted = staging / manifest["expected_archive_root"]
+        py = extracted / manifest["expected_interpreter_path"]
+        if not py.is_file():
+            raise RuntimeError("extracted CPython runtime missing python.exe")
+        subprocess.run([str(py), "--version"], check=True)
+        subprocess.run([str(py), "-m", "pip", "install", "--no-index", "--find-links", str(wheel.parent), str(wheel)], check=True)
+        req = SRC_TAURI / "python" / "requirements_desktop_runtime.txt"
+        subprocess.run([str(py), "-m", "pip", "install", "--only-binary", ":all:", "-r", str(req)], check=True)
+        probe = "import importlib.metadata as im,platform,sys; assert sys.version_info[:2]==(3,11); assert platform.machine().lower() in ('amd64','x86_64'); assert im.version('llama-cpp-python')=='0.3.32'"
+        subprocess.run([str(py), "-c", probe], check=True)
+        with zipfile.ZipFile(wheel) as zf:
+            names = set(zf.namelist())
+        required_dll_names = {name.lower() for name in manifest["required_native_dlls"] if name.lower().startswith(("llama", "ggml"))}
+        present = {Path(name).name.lower() for name in names}
+        missing = sorted(required_dll_names - present)
+        if missing:
+            raise RuntimeError(f"llama-cpp CUDA wheel missing native DLLs: {missing}")
+        provenance = {
+            "manifest": manifest,
+            "python_archive_sha256": _sha256(py_archive),
+            "llama_cpp_python_wheel_sha256": _sha256(wheel),
+        }
+        (extracted / PROVENANCE).write_text(json.dumps(provenance, indent=2, sort_keys=True), encoding="utf-8")
+        shutil.rmtree(RUNTIME, ignore_errors=True)
+        shutil.move(str(extracted), RUNTIME)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
+++ b/desktop-tauri/src-tauri/python/desktop_gpu_packaging.py
@@ -11,6 +11,8 @@ LLAMA_CPP_PYPI_INDEX_URL = "https://pypi.org/simple"
 LLAMA_CPP_PREBUILT_WHEEL_INDEX_BASE = "https://abetlen.github.io/llama-cpp-python/whl"
 LLAMA_CPP_CPU_WHEEL_INDEX_URL = f"{LLAMA_CPP_PREBUILT_WHEEL_INDEX_BASE}/cpu"
 LLAMA_CPP_METAL_WHEEL_INDEX_URL = f"{LLAMA_CPP_PREBUILT_WHEEL_INDEX_BASE}/metal"
+LLAMA_CPP_CUDA124_WHEEL_INDEX_URL = f"{LLAMA_CPP_PREBUILT_WHEEL_INDEX_BASE}/cu124"
+LLAMA_CPP_CUDA124_WINDOWS_WHEEL = "llama_cpp_python-0.3.32-py3-none-win_amd64.whl"
 
 
 @dataclass(frozen=True)
@@ -79,11 +81,12 @@ def llama_cpp_install_plan(
             platform=detected_platform,
             backend="cuda",
             package_spec=package_spec,
-            cmake_args="-DGGML_CUDA=on",
-            force_cmake=True,
+            cmake_args=None,
+            force_cmake=False,
             index_url=LLAMA_CPP_PYPI_INDEX_URL,
-            only_binary=False,
-            no_binary=True,
+            extra_index_url=LLAMA_CPP_CUDA124_WHEEL_INDEX_URL,
+            only_binary=True,
+            no_binary=False,
         )
 
     if detected_platform == "darwin":
@@ -118,22 +121,10 @@ def llama_cpp_install_plan_fallbacks(
     plans = [primary]
 
     if primary.platform.startswith("win"):
-        # If CUDA builds are unavailable for this ABI, fall back to
-        # an unpinned CPU wheel from PyPI to keep desktop CI/release buildable
-        # without entering another native compilation path.
-        plans.append(
-            LlamaCppInstallPlan(
-                platform=primary.platform,
-                backend="cpu",
-                package_spec="llama-cpp-python",
-                cmake_args=None,
-                force_cmake=False,
-                index_url=LLAMA_CPP_PYPI_INDEX_URL,
-                extra_index_url=LLAMA_CPP_CPU_WHEEL_INDEX_URL,
-                only_binary=True,
-                no_binary=False,
-            )
-        )
+        # Windows release builds must be CUDA wheel-only. Do not fall back to CPU
+        # wheels or source builds because packaged startup must fail closed when
+        # the bundled cu124 runtime is unavailable.
+        return plans
 
     if primary.platform == "darwin":
         # Prefer a prebuilt macOS wheel first so packaged apps do not require

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -239,6 +239,7 @@ INSTALL_LOG_TAIL_MAX_CHARS = 2000
 REEXEC_GUARD_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_REEXECED"
 DISABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP"
 ENABLE_BOOTSTRAP_ENV = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP"
+ENABLE_DEVELOPMENT_SOURCE_BUILD_ENV = "TOKEN_PLACE_DESKTOP_ENABLE_DEVELOPMENT_SOURCE_BUILD"
 RUNTIME_PROBE_ENV = "TOKEN_PLACE_DESKTOP_RUNTIME_PROBE_JSON"
 PROBE_RESULT_PREFIX = b"TOKEN_PLACE_RUNTIME_PROBE_RESULT "
 PROBE_RESULT_MAX_BYTES = 1024 * 1024
@@ -1430,15 +1431,27 @@ def _runtime_bootstrap_policy() -> RuntimeBootstrapPolicy:
     )
 
 
+def _is_bundled_packaged_runtime() -> bool:
+    executable = _safe_resolve_path(sys.executable)
+    parts = {part.lower() for part in executable.parts}
+    return "python-runtime" in parts
+
+
 def _bootstrap_disabled_reason() -> Optional[str]:
     if os.getenv(DISABLE_BOOTSTRAP_ENV) == "1":
         return f"desktop runtime bootstrap disabled by {DISABLE_BOOTSTRAP_ENV}=1"
+    if _is_bundled_packaged_runtime():
+        return "packaged bundled runtime is immutable; installer/source repair disabled"
     if os.getenv(ENABLE_BOOTSTRAP_ENV) != "1":
         return (
             "desktop runtime bootstrap skipped during normal startup; set "
             f"{ENABLE_BOOTSTRAP_ENV}=1 to allow runtime repair/install"
         )
     return None
+
+
+def _development_source_build_enabled() -> bool:
+    return (not _is_bundled_packaged_runtime()) and os.getenv(ENABLE_DEVELOPMENT_SOURCE_BUILD_ENV) == "1"
 
 
 def _installed_reexec_action(backend: str) -> str:
@@ -1676,7 +1689,14 @@ def _ensure_desktop_llama_runtime_impl(
     attempted_cuda_source_build = False
     cuda_source_build_suppressed = False
     if expected_backend == "cuda":
-        should_repair, repair_skip_reason = _should_attempt_source_repair()
+        if _development_source_build_enabled():
+            should_repair, repair_skip_reason = _should_attempt_source_repair()
+        else:
+            should_repair, repair_skip_reason = (
+                False,
+                "CUDA source repair requires unbundled development layout and "
+                "TOKEN_PLACE_DESKTOP_ENABLE_DEVELOPMENT_SOURCE_BUILD=1",
+            )
         if should_repair:
             if dependency_target is None:
                 last_error = (

--- a/desktop-tauri/src-tauri/python/embedded_python_runtime_windows_manifest.json
+++ b/desktop-tauri/src-tauri/python/embedded_python_runtime_windows_manifest.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "cpython_version": "3.11.13",
+  "python_build_standalone_release": "20250818",
+  "python_build_standalone_build": "cpython-3.11.13+20250818-x86_64-pc-windows-msvc-install_only",
+  "target_triple": "x86_64-pc-windows-msvc",
+  "archive_url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250818/cpython-3.11.13%2B20250818-x86_64-pc-windows-msvc-install_only.tar.gz",
+  "sha256": "008bab1b41dd88a831477af3deb3b10f056f02e3db8313f506e21b77ff2ae660",
+  "expected_archive_root": "python",
+  "expected_interpreter_path": "python.exe",
+  "expected_architecture": "AMD64",
+  "expected_packaged_runtime_path": "resources/python-runtime/python.exe",
+  "llama_cpp_python_wheel": {
+    "version": "0.3.32",
+    "backend": "cu124",
+    "filename": "llama_cpp_python-0.3.32-py3-none-win_amd64.whl",
+    "url": "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.32-cu124/llama_cpp_python-0.3.32-py3-none-win_amd64.whl",
+    "sha256": "c2149da0ff1af565418f27a9d11e88ed66732b3e2c46023e5d5dc0e30678fdc0"
+  },
+  "required_packages": {
+    "psutil": "7.1.0",
+    "requests": "2.32.5",
+    "python-dotenv": "1.1.1",
+    "cryptography": "46.0.1",
+    "Jinja2": "3.1.6",
+    "numpy": "2.3.3",
+    "diskcache": "5.6.3",
+    "llama-cpp-python": "0.3.32"
+  },
+  "required_native_dlls": [
+    "python311.dll",
+    "vcruntime140.dll",
+    "llama.dll",
+    "ggml.dll",
+    "ggml-cuda.dll"
+  ]
+}

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -5,7 +5,11 @@ use crate::backend::ComputeMode;
 
 pub const ENABLE_RUNTIME_BOOTSTRAP_ENV: &str = "TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP";
 pub const DISABLE_RUNTIME_BOOTSTRAP_ENV: &str = "TOKEN_PLACE_DESKTOP_DISABLE_RUNTIME_BOOTSTRAP";
-pub const BUNDLED_RUNTIME_RELATIVE_PYTHON: &str = "python-runtime/bin/python3";
+pub const BUNDLED_RUNTIME_RELATIVE_PYTHON: &str = if cfg!(target_os = "windows") {
+    "python-runtime/python.exe"
+} else {
+    "python-runtime/bin/python3"
+};
 pub const DESKTOP_PYTHON_RUNTIME_MISSING: &str = "desktop_python_runtime_missing";
 pub const DESKTOP_PYTHON_RUNTIME_INVALID: &str = "desktop_python_runtime_invalid";
 pub const DESKTOP_PYTHON_OVERRIDE_INVALID: &str = "desktop_python_override_invalid";
@@ -116,7 +120,7 @@ pub struct PythonLauncherError {
 
 impl std::fmt::Display for PythonLauncherError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} category={} source={:?} executable={} expected_python=3.11 expected_arch=arm64 packaged={}{}",
+        write!(f, "{} category={} source={:?} executable={} expected_python=3.11 expected_arch=target packaged={}{}",
             self.public_code, self.category.as_str(), self.source, self.executable_basename, self.packaged,
             self.exit_status.map(|s| format!(" exit_status={s}")).unwrap_or_default())
     }
@@ -217,13 +221,17 @@ fn json_string_field<'a>(payload: &'a str, key: &str) -> Option<&'a str> {
 fn metadata_probe_is_valid(
     stdout: &str,
     runtime_root: &Path,
-    expected_machine: &str,
+    expected_machines: &[&str],
 ) -> Result<(), PythonLauncherCategory> {
     let payload = stdout.trim();
     if !(payload.contains("\"version\"") && payload.contains("[3, 11]")) {
         return Err(PythonLauncherCategory::BundledRuntimeNotPython3);
     }
-    if json_string_field(payload, "machine") != Some(expected_machine) {
+    let machine = json_string_field(payload, "machine").unwrap_or("");
+    if !expected_machines
+        .iter()
+        .any(|expected| machine.eq_ignore_ascii_case(expected))
+    {
         return Err(PythonLauncherCategory::BundledRuntimeWrongArchitecture);
     }
     let runtime_root = runtime_root
@@ -393,25 +401,38 @@ fn bundled_runtime_candidate(opts: &PythonLauncherResolutionOptions<'_>) -> Opti
             .into_iter()
             .find(|c| {
                 c.layout == ResourceLayoutKind::MacOsAppResources
+                    || c.layout == ResourceLayoutKind::WindowsResources
                     || c.layout == ResourceLayoutKind::DevSourceTree
             })
             .map(|c| c.root)
     }?;
+    let runtime_id = if cfg!(target_os = "windows") {
+        "bundled-cpython-3.11-win-amd64-cu124"
+    } else {
+        "bundled-cpython-3.11-arm64"
+    };
     Some(PythonLauncher::new(
         root.join(BUNDLED_RUNTIME_RELATIVE_PYTHON)
             .to_string_lossy()
             .to_string(),
         vec![],
         PythonLauncherSource::BundledRuntime,
-        "bundled-cpython-3.11-arm64",
+        runtime_id,
     ))
 }
 
 fn bundled_runtime_root_from_candidate(candidate: &PythonLauncher) -> Option<PathBuf> {
-    Path::new(&candidate.program)
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
+    let path = Path::new(&candidate.program);
+    if cfg!(target_os = "windows")
+        || path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(|name| name.eq_ignore_ascii_case("python.exe"))
+            .unwrap_or(false)
+    {
+        return path.parent().map(Path::to_path_buf);
+    }
+    path.parent().and_then(Path::parent).map(Path::to_path_buf)
 }
 
 pub fn resolve_python_launcher_resource_aware(
@@ -437,7 +458,14 @@ pub fn resolve_python_launcher_resource_aware(
             .current_exe_path
             .map(|p| p.components().any(|c| c.as_os_str() == "Contents"))
             .unwrap_or(false);
-    if is_macos {
+    let is_windows = cfg!(target_os = "windows")
+        || opts
+            .current_exe_path
+            .and_then(|p| p.extension())
+            .and_then(|s| s.to_str())
+            .map(|ext| ext.eq_ignore_ascii_case("exe"))
+            .unwrap_or(false);
+    if is_macos || is_windows {
         if let Some(candidate) = bundled_runtime_candidate(&opts) {
             if !Path::new(&candidate.program).exists() {
                 if opts.packaged {
@@ -489,17 +517,25 @@ pub fn resolve_python_launcher_resource_aware(
                                     output_status_code(&output),
                                 )
                             })?;
-                        metadata_probe_is_valid(&stdout, &runtime_root, "arm64")
-                            .map(|_| candidate.clone())
-                            .map_err(|category| {
-                                launcher_error(
-                                    DESKTOP_PYTHON_RUNTIME_INVALID,
-                                    category,
-                                    Some(&candidate),
-                                    opts.packaged,
-                                    output_status_code(&output),
-                                )
-                            })
+                        metadata_probe_is_valid(
+                            &stdout,
+                            &runtime_root,
+                            if is_windows {
+                                &["AMD64", "x86_64"]
+                            } else {
+                                &["arm64", "aarch64"]
+                            },
+                        )
+                        .map(|_| candidate.clone())
+                        .map_err(|category| {
+                            launcher_error(
+                                DESKTOP_PYTHON_RUNTIME_INVALID,
+                                category,
+                                Some(&candidate),
+                                opts.packaged,
+                                output_status_code(&output),
+                            )
+                        })
                     }
                     Err(_) => Err(launcher_error(
                         if opts.packaged {
@@ -1365,6 +1401,24 @@ mod tests {
         .expect("bundled runtime");
         assert_eq!(launcher.source, PythonLauncherSource::BundledRuntime);
         assert_eq!(Path::new(&launcher.program), py.as_path());
+    }
+
+    #[test]
+    fn packaged_windows_layout_fails_closed_without_system_python_fallback() {
+        let temp = TempDir::new().expect("tempdir");
+        let exe = temp.path().join("App").join("token.place.exe");
+        std::fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        let err = resolve_python_launcher_resource_aware(PythonLauncherResolutionOptions {
+            override_var_name: "TOKEN_PLACE_TEST_PYTHON_NOT_SET",
+            tauri_resource_dir: None,
+            current_exe_path: Some(&exe),
+            manifest_dir: temp.path(),
+            packaged: true,
+        })
+        .expect_err("packaged Windows must not fall back to py/python");
+        assert_eq!(err.public_code, DESKTOP_PYTHON_RUNTIME_MISSING);
+        assert_eq!(err.source, PythonLauncherSource::BundledRuntime);
+        assert_ne!(err.executable_basename, "py");
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "token.place desktop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "place.token.desktop",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/tests/unit/test_desktop_gpu_packaging.py
+++ b/tests/unit/test_desktop_gpu_packaging.py
@@ -13,6 +13,7 @@ from desktop_gpu_packaging import (
     LlamaCppInstallPlan,
     LLAMA_CPP_CPU_WHEEL_INDEX_URL,
     LLAMA_CPP_METAL_WHEEL_INDEX_URL,
+    LLAMA_CPP_CUDA124_WHEEL_INDEX_URL,
     backend_probe_satisfies_install_plan,
     llama_cpp_install_plan,
     llama_cpp_install_plan_fallbacks,
@@ -20,25 +21,21 @@ from desktop_gpu_packaging import (
 )
 
 
-def test_windows_install_plan_requests_cuda_then_cpu_fallback():
+def test_windows_install_plan_requests_cuda_cu124_wheel_only_without_fallback():
     plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
-    assert len(plans) == 2
+    assert len(plans) == 1
 
     gpu_plan = plans[0]
     assert gpu_plan.backend == "cuda"
-    assert gpu_plan.package_spec.startswith("llama-cpp-python==")
+    assert gpu_plan.package_spec == "llama-cpp-python==0.3.32"
     assert gpu_plan.index_url == "https://pypi.org/simple"
-    assert gpu_plan.only_binary is False
-    assert gpu_plan.no_binary is True
-    assert gpu_plan.pip_env() == {"CMAKE_ARGS": "-DGGML_CUDA=on", "FORCE_CMAKE": "1"}
-
-    cpu_fallback = plans[1]
-    assert cpu_fallback.backend == "cpu"
-    assert cpu_fallback.package_spec == "llama-cpp-python"
-    assert cpu_fallback.index_url == "https://pypi.org/simple"
-    assert cpu_fallback.extra_index_url == LLAMA_CPP_CPU_WHEEL_INDEX_URL
-    assert cpu_fallback.only_binary is True
-    assert cpu_fallback.no_binary is False
+    assert gpu_plan.extra_index_url == LLAMA_CPP_CUDA124_WHEEL_INDEX_URL
+    assert gpu_plan.only_binary is True
+    assert gpu_plan.no_binary is False
+    assert gpu_plan.pip_env() == {}
+    args = gpu_plan.pip_install_args()
+    assert "--no-binary" not in args
+    assert "--only-binary" in args
 
 
 def test_macos_install_plan_requests_metal_then_cpu_fallback():
@@ -166,17 +163,17 @@ def test_llama_cpp_install_plan_uses_current_platform_by_default(monkeypatch):
     assert plan.backend == "cpu"
 
 
-def test_windows_cpu_fallback_install_args_only_accept_wheels():
+def test_windows_cuda_install_args_only_accept_cu124_wheels():
     plans = llama_cpp_install_plan_fallbacks(platform="win32", requirements_path=ROOT / "requirements.txt")
-    cpu_fallback = plans[1]
+    cuda_plan = plans[0]
 
-    assert cpu_fallback.pip_install_args() == [
+    assert cuda_plan.pip_install_args() == [
         "--upgrade",
         "--no-cache-dir",
         "--index-url",
         "https://pypi.org/simple",
         "--extra-index-url",
-        LLAMA_CPP_CPU_WHEEL_INDEX_URL,
+        LLAMA_CPP_CUDA124_WHEEL_INDEX_URL,
         "--only-binary",
         "llama-cpp-python",
         "--prefer-binary",
@@ -234,8 +231,9 @@ def test_llama_cpp_install_plan_uses_current_platform_for_windows(monkeypatch):
 
     assert plan.platform == "win32"
     assert plan.backend == "cuda"
-    assert plan.only_binary is False
-    assert plan.no_binary is True
+    assert plan.only_binary is True
+    assert plan.no_binary is False
+    assert plan.extra_index_url == LLAMA_CPP_CUDA124_WHEEL_INDEX_URL
 
 
 def test_llama_cpp_install_plan_darwin_selects_metal_plan_with_pypi_index():
@@ -328,3 +326,16 @@ def test_backend_probe_rejects_macos_metal_source_build_when_probe_errors():
     probe = SimpleNamespace(backend="missing", llama_module_path="missing", error="import failed")
 
     assert backend_probe_satisfies_install_plan(plan, probe) is False
+
+
+def test_windows_release_plan_never_emits_source_build_markers():
+    plan = llama_cpp_install_plan(platform="win32", requirements_path=ROOT / "requirements.txt")
+    args = plan.pip_install_args()
+    env = plan.pip_env()
+
+    assert plan.backend == "cuda"
+    assert plan.only_binary is True
+    assert plan.no_binary is False
+    assert "--no-binary" not in args
+    assert "FORCE_CMAKE" not in env
+    assert "CMAKE_ARGS" not in env


### PR DESCRIPTION
### Motivation

- Packaged Windows startup was still probing the host `py`/system Python and entering a bounded CUDA source build for `llama-cpp-python==0.3.32`, which forced end users to have system Python/pip/CMake/MSVC/CUDA tooling available during startup.
- The release must instead ship an immutable, pinned Win11 x86-64 CPython runtime with the exact CUDA 12.4 wheel so packaged builds never perform network/pip/source compilation at runtime and fail closed if the bundled runtime is missing or invalid.
- The change enforces deterministic provisioning, preserves E2EE and API v1 invariants, and ensures packaged Windows artifacts report the `desktop-v0.1.2` release metadata consistently.

### Description

- Bundle and prepare a pinned Windows embedded runtime by adding `desktop-tauri/src-tauri/python/embedded_python_runtime_windows_manifest.json` and a release-time preparation script `desktop-tauri/scripts/prepare_windows_embedded_python_runtime.py` that downloads CPython and the `llama_cpp_python-0.3.32-py3-none-win_amd64.whl` cu124 wheel with SHA-256 validation and stages `src-tauri/python-runtime` for bundling. (files changed/added: `desktop-tauri/scripts/prepare_windows_embedded_python_runtime.py`, `desktop-tauri/src-tauri/python/embedded_python_runtime_windows_manifest.json`).
- Make Windows wheel-only provisioning deterministic by switching the Windows install plan to the cu124 wheel-only index and removing `--no-binary`/`FORCE_CMAKE`/CMAKE build-env for release plans, and update packaging helpers and tests accordingly. (file changed: `desktop-tauri/src-tauri/python/desktop_gpu_packaging.py`, tests updated: `tests/unit/test_desktop_gpu_packaging.py`).
- Require the bundled interpreter in packaged Windows builds and validate it, extending Rust launcher logic to detect `python-runtime/python.exe`, probe metadata for Python 3.11 and x86_64, fail closed when the bundled runtime is missing/invalid, and add a unit test that packaged Windows layouts do not fall back to `py`. (file changed: `desktop-tauri/src-tauri/src/python_runtime.rs`, test additions in same file).
- Prevent automatic CUDA source repair in normal packaged startup by making bundled runtimes immutable and gating development-only source builds behind `TOKEN_PLACE_DESKTOP_ENABLE_DEVELOPMENT_SOURCE_BUILD=1` and an unbundled layout, plus update the release workflow to prepare/cache the Windows runtime and bump Tauri/package metadata to `0.1.2`. (files changed: `desktop-tauri/src-tauri/python/desktop_runtime_setup.py`, `.github/workflows/desktop-release.yml`, `desktop-tauri/package.json`, `desktop-tauri/package-lock.json`, `desktop-tauri/src-tauri/tauri.conf.json`).

### Testing

- Ran package-plan unit tests with `pytest -q tests/unit/test_desktop_gpu_packaging.py` and they passed (all tests in that module passed), which verifies the Windows plan is cu124 wheel-only and that `--no-binary`/`FORCE_CMAKE` markers are absent for release plans. 
- Verified Python-side compile sanity with `python -m py_compile desktop-tauri/src-tauri/python/desktop_runtime_setup.py desktop-tauri/scripts/prepare_windows_embedded_python_runtime.py`, and the files compiled successfully. 
- Validated Rust formatting with `cargo fmt --manifest-path desktop-tauri/src-tauri/Cargo.toml` (passed), and ran the Rust python_runtime unit tests locally where `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml python_runtime -- --nocapture` was blocked in this environment due to missing system `glib-2.0.pc`/`PKG_CONFIG_PATH` on the Linux runner. 
- Executed `git diff --check` and `pre-commit run --all-files` (pre-commit hooks ran through vulture/bandit and initial hooks passed, but the project checks hook was interrupted in this environment to avoid a long-running operation). 

Proof that packaged Windows path cannot invoke `cuda_build`:

- The Windows install plan was changed to a wheel-only plan (`only_binary=True`, `no_binary=False`, `extra_index_url` set to the cu124 wheel index) and all tests assert the plan does not include `--no-binary` or `FORCE_CMAKE`; the new unit test `test_windows_release_plan_never_emits_source_build_markers` asserts `"--no-binary" not in args` and `"FORCE_CMAKE" not in env`, which proves the normal packaged Windows plan cannot enter the `cuda_build` source path. 

Artifact inspection and metadata:

- Added manifest `desktop-tauri/src-tauri/python/embedded_python_runtime_windows_manifest.json` and staging script `desktop-tauri/scripts/prepare_windows_embedded_python_runtime.py` that record pinned URLs and SHA-256s and validate the wheel/DLL closure; these files are the provenance inputs for the release prep step. 
- Updated `.github/workflows/desktop-release.yml` to cache and prepare the Windows embedded runtime before Tauri bundling so NSIS/MSI artifacts include `src-tauri/python-runtime` via Tauri resources. 
- Confirmed package/version metadata were bumped to `0.1.2` in `desktop-tauri/package.json`, `desktop-tauri/package-lock.json`, and `desktop-tauri/src-tauri/tauri.conf.json`, so generated Windows filenames/internal package versions will report `0.1.2` for `desktop-v0.1.2` artifacts.

Remaining validation required on real NVIDIA hardware:

- A Win11 x86-64 NVIDIA/RTX smoke gate must run the produced NSIS/MSI installers and validate live behavior: that `qwen3 8B Q4 K_M` at `64k-full` uses CUDA offload (not CPU), positive GPU offload is observed, KV and non-CPU behavior are correct, the runtime registers with the relay, and there is no runtime fallback to CPU or model negotiation. 
- Release-prep must be executed in Windows CI to produce the actual `src-tauri/python-runtime` bundle and validate the prepared artifacts (wheel/CPython archive SHA-256 checks and presence of native DLLs) before publishing the installers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59c4ebe914832fb24b93bc0db3a764)