### PR TITLE
Add API v1 relay control: request deadlines, owner-only control route, and cancellation tombstones

### DIFF
--- a/docs/architecture/api_v1_compute_control.md
+++ b/docs/architecture/api_v1_compute_control.md
@@ -1,0 +1,41 @@
+# API v1 compute-control request status contract
+
+The relay exposes a narrow internal compute-control operation at
+`POST /api/v1/relay/requests/control` for API v1 compute nodes that already own
+an in-flight encrypted request. The route is not a user-facing API and does not
+change the frozen non-streaming API v1 final-response contract.
+
+## Authentication and ownership
+
+Compute-control requests use the same relay server-registration token validation
+as API v1 register, unregister, poll, and response submission routes. A control
+poll must include the registered `server_public_key` and a `request_id`; the
+relay returns active or cancellation state only when that exact registered server
+currently owns the request or has an unacknowledged owner-visible tombstone for
+that request.
+
+Server registration heartbeat state remains separate from per-request in-flight
+ownership. A valid control poll may renew the per-request in-flight accounting
+lease, but it never extends the absolute request deadline established at relay
+admission.
+
+## Response body
+
+The response is intentionally bounded and privacy-safe. It returns only:
+
+- `status`: one of `active`, `cancelled`, `expired`, or `completed/unavailable`.
+- `deadline_unix_ms` / `request_deadline_unix_ms` when known.
+- `remaining_ttl_seconds` when a deadline is known.
+- `next_poll_seconds`, a bounded polling hint.
+
+The relay must not include ciphertext, plaintext prompts, client keys, cancel
+proofs, encrypted payload bodies, tool arguments, or model output in this
+contract, logs, or metrics.
+
+## Tombstone acknowledgement
+
+When a requester cancels an in-flight request, the relay removes the active
+in-flight owner entry and keeps a short-lived tombstone visible only to the
+owning compute server. The compute server may send `acknowledge: true` to clean
+up that tombstone after observing the cancellation. Tombstones also expire after
+a bounded relay-side TTL.

--- a/relay.py
+++ b/relay.py
@@ -549,6 +549,14 @@ RELAY_REQUEST_OUTCOMES_TOTAL = _collector(
     "tokenplace_relay_request_outcomes_total",
     lambda: Counter("tokenplace_relay_request_outcomes_total", "Terminal relay request outcomes by fixed enum.", ["outcome"], registry=RELAY_METRICS_REGISTRY),
 )
