### PR TITLE
Ensure Stop unregisters from relays and landing page updates promptly

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1480,11 +1480,14 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
 
     if let Some(mut child) = owned_child {
         let mut exited = child.try_wait()?.is_some();
-        for _ in 0..20 {
+        let shutdown_deadline = Duration::from_secs(12);
+        let poll_interval = Duration::from_millis(100);
+        let max_attempts = (shutdown_deadline.as_millis() / poll_interval.as_millis()) as usize;
+        for _ in 0..max_attempts {
             if exited {
                 break;
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            tokio::time::sleep(poll_interval).await;
             exited = child.try_wait()?.is_some();
         }
 

--- a/static/chat.js
+++ b/static/chat.js
@@ -1,6 +1,6 @@
 const ASSISTANT_GENERIC_FALLBACK_MESSAGE = 'Sorry, I encountered an issue generating a response. Please try again.';
 const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an invalid response. Please try again.';
-const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
+const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 1500;
 const RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000;
 const EMERGENCY_MODEL_FALLBACK_ID = 'qwen3-8b-instruct';
 const CONTEXT_TIER_STORAGE_KEY = 'token.place.landing.contextTier.v1';
@@ -40,7 +40,9 @@ new Vue({
         computeNodeCountStatus: 'loading',
         computeNodeCountLastUpdated: '',
         computeNodeCountPoller: null,
-        computeNodeCountRequestId: 0
+        computeNodeCountRequestId: 0,
+        computeNodeCountRefreshInFlight: false,
+        computeNodeCountVisibilityHandler: null
     },
     mounted() {
         this.detectTouchInput();
@@ -49,8 +51,19 @@ new Vue({
         this.generateClientKeys();
         this.refreshComputeNodeCount();
         this.computeNodeCountPoller = setInterval(() => {
-            this.refreshComputeNodeCount();
+            if (typeof document !== 'undefined' && document.hidden) {
+                return;
+            }
+            this.refreshComputeNodeCount({ background: true });
         }, COMPUTE_NODE_COUNT_POLL_INTERVAL_MS);
+        if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+            this.computeNodeCountVisibilityHandler = () => {
+                if (!document.hidden) {
+                    this.refreshComputeNodeCount();
+                }
+            };
+            document.addEventListener('visibilitychange', this.computeNodeCountVisibilityHandler);
+        }
         this.$nextTick(() => {
             this.adjustMessageInputHeight();
         });
@@ -102,6 +115,10 @@ new Vue({
     },
     methods: {
         async refreshComputeNodeCount(options = {}) {
+            if (this.computeNodeCountRefreshInFlight && options && options.background === true) {
+                return false;
+            }
+            this.computeNodeCountRefreshInFlight = true;
             // Failover capacity refreshes must be allowed to apply their own
             // successful diagnostics result even if the background poller starts
             // another request before they finish; otherwise a stale count of one
@@ -148,6 +165,10 @@ new Vue({
                 this.computeNodeCountStatus = 'error';
                 this.computeNodeCountLastUpdated = '';
                 return false;
+            } finally {
+                if (requestId === this.computeNodeCountRequestId || !applySupersededSuccess) {
+                    this.computeNodeCountRefreshInFlight = false;
+                }
             }
         },
 
@@ -1335,6 +1356,14 @@ new Vue({
         if (this.computeNodeCountPoller) {
             clearInterval(this.computeNodeCountPoller);
             this.computeNodeCountPoller = null;
+        }
+        if (
+            this.computeNodeCountVisibilityHandler &&
+            typeof document !== 'undefined' &&
+            typeof document.removeEventListener === 'function'
+        ) {
+            document.removeEventListener('visibilitychange', this.computeNodeCountVisibilityHandler);
+            this.computeNodeCountVisibilityHandler = null;
         }
         if (!Array.isArray(this.chatHistory)) {
             return;

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -583,6 +583,41 @@ def test_compute_node_count_renders_and_updates(page: Page, base_url: str, setup
     assert "Updated" in status.inner_text()
 
 
+
+def test_compute_node_count_auto_polls_within_two_seconds(page: Page, base_url: str, setup_servers):
+    """Landing page should automatically refresh diagnostics without a manual method call."""
+    calls = {"count": 0}
+
+    def handle_diagnostics(route):
+        calls["count"] += 1
+        count = 1 if calls["count"] == 1 else 0
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(
+                {
+                    "total_registered_compute_nodes": count,
+                    "total_api_v1_registered_compute_nodes": count,
+                }
+            ),
+        )
+
+    page.route("**/relay/diagnostics", handle_diagnostics)
+    page.goto(base_url)
+    status = page.locator(".compute-node-status")
+    status.wait_for(state="visible")
+    page.wait_for_function(
+        "document.querySelector('.compute-node-status').textContent.includes('Live compute nodes: 1')"
+    )
+
+    deadline = time.monotonic() + 2.0
+    page.wait_for_function(
+        "document.querySelector('.compute-node-status').textContent.includes('Live compute nodes: 0')",
+        timeout=max(1, int((deadline - time.monotonic()) * 1000)),
+    )
+    assert calls["count"] >= 2
+    assert "Live compute nodes: 0" in status.inner_text()
+
 def test_compute_node_count_ignores_stale_refresh(page: Page, base_url: str, setup_servers):
     """Older diagnostics responses should not overwrite newer compute-node counts."""
     first_route = {}

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1330,6 +1330,8 @@ class RelayClient:
     def unregister_from_relay(self) -> bool:
         """Best-effort unregister call for graceful compute-node shutdown."""
 
+        self.stop_polling = True
+        self._polling_stopped_by_request = True
         self._api_v1_stop_heartbeat_worker()
 
         registered_relays = getattr(self, "_api_v1_registered_relays", set())
@@ -1395,7 +1397,7 @@ class RelayClient:
                 if response.status_code == 200:
                     if candidate_url in relay_index_by_url:
                         self._active_relay_index = relay_index_by_url[candidate_url]
-                    log_info("Unregistered compute node from relay {}", candidate_url)
+                    log_info("Unregistered compute node from relay {}", _sanitize_relay_target(candidate_url))
                     unregistered_relays.add(candidate_url)
                     self._api_v1_registered_relays.discard(candidate_url)
                     self._api_v1_last_heartbeat_at.pop(candidate_url, None)
@@ -1412,7 +1414,7 @@ class RelayClient:
                 last_error = f"HTTP {diagnostic['status_code']}"
                 log_error(
                     "Failed to unregister compute node from {}: {}",
-                    candidate_url,
+                    _sanitize_relay_target(candidate_url),
                     last_error,
                 )
             except requests.RequestException as exc:
@@ -1420,7 +1422,7 @@ class RelayClient:
                 last_error = str(exc)
                 log_error(
                     "Error unregistering compute node from {}: {}",
-                    candidate_url,
+                    _sanitize_relay_target(candidate_url),
                     last_error,
                     exc_info=True,
                 )
@@ -1429,7 +1431,7 @@ class RelayClient:
                 last_error = str(exc)
                 log_error(
                     "Unexpected error unregistering compute node from {}: {}",
-                    candidate_url,
+                    _sanitize_relay_target(candidate_url),
                     last_error,
                     exc_info=True,
                 )


### PR DESCRIPTION
### Motivation
- Prevent the desktop Stop action from being spuriously reported as successful when the Python bridge is killed before it can finish unregistering from relays.
- Make the relay landing-page widget reflect a successful unregister within the required two-second SLA instead of remaining stale for up to 30 seconds.

### Description
- Reduce the landing diagnostics poll interval and add a lightweight in-flight guard, hidden-tab pause, visibility-triggered immediate refresh, and listener cleanup in `static/chat.js` so the widget can reflect `N → N-1` within ~2s and avoid overlapping background requests.
- Extend the Tauri compute-node bridge shutdown wait to a coherent bounded 12s grace window before falling back to a hard kill in `desktop-tauri/src-tauri/src/compute_node.rs` so the bridge can finish unregister and emit its stopped outcome.
- Ensure the relay client stops polling/heartbeats before attempting unregister, sanitize relay targets in logs, and preserve per-relay retry/idempotency behavior in `utils/networking/relay_client.py` so each previously-registered relay gets an explicit unregister attempt.
- Add a Playwright regression `tests/e2e/test_ui.py` that mocks a diagnostics sequence `1 → 0` and asserts the landing widget auto-updates within two seconds without calling `refreshComputeNodeCount()` manually.

### Testing
- Installed verification deps and Playwright browsers via `pip install -r config/requirements_codex_verification.txt`, `python -m playwright install chromium`, and `python -m playwright install-deps chromium` (succeeded).
- Ran landing E2E slice: `python -m pytest tests/e2e/test_ui.py -k "compute_node_count" -v` and all selected tests passed (5 passed, 31 deselected), validating automatic `1 → 0` refresh within the 2s SLA.
- Ran focused unit suites: `python -m pytest tests/unit/test_relay_client.py -k "unregister or stop or heartbeat" -v` (30 passed), `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -k "stop or unregister or registered" -v` (18 passed), `python -m pytest tests/test_relay.py -k "unregister or diagnostics" -v` (17 passed), and `python -m pytest tests/unit/test_compute_node_runtime.py -k "stop or unregister" -v` (5 passed); all selected tests passed.
- Rust `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node` was not run to completion here due to a missing system `glib-2.0.pc` dependency in the environment (blocked by system pkg-config / `glib-2.0`).
- Project checks: `pre-commit run --all-files` and `git diff --check` passed.

Changed files: `static/chat.js`, `desktop-tauri/src-tauri/src/compute_node.rs`, `utils/networking/relay_client.py`, and `tests/e2e/test_ui.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59d2e36cd0832f9bb8fe087bf29931)