### PR TITLE
Add relay request deadlines, owner-only control poll, and cancellation tombstones

### DIFF
--- a/docs/architecture/api_v1_relay_compute_control.md
+++ b/docs/architecture/api_v1_relay_compute_control.md
@@ -1,0 +1,43 @@
+# API v1 relay compute-control contract
+
+The relay exposes one narrow internal compute-control operation for work that has
+already been dispatched to a registered API v1 compute node:
+
+`POST /api/v1/relay/requests/control`
+
+The route is for compute nodes only. It reuses the relay server-registration
+authentication primitive (`X-Relay-Server-Token` when configured) and only returns
+state for the exact registered `server_public_key` that owns the in-flight
+`request_id` for the supplied `client_public_key`. A node that is unregistered,
+unauthenticated, or polling a request owned by another node receives no usable
+request state.
+
+Request body:
+
+```json
+{
+  "server_public_key": "registered compute-node public key",
+  "client_public_key": "client public key from the encrypted envelope",
+  "request_id": "request identifier from the encrypted envelope",
+  "acknowledge": false
+}
+```
+
+Response bodies are intentionally bounded and privacy-safe. They contain only:
+
+- `status`: one of `active`, `cancelled`, `expired`, or `completed/unavailable`.
+- `request_deadline_unix_ms` and `request_ttl_seconds` when a deadline is still
+  known.
+- `next_poll_seconds`, capped by the relay.
+
+The route never returns ciphertext, client keys, cancel proofs, prompt contents,
+responses, tool arguments, or payload bodies. A valid `active` poll refreshes only
+the in-flight accounting lease so the relay does not evict a still-running
+request as stale. It never extends the absolute request deadline established when
+the relay admitted the request. Cancelled or expired in-flight requests leave a
+short-lived, owner-visible tombstone until the owner acknowledges it or the
+bounded tombstone TTL elapses.
+
+API v1 remains non-streaming: clients still retrieve a final encrypted response
+from `/api/v1/relay/responses/retrieve`, and late response submissions after
+cancellation or expiry are rejected.