+RELAY_CONTROL_REQUESTS_TOTAL = _collector(
+    "tokenplace_relay_control_requests_total",
+    lambda: Counter("tokenplace_relay_control_requests_total", "Privacy-safe API v1 compute-control observations by fixed state.", ["state"], registry=RELAY_METRICS_REGISTRY),
+)
+RELAY_CONTROL_LEASE_RENEWALS_TOTAL = _collector(
+    "tokenplace_relay_control_lease_renewals_total",
+    lambda: Counter("tokenplace_relay_control_lease_renewals_total", "API v1 in-flight request lease renewals from authenticated owner control polls.", registry=RELAY_METRICS_REGISTRY),
+)
 BUILD_INFO = _collector(
     "tokenplace_build_info",
     lambda: Gauge("tokenplace_build_info", "token.place build metadata.", ["version", "revision"], registry=RELAY_METRICS_REGISTRY),
@@ -565,6 +573,8 @@ def _initialise_metric_labels() -> None:
         return
     for outcome in OUTCOME_ENUM:
         RELAY_REQUEST_OUTCOMES_TOTAL.labels(outcome)
+    for state in ("active", "cancelled", "expired", "acknowledged", "completed_unavailable"):
+        RELAY_CONTROL_REQUESTS_TOTAL.labels(state)
     for reason in EVICTION_REASON_ENUM:
         COMPUTE_NODE_EVICTIONS_TOTAL.labels(reason)
     RELAY_QUEUE_DEPTH.labels("relay").set(0)
@@ -616,6 +626,7 @@ def _normalise_http_route() -> str:
         "api_v1_relay_servers_register": "/api/v1/relay/servers/register",
         "api_v1_relay_servers_unregister": "/api/v1/relay/servers/unregister",
         "api_v1_relay_servers_poll": "/api/v1/relay/servers/poll",
+        "api_v1_relay_requests_control": "/api/v1/relay/requests/control",
         "api_v1_relay_servers_next": "/api/v1/relay/servers/next",
         "healthz": "/healthz",
         "livez": "/livez",
@@ -847,6 +858,8 @@ PENDING_REQUEST_TTL_SECONDS = float(os.getenv("TOKENPLACE_PENDING_REQUEST_TTL_SE
 client_inference_requests_lock = threading.Lock()
 client_inference_requests_changed = threading.Condition(client_inference_requests_lock)
 api_v1_in_flight_requests_lock = threading.Lock()
+api_v1_control_tombstones: dict[str, dict[str, dict[str, Any]]] = {}
+api_v1_control_tombstones_lock = threading.Lock()
 streaming_sessions = {}
 streaming_sessions_by_client = {}
 stream_lock = threading.Lock()
@@ -859,6 +872,13 @@ DEFAULT_API_V1_POLL_WAIT_SECONDS = 10
 API_V1_LEASE_SECONDS_ENV = "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS"
 DEFAULT_API_V1_LEASE_SECONDS = 30
 API_V1_IN_FLIGHT_TTL_SECONDS_ENV = "TOKEN_PLACE_API_V1_IN_FLIGHT_TTL_SECONDS"
+API_V1_REQUEST_DEADLINE_SECONDS_ENV = "TOKEN_PLACE_API_V1_REQUEST_DEADLINE_SECONDS"
+API_V1_REQUEST_DEADLINE_MIN_SECONDS_ENV = "TOKEN_PLACE_API_V1_REQUEST_DEADLINE_MIN_SECONDS"
+API_V1_REQUEST_DEADLINE_MAX_SECONDS_ENV = "TOKEN_PLACE_API_V1_REQUEST_DEADLINE_MAX_SECONDS"
+DEFAULT_API_V1_REQUEST_DEADLINE_SECONDS = 300.0
+API_V1_CONTROL_TOMBSTONE_TTL_SECONDS = 60.0
+API_V1_CONTROL_NEXT_POLL_MIN_SECONDS = 1.0
+API_V1_CONTROL_NEXT_POLL_MAX_SECONDS = 30.0
 API_V1_MAX_QUEUE_DEPTH_ENV = "TOKEN_PLACE_API_V1_MAX_QUEUE_DEPTH_PER_NODE"
 DEFAULT_CONTEXT_TIER = "8k-fast"
 MAX_API_V1_MODEL_IDS_PER_NODE = 64
@@ -909,6 +929,37 @@ def _api_v1_lease_seconds() -> int:
     return max(value, 1)
 
 
+
+def _api_v1_request_deadline_seconds() -> float:
+    def _float_env(name: str, default: float) -> float:
+        try:
+            return float(os.environ.get(name, str(default)))
+        except ValueError:
+            return default
+
+    minimum = max(_float_env(API_V1_REQUEST_DEADLINE_MIN_SECONDS_ENV, 1.0), 1.0)
+    maximum = max(_float_env(API_V1_REQUEST_DEADLINE_MAX_SECONDS_ENV, DEFAULT_API_V1_REQUEST_DEADLINE_SECONDS), minimum)
+    requested = _float_env(API_V1_REQUEST_DEADLINE_SECONDS_ENV, DEFAULT_API_V1_REQUEST_DEADLINE_SECONDS)
+    return min(max(requested, minimum), maximum)
+
+
+def _api_v1_deadline_metadata(deadline_wall: Any, *, now: float | None = None) -> dict[str, Any]:
+    if not isinstance(deadline_wall, (int, float)):
+        return {}
+    now = time.time() if now is None else now
+    remaining = max(float(deadline_wall) - now, 0.0)
+    deadline_ms = int(float(deadline_wall) * 1000)
+    return {
+        "deadline_unix_ms": deadline_ms,
+        "request_deadline_unix_ms": deadline_ms,
+        "remaining_ttl_seconds": round(remaining, 3),
+    }
+
+
+def _api_v1_control_next_poll_hint(remaining_ttl: float | None) -> float:
+    if remaining_ttl is None:
+        return API_V1_CONTROL_NEXT_POLL_MAX_SECONDS
+    return round(min(max(remaining_ttl, API_V1_CONTROL_NEXT_POLL_MIN_SECONDS), API_V1_CONTROL_NEXT_POLL_MAX_SECONDS), 3)
 
 
 def _api_v1_max_queue_depth_per_node() -> int:
@@ -1161,8 +1212,19 @@ def _pop_next_api_v1_request(public_key: str):
     def _is_legacy_ciphertext_payload(payload):
         return all(key in payload for key in ('client_public_key', 'chat_history', 'cipherkey', 'iv'))
 
-    for idx, candidate in enumerate(queued_requests):
+    for idx, candidate in enumerate(list(queued_requests)):
         if bool(candidate.get('e2ee_v1')):
+            deadline_unix_ms = candidate.get('deadline_unix_ms')
+            if isinstance(deadline_unix_ms, (int, float)) and time.time() * 1000 >= float(deadline_unix_ms):
+                queued_requests.pop(idx)
+                _clear_pending_request(candidate.get('client_public_key'), candidate.get('request_id'))
+                _mark_request_terminal(
+                    candidate.get('client_public_key'),
+                    candidate.get('request_id'),
+                    status='expired',
+                    reason='expired',
+                )
+                return None
             first_request = queued_requests.pop(idx)
             break
 
@@ -2083,6 +2145,7 @@ _ALLOWED_API_V1_TERMINAL_REASONS = {
     "provider_timeout",
     "pending_request_ttl_exceeded",
     "server_unregistered",
+    "client_timeout",
 }
 
 
@@ -2254,9 +2317,17 @@ def _cancel_api_v1_request(client_public_key, request_id, *, status="cancelled",
                     in_flight_requests = server_payload.get("api_v1_in_flight_requests")
                     if not isinstance(in_flight_requests, dict) or request_id not in in_flight_requests:
                         continue
-                    if _in_flight_entry_matches_client(in_flight_requests.get(request_id), client_public_key):
+                    entry = in_flight_requests.get(request_id)
+                    if _in_flight_entry_matches_client(entry, client_public_key):
                         in_flight_requests.pop(request_id, None)
                         in_flight_removed += 1
+                        tombstone = dict(entry) if isinstance(entry, dict) else {}
+                        tombstone.update({"status": status, "reason": reason})
+                        _store_api_v1_control_tombstone(
+                            server_payload.get('public_key'),
+                            request_id,
+                            tombstone,
+                        )
                         if not in_flight_requests:
                             server_payload.pop("api_v1_in_flight_requests", None)
         lifecycle_removed = bool(removed or pending_removed or in_flight_removed)
@@ -2279,7 +2350,50 @@ def _cancel_api_v1_request(client_public_key, request_id, *, status="cancelled",
     return removed
 
 
-def _mark_request_pending(client_public_key, request_id, *, cancel_token=None):
+def _prune_api_v1_control_tombstones(*, now: float | None = None) -> None:
+    now = time.time() if now is None else now
+    with api_v1_control_tombstones_lock:
+        for server_public_key, requests in list(api_v1_control_tombstones.items()):
+            if not isinstance(requests, dict):
+                api_v1_control_tombstones.pop(server_public_key, None)
+                continue
+            for request_id, tombstone in list(requests.items()):
+                expires_at = tombstone.get("tombstone_expires_at") if isinstance(tombstone, dict) else None
+                if not isinstance(expires_at, (int, float)) or expires_at <= now:
+                    requests.pop(request_id, None)
+            if not requests:
+                api_v1_control_tombstones.pop(server_public_key, None)
+
+
+def _store_api_v1_control_tombstone(server_public_key: Any, request_id: Any, tombstone: dict[str, Any]) -> None:
+    if not isinstance(server_public_key, str) or not server_public_key or not isinstance(request_id, str) or not request_id:
+        return
+    safe = {
+        "request_id": request_id,
+        "status": _sanitize_terminal_status(tombstone.get("status")),
+        "reason": _sanitize_terminal_reason(tombstone.get("reason"), tombstone.get("status")),
+        "deadline_unix_ms": tombstone.get("deadline_unix_ms"),
+        "request_deadline_unix_ms": tombstone.get("request_deadline_unix_ms"),
+        "tombstone_expires_at": time.time() + API_V1_CONTROL_TOMBSTONE_TTL_SECONDS,
+    }
+    _prune_api_v1_control_tombstones()
+    with api_v1_control_tombstones_lock:
+        api_v1_control_tombstones.setdefault(server_public_key, {})[request_id] = safe
+
+
+def _pop_api_v1_control_tombstone(server_public_key: str, request_id: str) -> dict[str, Any] | None:
+    _prune_api_v1_control_tombstones()
+    with api_v1_control_tombstones_lock:
+        requests = api_v1_control_tombstones.get(server_public_key)
+        if not isinstance(requests, dict):
+            return None
+        tombstone = requests.pop(request_id, None)
+        if not requests:
+            api_v1_control_tombstones.pop(server_public_key, None)
+        return tombstone if isinstance(tombstone, dict) else None
+
+
+def _mark_request_pending(client_public_key, request_id, *, cancel_token=None, deadline_unix_ms=None):
     if not client_public_key or not request_id:
         return
     with client_pending_request_ids_lock:
@@ -2288,9 +2402,10 @@ def _mark_request_pending(client_public_key, request_id, *, cancel_token=None):
             pending_ids[request_id] = {
                 "queued_at": time.time(),
                 "cancel_token": cancel_token,
+                "deadline_unix_ms": deadline_unix_ms,
             }
         else:
-            pending_ids[request_id] = time.time()
+            pending_ids[request_id] = {"queued_at": time.time(), "deadline_unix_ms": deadline_unix_ms}
 
 
 def _clear_pending_request(client_public_key, request_id):
@@ -2321,6 +2436,10 @@ def _pending_request_entry_is_expired(pending_entry, *, now=None):
     if PENDING_REQUEST_TTL_SECONDS <= 0:
         return False
     now = time.time() if now is None else now
+    if isinstance(pending_entry, dict):
+        deadline_unix_ms = pending_entry.get("deadline_unix_ms")
+        if isinstance(deadline_unix_ms, (int, float)) and now * 1000 >= float(deadline_unix_ms):
+            return True
     queued_at = pending_entry.get("queued_at") if isinstance(pending_entry, dict) else pending_entry
     try:
         return (now - float(queued_at)) > PENDING_REQUEST_TTL_SECONDS
@@ -2644,6 +2763,8 @@ def api_v1_relay_servers_poll():
                             'started_at_monotonic': time.monotonic(),
                             'client_public_key': first_request.get('client_public_key'),
                             'cancel_token': first_request.get('cancel_token'),
+                            'deadline_unix_ms': first_request.get('deadline_unix_ms'),
+                            'request_deadline_unix_ms': first_request.get('request_deadline_unix_ms'),
                         }
         if server_missing:
             return _server_not_found_response(first_request)
@@ -2678,6 +2799,8 @@ def api_v1_relay_requests():
 
     envelope['e2ee_v1'] = True
     queued_at = time.time()
+    deadline_wall = queued_at + _api_v1_request_deadline_seconds()
+    envelope.update(_api_v1_deadline_metadata(deadline_wall, now=queued_at))
     envelope['_queued_at'] = queued_at
     with server_round_robin_lock:
         server_payload = known_servers.get(server_public_key)
@@ -2687,6 +2810,7 @@ def api_v1_relay_requests():
             envelope.get('client_public_key'),
             envelope.get('request_id'),
             cancel_token=envelope.get('cancel_token'),
+            deadline_unix_ms=envelope.get('deadline_unix_ms'),
         )
         with client_inference_requests_changed:
             client_inference_requests.setdefault(server_public_key, []).append(envelope)
@@ -2699,8 +2823,79 @@ def api_v1_relay_requests():
             "queue_depth": queue_depth,
         },
     )
-    return jsonify({'message': 'Request received'}), 200
+    return jsonify({'message': 'Request received', **_api_v1_deadline_metadata(deadline_wall, now=queued_at)}), 200
 
+
+@app.route('/api/v1/relay/requests/control', methods=['POST'])
+def api_v1_relay_requests_control():
+    """Authenticated owner-only compute control poll for one in-flight API v1 request."""
+    auth_error = _validate_server_registration()
+    if auth_error:
+        return auth_error
+
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({'error': {'message': 'Invalid request data', 'code': 400}}), 400
+    server_public_key = data.get('server_public_key')
+    request_id = data.get('request_id')
+    if not isinstance(server_public_key, str) or not server_public_key or not isinstance(request_id, str) or not request_id:
+        return jsonify({'error': {'message': 'Invalid request data', 'code': 400}}), 400
+
+    ack = bool(data.get('acknowledge'))
+    now_mono = time.monotonic()
+    now_wall = time.time()
+    lease_seconds = _api_v1_in_flight_ttl_seconds()
+    client_key = None
+    with server_round_robin_lock:
+        server_payload = known_servers.get(server_public_key)
+        if not isinstance(server_payload, dict) or not bool(server_payload.get(API_V1_SERVER_MARKER)):
+            RELAY_CONTROL_REQUESTS_TOTAL.labels('completed_unavailable').inc()
+            return jsonify({'status': 'completed/unavailable', 'next_poll_seconds': API_V1_CONTROL_NEXT_POLL_MAX_SECONDS}), 404
+        with api_v1_in_flight_requests_lock:
+            in_flight_requests = server_payload.get('api_v1_in_flight_requests')
+            entry = in_flight_requests.get(request_id) if isinstance(in_flight_requests, dict) else None
+            if isinstance(entry, dict):
+                deadline_unix_ms = entry.get('deadline_unix_ms') or entry.get('request_deadline_unix_ms')
+                remaining = None
+                if isinstance(deadline_unix_ms, (int, float)):
+                    remaining = max((float(deadline_unix_ms) / 1000.0) - now_wall, 0.0)
+                    if remaining > 0:
+                        entry['expires_at'] = now_mono + lease_seconds
+                        RELAY_CONTROL_LEASE_RENEWALS_TOTAL.inc()
+                        RELAY_CONTROL_REQUESTS_TOTAL.labels('active').inc()
+                        return jsonify({
+                            'status': 'active',
+                            'remaining_ttl_seconds': round(remaining, 3),
+                            'deadline_unix_ms': deadline_unix_ms,
+                            'request_deadline_unix_ms': deadline_unix_ms,
+                            'next_poll_seconds': _api_v1_control_next_poll_hint(remaining),
+                        }), 200
+                client_key = entry.get('client_public_key')
+    if client_key:
+        _cancel_api_v1_request(client_key, request_id, status='expired', reason='expired')
+
+    tombstone = _pop_api_v1_control_tombstone(server_public_key, request_id) if ack else None
+    if tombstone is None:
+        _prune_api_v1_control_tombstones()
+        with api_v1_control_tombstones_lock:
+            server_tombstones = api_v1_control_tombstones.get(server_public_key, {})
+            tombstone = server_tombstones.get(request_id) if isinstance(server_tombstones, dict) else None
+    if isinstance(tombstone, dict):
+        status = tombstone.get('status', 'cancelled')
+        control_status = 'expired' if status == 'expired' else 'cancelled'
+        RELAY_CONTROL_REQUESTS_TOTAL.labels('acknowledged' if ack else control_status).inc()
+        deadline_unix_ms = tombstone.get('deadline_unix_ms') or tombstone.get('request_deadline_unix_ms')
+        remaining = max((float(deadline_unix_ms) / 1000.0) - now_wall, 0.0) if isinstance(deadline_unix_ms, (int, float)) else None
+        return jsonify({
+            'status': control_status,
+            'remaining_ttl_seconds': round(remaining, 3) if remaining is not None else None,
+            'deadline_unix_ms': deadline_unix_ms,
+            'request_deadline_unix_ms': deadline_unix_ms,
+            'next_poll_seconds': _api_v1_control_next_poll_hint(remaining),
+        }), 200
+
+    RELAY_CONTROL_REQUESTS_TOTAL.labels('completed_unavailable').inc()
+    return jsonify({'status': 'completed/unavailable', 'next_poll_seconds': API_V1_CONTROL_NEXT_POLL_MAX_SECONDS}), 200
 
 
 @app.route('/api/v1/relay/requests/cancel', methods=['POST'])

--- a/static/index.html
+++ b/static/index.html
@@ -756,6 +756,7 @@
                 <tr><td><code>POST /api/v1/relay/servers/register</code></td><td>Compute node registration and heartbeat lease setup.</td></tr>
                 <tr><td><code>POST /api/v1/relay/servers/unregister</code></td><td>Compute node self-unregister with relay registration authentication.</td></tr>
                 <tr><td><code>POST /api/v1/relay/servers/poll</code></td><td>Compute node long-poll for the next encrypted workload envelope.</td></tr>
+                <tr><td><code>POST /api/v1/relay/requests/control</code></td><td>Authenticated owner-only compute control poll for in-flight request status, deadline TTL, and lease renewal.</td></tr>
                 <tr><td><code>POST /api/v1/relay/requests/cancel</code></td><td>Client request cancellation with a requester proof token.</td></tr>
                 <tr><td><code>POST /api/v1/relay/responses</code></td><td>Compute node stores an encrypted response envelope for client retrieval.</td></tr>
             </tbody>

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -50,6 +50,7 @@ COMPUTE_NODE_CONTROL_PLANE_ROUTES = {
     ("POST", "/api/v1/relay/servers/register"),
     ("POST", "/api/v1/relay/servers/unregister"),
     ("POST", "/api/v1/relay/servers/poll"),
+    ("POST", "/api/v1/relay/requests/control"),
     ("POST", "/api/v1/relay/responses"),
 }
 

--- a/tests/unit/test_api_v1_relay_control.py
+++ b/tests/unit/test_api_v1_relay_control.py
@@ -1,0 +1,241 @@
+import time
+
+import pytest
+
+import relay
+
+
+@pytest.fixture
+def relay_client(monkeypatch):
+    relay.app.config["TESTING"] = True
+    monkeypatch.setattr(relay, "SERVER_REGISTRATION_TOKENS", ["token"])
+    relay.known_servers.clear()
+    relay.client_inference_requests.clear()
+    relay.client_responses.clear()
+    relay.client_pending_request_ids.clear()
+    relay.client_terminal_request_ids.clear()
+    relay.client_terminal_outcomes.clear()
+    relay.api_v1_control_tombstones.clear()
+    with relay.app.test_client() as client:
+        yield client
+    relay.known_servers.clear()
+    relay.client_inference_requests.clear()
+    relay.client_responses.clear()
+    relay.client_pending_request_ids.clear()
+    relay.client_terminal_request_ids.clear()
+    relay.client_terminal_outcomes.clear()
+    relay.api_v1_control_tombstones.clear()
+
+
+def _headers():
+    return {"X-Relay-Server-Token": "token"}
+
+
+def _register(client, key="server-a"):
+    res = client.post(
+        "/api/v1/relay/servers/register",
+        json={
+            "server_public_key": key,
+            "capabilities": {
+                "api_version": "v1",
+                "supported_model_ids": ["qwen3-8b-instruct"],
+                "active_context_tier": "8k-fast",
+                "maximum_total_context_tokens": 8192,
+                "default_output_token_reservation": 1024,
+                "maximum_output_tokens": 2048,
+                "max_concurrency": 1,
+            },
+        },
+        headers=_headers(),
+    )
+    assert res.status_code == 200
+
+
+def _request(client, server="server-a", request_id="req-1", cancel_token="cancel"):
+    res = client.post(
+        "/api/v1/relay/requests",
+        json={
+            "server_public_key": server,
+            "client_public_key": "client-a",
+            "request_id": request_id,
+            "cancel_token": cancel_token,
+            "ciphertext": "sealed",
+            "cipherkey": "sealed-key",
+            "iv": "sealed-iv",
+            "protocol": "e2ee_v1",
+        },
+    )
+    assert res.status_code == 200
+    body = res.get_json()
+    assert "deadline_unix_ms" in body
+    return body
+
+
+def _poll(client, server="server-a"):
+    res = client.post(
+        "/api/v1/relay/servers/poll",
+        json={"server_public_key": server},
+        headers=_headers(),
+    )
+    assert res.status_code == 200
+    return res.get_json()
+
+
+def test_queued_cancellation_preserves_client_timeout_and_rejects_late_response(
+    relay_client,
+):
+    _register(relay_client)
+    _request(relay_client)
+    cancel = relay_client.post(
+        "/api/v1/relay/requests/cancel",
+        json={
+            "client_public_key": "client-a",
+            "request_id": "req-1",
+            "cancel_token": "cancel",
+            "status": "cancelled",
+            "reason": "client_timeout",
+        },
+    )
+    assert cancel.status_code == 200
+    retrieve = relay_client.post(
+        "/api/v1/relay/responses/retrieve",
+        json={"client_public_key": "client-a", "request_id": "req-1"},
+    )
+    assert retrieve.status_code == 410
+    assert retrieve.get_json()["error"]["reason"] == "client_timeout"
+    late = relay_client.post(
+        "/api/v1/relay/responses",
+        json={
+            "client_public_key": "client-a",
+            "request_id": "req-1",
+            "ciphertext": "sealed-response",
+            "cipherkey": "sealed-key",
+            "iv": "sealed-iv",
+            "protocol": "e2ee_v1",
+        },
+        headers=_headers(),
+    )
+    assert late.status_code == 410
+
+
+def test_in_flight_cancellation_visible_only_to_owner_and_ack_cleans_tombstone(
+    relay_client,
+):
+    _register(relay_client, "server-a")
+    _register(relay_client, "server-b")
+    _request(relay_client)
+    assert _poll(relay_client)["request_id"] == "req-1"
+    wrong = relay_client.post(
+        "/api/v1/relay/requests/control",
+        json={"server_public_key": "server-b", "request_id": "req-1"},
+        headers=_headers(),
+    )
+    assert wrong.status_code == 200
+    assert wrong.get_json()["status"] == "completed/unavailable"
+    cancel = relay_client.post(
+        "/api/v1/relay/requests/cancel",
+        json={
+            "client_public_key": "client-a",
+            "request_id": "req-1",
+            "cancel_token": "cancel",
+            "status": "cancelled",
+            "reason": "client_timeout",
+        },
+    )
+    assert cancel.status_code == 200
+    owner = relay_client.post(
+        "/api/v1/relay/requests/control",
+        json={"server_public_key": "server-a", "request_id": "req-1"},
+        headers=_headers(),
+    )
+    assert owner.status_code == 200
+    assert owner.get_json()["status"] == "cancelled"
+    ack = relay_client.post(
+        "/api/v1/relay/requests/control",
+        json={
+            "server_public_key": "server-a",
+            "request_id": "req-1",
+            "acknowledge": True,
+        },
+        headers=_headers(),
+    )
+    assert ack.status_code == 200
+    assert ack.get_json()["status"] == "cancelled"
+    gone = relay_client.post(
+        "/api/v1/relay/requests/control",
+        json={"server_public_key": "server-a", "request_id": "req-1"},
+        headers=_headers(),
+    )
+    assert gone.get_json()["status"] == "completed/unavailable"
+
+
+def test_unsigned_control_fails_closed(relay_client):
+    _register(relay_client)
+    res = relay_client.post(
+        "/api/v1/relay/requests/control",
+        json={"server_public_key": "server-a", "request_id": "req-1"},
+    )
+    assert res.status_code == 401
+
+
+def test_absolute_deadline_expiry_and_lease_renewal_without_deadline_extension(
+    relay_client, monkeypatch
+):
+    monkeypatch.setenv(relay.API_V1_REQUEST_DEADLINE_SECONDS_ENV, "1")
+    _register(relay_client)
+    request_meta = _request(relay_client)
+    _poll(relay_client)
+    entry = relay.known_servers["server-a"]["api_v1_in_flight_requests"]["req-1"]
+    original_deadline = entry["deadline_unix_ms"]
+    entry["expires_at"] = time.monotonic() + 0.1
+    active = relay_client.post(
+        "/api/v1/relay/requests/control",
+        json={"server_public_key": "server-a", "request_id": "req-1"},
+        headers=_headers(),
+    )
+    assert active.status_code == 200
+    assert active.get_json()["status"] == "active"
+    assert (
+        relay.known_servers["server-a"]["api_v1_in_flight_requests"]["req-1"][
+            "deadline_unix_ms"
+        ]
+        == original_deadline
+        == request_meta["deadline_unix_ms"]
+    )
+    relay.known_servers["server-a"]["api_v1_in_flight_requests"]["req-1"][
+        "deadline_unix_ms"
+    ] = int((time.time() - 1) * 1000)
+    expired = relay_client.post(
+        "/api/v1/relay/requests/control",
+        json={"server_public_key": "server-a", "request_id": "req-1"},
+        headers=_headers(),
+    )
+    assert expired.status_code == 200
+    assert expired.get_json()["status"] == "expired"
+    late = relay_client.post(
+        "/api/v1/relay/responses",
+        json={
+            "client_public_key": "client-a",
+            "request_id": "req-1",
+            "ciphertext": "sealed-response",
+            "cipherkey": "sealed-key",
+            "iv": "sealed-iv",
+            "protocol": "e2ee_v1",
+        },
+        headers=_headers(),
+    )
+    assert late.status_code == 410
+
+
+def test_old_clients_can_ignore_deadline_metadata_queue_depth_and_live_nodes_unchanged(
+    relay_client,
+):
+    _register(relay_client)
+    _request(relay_client)
+    diagnostics = relay_client.get("/relay/diagnostics").get_json()
+    assert diagnostics["total_api_v1_registered_compute_nodes"] == 1
+    assert len(relay.client_inference_requests["server-a"]) == 1
+    dispatched = _poll(relay_client)
+    assert dispatched["ciphertext"] == "sealed"
+    assert "deadline_unix_ms" in dispatched
+    assert relay.client_inference_requests.get("server-a") is None


### PR DESCRIPTION
### Motivation
- Make relay the authoritative source of an API v1 request deadline and expose that deadline to owning compute nodes without leaking ciphertext or request payloads. 
- Surface in-flight cancellation to the owning compute node (not all servers) via a bounded tombstone so late results are rejected and owners can acknowledge cancellation.
- Preserve existing semantics (300s default browser behavior, `client_timeout` reason, non‑streaming final-response contract) while adding bounded configurability, lease semantics, and privacy-safe metrics.

### Description
- Introduces configurable, bounded request deadlines with a 300s default using environment variables `TOKEN_PLACE_API_V1_REQUEST_DEADLINE_SECONDS`, `..._MIN_SECONDS`, and `..._MAX_SECONDS`, and helper functions `_api_v1_request_deadline_seconds()` and `_api_v1_deadline_metadata()` to compute and expose deadline/TTL metadata. (`relay.py`)
- Stores deadline metadata on pending, queued, and in-flight entries and enforces queued/in-flight expiry without extending the absolute request deadline when leases or control polls renew in-flight accounting. (`relay.py`)
- Adds an authenticated, owner‑scoped compute-control route `POST /api/v1/relay/requests/control` that returns a privacy-safe response with only `status` (`active|cancelled|expired|completed/unavailable`), deadline/remaining TTL, and a bounded `next_poll_seconds` hint, and may renew the per-request lease but never the absolute deadline. (`relay.py`, `docs/architecture/api_v1_compute_control.md`)
- Keeps `client_timeout` in the allowed terminal reasons and ensures late response submissions are rejected after cancellation/expiry; when an in-flight request is cancelled the relay records a short-lived compute-visible tombstone instead of immediately discarding owner-visible traces. (`relay.py`)
- Adds privacy-safe metrics: `tokenplace_relay_control_requests_total` (states) and `tokenplace_relay_control_lease_renewals_total` (lease renewals) while avoiding high-cardinality or sensitive labels. (`relay.py`)
- Adds regression tests covering queued cancellation, in-flight owner-only visibility and acknowledgement, unsigned/wrong-server control rejection, deadline expiry and lease-renewal semantics, late-response rejection, and compatibility with older clients; and updates the landing page to document the new internal control route as internal-only. (`tests/unit/test_api_v1_relay_control.py`, `static/index.html`, `docs/architecture/api_v1_compute_control.md`)

### Testing
- Ran the focused relay control unit tests: `pytest -q tests/unit/test_api_v1_relay_control.py` — all asserted cases passed.
- Ran related unit suites to verify CORS, logging/metrics, E2EE invariants, and legacy route guardrails: `pytest -q tests/unit/test_api_v1_cors.py tests/unit/test_relay_logging_and_metrics.py tests/unit/test_e2ee_relay_invariant.py tests/unit/test_legacy_route_usage_guardrails.py` — passed.
- Verified API launch contract and compute control documentation integration: `pytest -q tests/unit/test_api_v1_launch_contract.py tests/unit/test_api_v1_relay_control.py` — passed.
- Ran project checks and formatting via `pre-commit run --all-files` — passed.

Notes: a redeploy of the relay is required for compute nodes to start using the new `POST /api/v1/relay/requests/control` route; this change is relay-side only and does not claim desktop worker termination or desktop cancellation (Prompt 2 will handle that).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59d468c700832fb88ee197e7ab3239)