--- a/relay.py
+++ b/relay.py
@@ -451,9 +451,12 @@ REQUEST_COUNTER = None
 
 PROVIDER_MODE_ENUM = ("relay", "direct", "unknown")
 OUTCOME_ENUM = (
+    "active",
     "completed",
     "cancelled",
     "expired",
+    "acknowledged",
+    "lease_renewed",
     "timed_out",
     "rate_limited",
     "dependency_failure",
@@ -611,6 +614,7 @@ def _normalise_http_route() -> str:
     route_map = {
         "api_v1_relay_requests": "/api/v1/relay/requests",
         "api_v1_relay_requests_cancel": "/api/v1/relay/requests/cancel",
+        "api_v1_relay_requests_control": "/api/v1/relay/requests/control",
         "api_v1_relay_responses": "/api/v1/relay/responses",
         "api_v1_relay_responses_retrieve": "/api/v1/relay/responses/retrieve",
         "api_v1_relay_servers_register": "/api/v1/relay/servers/register",
@@ -847,6 +851,8 @@ PENDING_REQUEST_TTL_SECONDS = float(os.getenv("TOKENPLACE_PENDING_REQUEST_TTL_SE
 client_inference_requests_lock = threading.Lock()
 client_inference_requests_changed = threading.Condition(client_inference_requests_lock)
 api_v1_in_flight_requests_lock = threading.Lock()
+api_v1_control_tombstones: dict[str, dict[str, Any]] = {}
+api_v1_control_tombstones_lock = threading.Lock()
 streaming_sessions = {}
 streaming_sessions_by_client = {}
 stream_lock = threading.Lock()
@@ -859,6 +865,12 @@ DEFAULT_API_V1_POLL_WAIT_SECONDS = 10
 API_V1_LEASE_SECONDS_ENV = "TOKEN_PLACE_API_V1_RELAY_SERVER_LEASE_SECONDS"
 DEFAULT_API_V1_LEASE_SECONDS = 30
 API_V1_IN_FLIGHT_TTL_SECONDS_ENV = "TOKEN_PLACE_API_V1_IN_FLIGHT_TTL_SECONDS"
+API_V1_REQUEST_DEADLINE_SECONDS_ENV = "TOKEN_PLACE_API_V1_REQUEST_DEADLINE_SECONDS"
+API_V1_MIN_REQUEST_DEADLINE_SECONDS = 30
+API_V1_MAX_REQUEST_DEADLINE_SECONDS = 1800
+DEFAULT_API_V1_REQUEST_DEADLINE_SECONDS = 300
+API_V1_CONTROL_TOMBSTONE_TTL_SECONDS = 60.0
+API_V1_MAX_CONTROL_POLL_SECONDS = 30.0
 API_V1_MAX_QUEUE_DEPTH_ENV = "TOKEN_PLACE_API_V1_MAX_QUEUE_DEPTH_PER_NODE"
 DEFAULT_CONTEXT_TIER = "8k-fast"
 MAX_API_V1_MODEL_IDS_PER_NODE = 64
@@ -909,6 +921,30 @@ def _api_v1_lease_seconds() -> int:
     return max(value, 1)
 
 
+
+
+def _api_v1_request_deadline_seconds() -> int:
+    raw = os.environ.get(API_V1_REQUEST_DEADLINE_SECONDS_ENV, str(DEFAULT_API_V1_REQUEST_DEADLINE_SECONDS))
+    try:
+        value = int(raw)
+    except ValueError:
+        value = DEFAULT_API_V1_REQUEST_DEADLINE_SECONDS
+    return min(max(value, API_V1_MIN_REQUEST_DEADLINE_SECONDS), API_V1_MAX_REQUEST_DEADLINE_SECONDS)
+
+
+def _api_v1_deadline_metadata(deadline_wall: float) -> dict[str, Any]:
+    remaining = max(float(deadline_wall) - time.time(), 0.0)
+    return {
+        "request_deadline_unix_ms": int(float(deadline_wall) * 1000),
+        "request_ttl_seconds": round(remaining, 3),
+    }
+
+
+def _api_v1_request_is_deadline_expired(deadline_wall: Any, *, now: float | None = None) -> bool:
+    if not isinstance(deadline_wall, (int, float)):
+        return False
+    now = time.time() if now is None else now
+    return float(deadline_wall) <= now
 
 
 def _api_v1_max_queue_depth_per_node() -> int:
@@ -1161,10 +1197,30 @@ def _pop_next_api_v1_request(public_key: str):
     def _is_legacy_ciphertext_payload(payload):
         return all(key in payload for key in ('client_public_key', 'chat_history', 'cipherkey', 'iv'))
 
-    for idx, candidate in enumerate(queued_requests):
+    idx = 0
+    while idx < len(queued_requests):
+        candidate = queued_requests[idx]
         if bool(candidate.get('e2ee_v1')):
+            deadline_wall = candidate.get('request_deadline_unix_ms')
+            if isinstance(deadline_wall, (int, float)):
+                deadline_wall = float(deadline_wall) / 1000.0
+            if not isinstance(deadline_wall, (int, float)):
+                deadline_wall = time.time() + _api_v1_request_deadline_seconds()
+                candidate['request_deadline_unix_ms'] = int(deadline_wall * 1000)
+                candidate['request_ttl_seconds'] = _api_v1_request_deadline_seconds()
+            if _api_v1_request_is_deadline_expired(deadline_wall):
+                queued_requests.pop(idx)
+                _cancel_api_v1_request(
+                    candidate.get('client_public_key'),
+                    candidate.get('request_id'),
+                    status='expired',
+                    reason='expired',
+                )
+                continue
             first_request = queued_requests.pop(idx)
+            first_request.update(_api_v1_deadline_metadata(deadline_wall))
             break
+        idx += 1
 
     if first_request is None:
         while queued_requests:
@@ -2080,6 +2136,7 @@ _ALLOWED_API_V1_TERMINAL_REASONS = {
     "expired",
     "requester_cancelled",
     "requester_gave_up",
+    "client_timeout",
     "provider_timeout",
     "pending_request_ttl_exceeded",
     "server_unregistered",
@@ -2254,7 +2311,17 @@ def _cancel_api_v1_request(client_public_key, request_id, *, status="cancelled",
                     in_flight_requests = server_payload.get("api_v1_in_flight_requests")
                     if not isinstance(in_flight_requests, dict) or request_id not in in_flight_requests:
                         continue
-                    if _in_flight_entry_matches_client(in_flight_requests.get(request_id), client_public_key):
+                    entry = in_flight_requests.get(request_id)
+                    if _in_flight_entry_matches_client(entry, client_public_key):
+                        deadline_wall = entry.get('deadline_wall') if isinstance(entry, dict) else None
+                        _store_api_v1_control_tombstone(
+                            server_payload.get('public_key'),
+                            client_public_key,
+                            request_id,
+                            status=status,
+                            reason=reason,
+                            deadline_wall=deadline_wall,
+                        )
                         in_flight_requests.pop(request_id, None)
                         in_flight_removed += 1
                         if not in_flight_requests:
@@ -2279,18 +2346,85 @@ def _cancel_api_v1_request(client_public_key, request_id, *, status="cancelled",
     return removed
 
 
-def _mark_request_pending(client_public_key, request_id, *, cancel_token=None):
+
+def _request_tombstone_key(client_public_key: str | None, request_id: str | None) -> str | None:
+    if not client_public_key or not request_id:
+        return None
+    return f"{client_public_key}\0{request_id}"
+
+
+def _store_api_v1_control_tombstone(
+    server_public_key: str | None,
+    client_public_key: str | None,
+    request_id: str | None,
+    *,
+    status: str,
+    reason: str,
+    deadline_wall: float | None = None,
+) -> None:
+    key = _request_tombstone_key(client_public_key, request_id)
+    if not key or not server_public_key:
+        return
+    now = time.time()
+    with api_v1_control_tombstones_lock:
+        api_v1_control_tombstones[key] = {
+            "server_public_key": server_public_key,
+            "client_public_key": client_public_key,
+            "request_id": request_id,
+            "status": status,
+            "reason": reason,
+            "deadline_wall": deadline_wall,
+            "expires_at": now + max(API_V1_CONTROL_TOMBSTONE_TTL_SECONDS, 1.0),
+        }
+
+
+def _get_api_v1_control_tombstone(client_public_key: str | None, request_id: str | None):
+    key = _request_tombstone_key(client_public_key, request_id)
+    if not key:
+        return None
+    now = time.time()
+    with api_v1_control_tombstones_lock:
+        tombstone = api_v1_control_tombstones.get(key)
+        if not isinstance(tombstone, dict):
+            return None
+        expires_at = tombstone.get("expires_at")
+        if not isinstance(expires_at, (int, float)) or expires_at <= now:
+            api_v1_control_tombstones.pop(key, None)
+            return None
+        return dict(tombstone)
+
+
+def _ack_api_v1_control_tombstone(client_public_key: str | None, request_id: str | None, server_public_key: str | None) -> bool:
+    key = _request_tombstone_key(client_public_key, request_id)
+    if not key or not server_public_key:
+        return False
+    with api_v1_control_tombstones_lock:
+        tombstone = api_v1_control_tombstones.get(key)
+        if not isinstance(tombstone, dict) or tombstone.get("server_public_key") != server_public_key:
+            return False
+        api_v1_control_tombstones.pop(key, None)
+    _record_terminal_outcome("acknowledged")
+    return True
+
+
+def _prune_api_v1_control_tombstones() -> None:
+    now = time.time()
+    with api_v1_control_tombstones_lock:
+        for key, tombstone in list(api_v1_control_tombstones.items()):
+            expires_at = tombstone.get("expires_at") if isinstance(tombstone, dict) else None
+            if not isinstance(expires_at, (int, float)) or expires_at <= now:
+                api_v1_control_tombstones.pop(key, None)
+
+def _mark_request_pending(client_public_key, request_id, *, cancel_token=None, deadline_wall=None):
     if not client_public_key or not request_id:
         return
     with client_pending_request_ids_lock:
         pending_ids = client_pending_request_ids.setdefault(client_public_key, {})
-        if isinstance(cancel_token, str) and cancel_token:
-            pending_ids[request_id] = {
-                "queued_at": time.time(),
-                "cancel_token": cancel_token,
-            }
-        else:
-            pending_ids[request_id] = time.time()
+        pending_ids[request_id] = {
+            "queued_at": time.time(),
+            "cancel_token": cancel_token if isinstance(cancel_token, str) and cancel_token else None,
+            "deadline_wall": deadline_wall if isinstance(deadline_wall, (int, float)) else None,
+        }
 
 
 def _clear_pending_request(client_public_key, request_id):
@@ -2644,6 +2778,7 @@ def api_v1_relay_servers_poll():
                             'started_at_monotonic': time.monotonic(),
                             'client_public_key': first_request.get('client_public_key'),
                             'cancel_token': first_request.get('cancel_token'),
+                            'deadline_wall': float(first_request.get('request_deadline_unix_ms', 0)) / 1000.0 if isinstance(first_request.get('request_deadline_unix_ms'), (int, float)) else None,
                         }
         if server_missing:
             return _server_not_found_response(first_request)
@@ -2683,10 +2818,15 @@ def api_v1_relay_requests():
         server_payload = known_servers.get(server_public_key)
         if server_payload is None or not bool(server_payload.get(API_V1_SERVER_MARKER)):
             return jsonify({'error': {'message': 'Server with the specified public key not found', 'code': 404}}), 404
+        deadline_seconds = _api_v1_request_deadline_seconds()
+        deadline_wall = time.time() + deadline_seconds
+        envelope['request_deadline_unix_ms'] = int(deadline_wall * 1000)
+        envelope['request_ttl_seconds'] = deadline_seconds
         _mark_request_pending(
             envelope.get('client_public_key'),
             envelope.get('request_id'),
             cancel_token=envelope.get('cancel_token'),
+            deadline_wall=deadline_wall,
         )
         with client_inference_requests_changed:
             client_inference_requests.setdefault(server_public_key, []).append(envelope)
@@ -2699,7 +2839,7 @@ def api_v1_relay_requests():
             "queue_depth": queue_depth,
         },
     )
-    return jsonify({'message': 'Request received'}), 200
+    return jsonify({'message': 'Request received', **_api_v1_deadline_metadata(deadline_wall)}), 200
 
 
 
@@ -2733,6 +2873,70 @@ def api_v1_relay_requests_cancel():
         reason=reason,
     )
     return jsonify({'status': status, 'request_id': request_id, 'removed_from_queue': removed}), 200
+
+
+@app.route('/api/v1/relay/requests/control', methods=['POST'])
+def api_v1_relay_requests_control():
+    """Authenticated compute-node control poll for one owned in-flight request."""
+    auth_error = _validate_server_registration()
+    if auth_error:
+        return auth_error
+
+    _prune_api_v1_control_tombstones()
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({'error': {'message': 'Invalid request data', 'code': 400}}), 400
+    server_public_key = data.get('server_public_key')
+    client_public_key = data.get('client_public_key')
+    request_id = data.get('request_id')
+    if not server_public_key or not client_public_key or not request_id:
+        return jsonify({'error': {'message': 'Invalid request data', 'code': 400}}), 400
+
+    with server_round_robin_lock:
+        server_payload = known_servers.get(server_public_key)
+        if server_payload is None or not bool(server_payload.get(API_V1_SERVER_MARKER)):
+            return jsonify({'error': {'message': 'Request unavailable', 'code': 404}}), 404
+
+    if data.get('acknowledge') is True and _ack_api_v1_control_tombstone(client_public_key, request_id, server_public_key):
+        return jsonify({'status': 'completed/unavailable', 'next_poll_seconds': 0}), 200
+
+    tombstone = _get_api_v1_control_tombstone(client_public_key, request_id)
+    if tombstone is not None:
+        if tombstone.get('server_public_key') != server_public_key:
+            return jsonify({'error': {'message': 'Request unavailable', 'code': 404}}), 404
+        deadline_wall = tombstone.get('deadline_wall')
+        payload = {'status': tombstone.get('status') if tombstone.get('status') in {'cancelled', 'expired'} else 'cancelled'}
+        if isinstance(deadline_wall, (int, float)):
+            payload.update(_api_v1_deadline_metadata(float(deadline_wall)))
+        payload['next_poll_seconds'] = 0
+        _record_terminal_outcome(payload['status'])
+        return jsonify(payload), 200
+
+    with server_round_robin_lock:
+        server_payload = known_servers.get(server_public_key)
+        if server_payload is None:
+            return jsonify({'error': {'message': 'Request unavailable', 'code': 404}}), 404
+        with api_v1_in_flight_requests_lock:
+            in_flight_requests = server_payload.get('api_v1_in_flight_requests')
+            entry = in_flight_requests.get(request_id) if isinstance(in_flight_requests, dict) else None
+            if not isinstance(entry, dict) or entry.get('client_public_key') != client_public_key:
+                return jsonify({'status': 'completed/unavailable', 'next_poll_seconds': 0}), 200
+            deadline_wall = entry.get('deadline_wall')
+            if _api_v1_request_is_deadline_expired(deadline_wall):
+                in_flight_requests.pop(request_id, None)
+                if not in_flight_requests:
+                    server_payload.pop('api_v1_in_flight_requests', None)
+                _store_api_v1_control_tombstone(server_public_key, client_public_key, request_id, status='expired', reason='expired', deadline_wall=deadline_wall)
+                _mark_request_terminal(client_public_key, request_id, status='expired', reason='expired')
+                return jsonify({'status': 'expired', **_api_v1_deadline_metadata(float(deadline_wall)), 'next_poll_seconds': 0}), 200
+            # Renew only the accounting lease. Never mutate deadline_wall.
+            now_monotonic = time.monotonic()
+            entry['expires_at'] = now_monotonic + _api_v1_in_flight_ttl_seconds()
+            next_poll = min(API_V1_MAX_CONTROL_POLL_SECONDS, _api_v1_in_flight_ttl_seconds() / 2.0)
+    _record_terminal_outcome('active')
+    _record_terminal_outcome('lease_renewed')
+    payload = {'status': 'active', **_api_v1_deadline_metadata(float(deadline_wall)), 'next_poll_seconds': round(max(next_poll, 1.0), 3)}
+    return jsonify(payload), 200
 
 
 @app.route('/api/v1/relay/responses', methods=['POST'])

--- a/static/index.html
+++ b/static/index.html
@@ -757,6 +757,7 @@
                 <tr><td><code>POST /api/v1/relay/servers/unregister</code></td><td>Compute node self-unregister with relay registration authentication.</td></tr>
                 <tr><td><code>POST /api/v1/relay/servers/poll</code></td><td>Compute node long-poll for the next encrypted workload envelope.</td></tr>
                 <tr><td><code>POST /api/v1/relay/requests/cancel</code></td><td>Client request cancellation with a requester proof token.</td></tr>
+                <tr><td><code>POST /api/v1/relay/requests/control</code></td><td>Authenticated owner-only compute control poll for active, cancelled, expired, or unavailable request state.</td></tr>
                 <tr><td><code>POST /api/v1/relay/responses</code></td><td>Compute node stores an encrypted response envelope for client retrieval.</td></tr>
             </tbody>
         </table>

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -54,6 +54,7 @@ def client():
     streaming_sessions.clear()
     streaming_sessions_by_client.clear()
     relay_module.api_v1_recently_unregistered_servers.clear()
+    relay_module.api_v1_control_tombstones.clear()
 
     with app.test_client() as client:
         yield client
@@ -73,6 +74,7 @@ def client():
     streaming_sessions.clear()
     streaming_sessions_by_client.clear()
     relay_module.api_v1_recently_unregistered_servers.clear()
+    relay_module.api_v1_control_tombstones.clear()
 
 
 def test_operational_endpoints_are_not_rate_limited_by_public_quota(client):
@@ -2392,7 +2394,7 @@ def test_api_v1_response_retrieve_stays_pending_for_long_running_valid_interval(
     )
     assert queued.status_code == 200
 
-    queued_at = client_pending_request_ids[DUMMY_CLIENT_PUB_KEY]['req-long-running']
+    queued_at = client_pending_request_ids[DUMMY_CLIENT_PUB_KEY]['req-long-running']['queued_at']
     monkeypatch.setattr(relay_module, 'PENDING_REQUEST_TTL_SECONDS', 300.0)
     monkeypatch.setattr(relay_module.time, 'time', lambda: queued_at + 299.0)
 
@@ -3834,3 +3836,141 @@ def test_api_v1_terminal_records_are_pruned_without_retrieve(client, monkeypatch
 
     assert diagnostics.status_code == 200
     assert DUMMY_CLIENT_PUB_KEY not in client_terminal_request_ids
+
+
+def _api_v1_request_payload(request_id, server_key=DUMMY_SERVER_PUB_KEY, client_key=DUMMY_CLIENT_PUB_KEY, cancel_token="cancel-token"):
+    return {
+        'request_id': request_id,
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+        'client_public_key': client_key,
+        'server_public_key': server_key,
+        'chat_history': 'ciphertext-request',
+        'cipherkey': 'cipherkey-request',
+        'iv': 'iv-request',
+        'cancel_token': cancel_token,
+    }
+
+
+def test_api_v1_control_in_flight_cancellation_owner_only_and_late_response_rejected(client, monkeypatch):
+    monkeypatch.setattr(relay_module, 'SERVER_REGISTRATION_TOKENS', ['expected-token'])
+    headers = {'X-Relay-Server-Token': 'expected-token'}
+    other_server = _server_key('other-control-server')
+    client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY}, headers=headers)
+    client.post('/api/v1/relay/servers/register', json={'server_public_key': other_server}, headers=headers)
+    assert client.post('/api/v1/relay/requests', json=_api_v1_request_payload('req-control')).status_code == 200
+    polled = client.post('/api/v1/relay/servers/poll', json={'server_public_key': DUMMY_SERVER_PUB_KEY}, headers=headers)
+    assert polled.status_code == 200
+
+    cancelled = client.post('/api/v1/relay/requests/cancel', json={
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': 'req-control',
+        'cancel_token': 'cancel-token',
+        'reason': 'client_timeout',
+    })
+    assert cancelled.status_code == 200
+
+    wrong = client.post('/api/v1/relay/requests/control', json={
+        'server_public_key': other_server,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': 'req-control',
+    }, headers=headers)
+    assert wrong.status_code == 404
+
+    unsigned = client.post('/api/v1/relay/requests/control', json={
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': 'req-control',
+    })
+    assert unsigned.status_code == 401
+
+    owner = client.post('/api/v1/relay/requests/control', json={
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': 'req-control',
+    }, headers=headers)
+    assert owner.status_code == 200
+    assert owner.get_json()['status'] == 'cancelled'
+    assert 'request_ttl_seconds' in owner.get_json()
+
+    late = client.post('/api/v1/relay/responses', json={
+        'request_id': 'req-control',
+        'protocol': 'tokenplace_api_v1_relay_e2ee',
+        'version': 1,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'chat_history': 'ciphertext-response',
+        'cipherkey': 'cipherkey-response',
+        'iv': 'iv-response',
+    }, headers=headers)
+    assert late.status_code == 410
+
+    retrieve = client.post('/api/v1/relay/responses/retrieve', json={'client_public_key': DUMMY_CLIENT_PUB_KEY, 'request_id': 'req-control'})
+    assert retrieve.status_code == 410
+    assert retrieve.get_json()['error']['reason'] == 'client_timeout'
+
+    ack = client.post('/api/v1/relay/requests/control', json={
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': 'req-control',
+        'acknowledge': True,
+    }, headers=headers)
+    assert ack.status_code == 200
+    assert relay_module.api_v1_control_tombstones == {}
+
+
+def test_api_v1_control_active_renews_lease_without_deadline_extension(client, monkeypatch):
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_REQUEST_DEADLINE_SECONDS', '300')
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_IN_FLIGHT_TTL_SECONDS', '10')
+    headers = {}
+    client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY}, headers=headers)
+    queued = client.post('/api/v1/relay/requests', json=_api_v1_request_payload('req-lease'))
+    assert queued.status_code == 200
+    client.post('/api/v1/relay/servers/poll', json={'server_public_key': DUMMY_SERVER_PUB_KEY}, headers=headers)
+    entry = known_servers[DUMMY_SERVER_PUB_KEY]['api_v1_in_flight_requests']['req-lease']
+    original_deadline = entry['deadline_wall']
+    original_expires = entry['expires_at']
+    entry['expires_at'] = time.monotonic() + 1
+
+    control = client.post('/api/v1/relay/requests/control', json={
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': 'req-lease',
+    }, headers=headers)
+    assert control.status_code == 200
+    assert control.get_json()['status'] == 'active'
+    renewed = known_servers[DUMMY_SERVER_PUB_KEY]['api_v1_in_flight_requests']['req-lease']
+    assert renewed['expires_at'] > original_expires or renewed['expires_at'] > time.monotonic() + 5
+    assert renewed['deadline_wall'] == original_deadline
+
+
+def test_api_v1_absolute_deadline_expiry_is_control_visible(client, monkeypatch):
+    monkeypatch.setenv('TOKEN_PLACE_API_V1_REQUEST_DEADLINE_SECONDS', '30')
+    client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
+    assert client.post('/api/v1/relay/requests', json=_api_v1_request_payload('req-expire')).status_code == 200
+    client.post('/api/v1/relay/servers/poll', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
+    entry = known_servers[DUMMY_SERVER_PUB_KEY]['api_v1_in_flight_requests']['req-expire']
+    entry['deadline_wall'] = time.time() - 1
+
+    control = client.post('/api/v1/relay/requests/control', json={
+        'server_public_key': DUMMY_SERVER_PUB_KEY,
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': 'req-expire',
+    })
+    assert control.status_code == 200
+    assert control.get_json()['status'] == 'expired'
+
+
+def test_api_v1_queued_cancellation_preserves_queue_depth_and_live_nodes(client):
+    client.post('/api/v1/relay/servers/register', json={'server_public_key': DUMMY_SERVER_PUB_KEY})
+    client.post('/api/v1/relay/requests', json=_api_v1_request_payload('req-queued'))
+    live_before = client.get('/relay/diagnostics').get_json()['total_api_v1_registered_compute_nodes']
+    assert len(client_inference_requests[DUMMY_SERVER_PUB_KEY]) == 1
+    cancelled = client.post('/api/v1/relay/requests/cancel', json={
+        'client_public_key': DUMMY_CLIENT_PUB_KEY,
+        'request_id': 'req-queued',
+        'cancel_token': 'cancel-token',
+    })
+    assert cancelled.status_code == 200
+    assert DUMMY_SERVER_PUB_KEY not in client_inference_requests
+    live_after = client.get('/relay/diagnostics').get_json()['total_api_v1_registered_compute_nodes']
+    assert live_after == live_before

--- a/tests/unit/test_api_v1_launch_contract.py
+++ b/tests/unit/test_api_v1_launch_contract.py
@@ -51,6 +51,7 @@ COMPUTE_NODE_CONTROL_PLANE_ROUTES = {
     ("POST", "/api/v1/relay/servers/unregister"),
     ("POST", "/api/v1/relay/servers/poll"),
     ("POST", "/api/v1/relay/responses"),
+    ("POST", "/api/v1/relay/requests/control"),
 }
 
 INTERNAL_RELAY_LIFECYCLE_ROUTES = {


### PR DESCRIPTION
### Motivation
- Make relay-side request cancellation visible to the compute node that owns an already-running API v1 request and establish one authoritative deadline at relay admission. 
- Keep the absolute request deadline immutable across in-flight lease renewals while giving compute nodes a bounded way to learn active/cancelled/expired state.

### Description
- Add a configurable, bounded request deadline at admission with a default of 300s and surface deadline metadata back to requesters via `request_deadline_unix_ms` and `request_ttl_seconds`.
- Implement short-lived owner-visible control tombstones and acknowledgement cleanup to preserve owner-visible cancellation state without exposing payloads.
- Add an authenticated owner-only control route `POST /api/v1/relay/requests/control` that returns only `status` (active/cancelled/expired/completed-unavailable), deadline/TTL if known, and a bounded `next_poll_seconds`, and that may renew the in-flight lease but never the absolute deadline.
- Preserve `client_timeout` as a cancellation reason, extend outcome metrics to include active/acknowledged/lease_renewed labels, and document the internal control contract in `docs/architecture/api_v1_relay_compute_control.md`.

### Testing
- Compiled the updated module with `python -m py_compile relay.py` which succeeded.
- Ran focused relay tests: `pytest -q tests/test_relay.py -k "control_in_flight or active_renews or absolute_deadline or queued_cancellation"` which passed.
- Ran broader suites: `pytest -q tests/test_relay.py tests/unit/test_api_v1_launch_contract.py tests/unit/test_e2ee_relay_invariant.py tests/unit/test_rate_limit.py` resulting in all tests passing (205 passed across the selected suites).
- Ran repository checks with `pre-commit run --all-files` which completed without failures.

Notes: The change adds the route `POST /api/v1/relay/requests/control` and the `api_v1_control_tombstones` state, reuses existing server-registration authentication, and requires a relay redeploy before compute nodes can use the new control contract; desktop worker termination/cancellation remains out of scope for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59d470c67c832fa9b5226045aa514a)