### PR TITLE
Ensure Stop unregister completes and landing page reflects node removal quickly

### DIFF
--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -22,6 +22,8 @@ use std::path::Path;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const COMPUTE_NODE_BRIDGE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(15);
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
@@ -1479,11 +1481,9 @@ pub async fn stop_compute_node(state: ComputeNodeState) -> anyhow::Result<()> {
     }
 
     if let Some(mut child) = owned_child {
+        let shutdown_deadline = tokio::time::Instant::now() + COMPUTE_NODE_BRIDGE_SHUTDOWN_TIMEOUT;
         let mut exited = child.try_wait()?.is_some();
-        for _ in 0..20 {
-            if exited {
-                break;
-            }
+        while !exited && tokio::time::Instant::now() < shutdown_deadline {
             tokio::time::sleep(Duration::from_millis(50)).await;
             exited = child.try_wait()?.is_some();
         }
@@ -2305,6 +2305,68 @@ mod tests {
     }
 
     #[cfg(not(windows))]
+    #[tokio::test]
+    async fn stop_compute_node_waits_for_bridge_cleanup_before_kill_deadline() {
+        let state = ComputeNodeState::default();
+        let temp = TempDir::new().expect("tempdir");
+        let observed_cancel_path = temp.path().join("observed-cancel.json");
+        let completed_path = temp.path().join("cleanup-complete");
+        let log_path = temp.path().join("operator.log");
+        std::fs::write(&log_path, "").expect("create log");
+
+        let mut child = Command::new("sh")
+            .args([
+                "-c",
+                r#"IFS= read -r line; printf '%s' "$line" > "$1"; sleep 2; printf done > "$2""#,
+                "sh",
+                observed_cancel_path
+                    .to_str()
+                    .expect("cancel path should be valid UTF-8"),
+                completed_path
+                    .to_str()
+                    .expect("completed path should be valid UTF-8"),
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn slow cleanup bridge");
+        let child_stdin = child.stdin.take().expect("child stdin");
+
+        *state.child.lock().await = Some(child);
+        *state.stdin.lock().await = Some(child_stdin);
+        {
+            let mut status = state.status.lock().await;
+            status.running = true;
+            status.registered = true;
+            status.operator_session_id = Some("slow-cleanup-session".into());
+            status.log_file_path = Some(log_path.to_string_lossy().into_owned());
+        }
+
+        let stop_result =
+            tokio::time::timeout(Duration::from_secs(5), stop_compute_node(state.clone())).await;
+        assert!(
+            stop_result.is_ok(),
+            "stop should honor bounded cleanup wait"
+        );
+        stop_result
+            .expect("timeout result")
+            .expect("stop should succeed");
+
+        assert_eq!(
+            std::fs::read_to_string(&observed_cancel_path).expect("cancel message"),
+            r#"{"type":"cancel"}"#
+        );
+        assert_eq!(
+            std::fs::read_to_string(&completed_path).expect("cleanup marker"),
+            "done"
+        );
+        let log = std::fs::read_to_string(log_path).expect("operator log");
+        assert!(log.contains("desktop.compute_node.bridge_process_exited"));
+        assert!(log.contains("killed=false"));
+        assert!(!log.contains("desktop.compute_node.bridge_kill_requested"));
+    }
+
     #[tokio::test]
     async fn repeated_start_stop_start_does_not_leave_stale_child_handle() {
         let state = ComputeNodeState::default();

--- a/static/chat.js
+++ b/static/chat.js
@@ -1,6 +1,6 @@
 const ASSISTANT_GENERIC_FALLBACK_MESSAGE = 'Sorry, I encountered an issue generating a response. Please try again.';
 const ASSISTANT_INVALID_RELAY_RESPONSE_MESSAGE = 'Sorry, the relay returned an invalid response. Please try again.';
-const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 30000;
+const COMPUTE_NODE_COUNT_POLL_INTERVAL_MS = 1000;
 const RELAY_RESPONSE_POLL_TIMEOUT_MS = 300000;
 const EMERGENCY_MODEL_FALLBACK_ID = 'qwen3-8b-instruct';
 const CONTEXT_TIER_STORAGE_KEY = 'token.place.landing.contextTier.v1';
@@ -40,6 +40,7 @@ new Vue({
         computeNodeCountStatus: 'loading',
         computeNodeCountLastUpdated: '',
         computeNodeCountPoller: null,
+        computeNodeCountRefreshInFlight: false,
         computeNodeCountRequestId: 0
     },
     mounted() {
@@ -47,10 +48,7 @@ new Vue({
         this.selectedContextTier = this.loadStoredContextTier();
         this.fetchModels();
         this.generateClientKeys();
-        this.refreshComputeNodeCount();
-        this.computeNodeCountPoller = setInterval(() => {
-            this.refreshComputeNodeCount();
-        }, COMPUTE_NODE_COUNT_POLL_INTERVAL_MS);
+        this.startComputeNodeCountPoller();
         this.$nextTick(() => {
             this.adjustMessageInputHeight();
         });
@@ -101,12 +99,45 @@ new Vue({
         }
     },
     methods: {
+        startComputeNodeCountPoller() {
+            const scheduleNext = () => {
+                if (this.computeNodeCountPoller) {
+                    clearTimeout(this.computeNodeCountPoller);
+                    this.computeNodeCountPoller = null;
+                }
+                this.computeNodeCountPoller = setTimeout(async () => {
+                    if (typeof document !== 'undefined' && document.hidden) {
+                        scheduleNext();
+                        return;
+                    }
+                    await this.refreshComputeNodeCount({ skipIfInFlight: true });
+                    scheduleNext();
+                }, COMPUTE_NODE_COUNT_POLL_INTERVAL_MS);
+            };
+            this.refreshComputeNodeCount({ skipIfInFlight: true });
+            scheduleNext();
+            if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+                document.addEventListener('visibilitychange', this.handleComputeNodeCountVisibilityChange);
+            }
+        },
+
+        handleComputeNodeCountVisibilityChange() {
+            if (typeof document !== 'undefined' && !document.hidden) {
+                this.refreshComputeNodeCount({ skipIfInFlight: true });
+            }
+        },
+
         async refreshComputeNodeCount(options = {}) {
             // Failover capacity refreshes must be allowed to apply their own
             // successful diagnostics result even if the background poller starts
             // another request before they finish; otherwise a stale count of one
             // can incorrectly suppress probing for a newly registered replacement.
             const applySupersededSuccess = options && options.applySupersededSuccess === true;
+            const skipIfInFlight = options && options.skipIfInFlight === true;
+            if (skipIfInFlight && this.computeNodeCountRefreshInFlight) {
+                return false;
+            }
+            this.computeNodeCountRefreshInFlight = true;
             const requestId = this.computeNodeCountRequestId + 1;
             this.computeNodeCountRequestId = requestId;
 
@@ -148,6 +179,10 @@ new Vue({
                 this.computeNodeCountStatus = 'error';
                 this.computeNodeCountLastUpdated = '';
                 return false;
+            } finally {
+                if (requestId === this.computeNodeCountRequestId || !this.computeNodeCountRefreshInFlight) {
+                    this.computeNodeCountRefreshInFlight = false;
+                }
             }
         },
 
@@ -1333,8 +1368,11 @@ new Vue({
     },
     beforeDestroy() {
         if (this.computeNodeCountPoller) {
-            clearInterval(this.computeNodeCountPoller);
+            clearTimeout(this.computeNodeCountPoller);
             this.computeNodeCountPoller = null;
+        }
+        if (typeof document !== 'undefined' && typeof document.removeEventListener === 'function') {
+            document.removeEventListener('visibilitychange', this.handleComputeNodeCountVisibilityChange);
         }
         if (!Array.isArray(this.chatHistory)) {
             return;

--- a/tests/e2e/test_ui.py
+++ b/tests/e2e/test_ui.py
@@ -525,11 +525,13 @@ def test_compute_node_status_keeps_first_paint_footprint_when_loading_label_is_b
 
 
 def test_compute_node_count_renders_and_updates(page: Page, base_url: str, setup_servers):
-    """Landing page should render and refresh the relay diagnostics compute-node count."""
-    counts = iter([3, 5])
-    latest_count = {"value": 5}
+    """Landing page should automatically refresh the relay diagnostics compute-node count."""
+    counts = iter([1, 0])
+    latest_count = {"value": 0}
+    call_count = {"value": 0}
 
     def handle_diagnostics(route):
+        call_count["value"] += 1
         try:
             latest_count["value"] = next(counts)
         except StopIteration:
@@ -557,29 +559,30 @@ def test_compute_node_count_renders_and_updates(page: Page, base_url: str, setup
             const status = document.querySelector('.compute-node-status');
             return Boolean(
                 status &&
-                status.textContent.includes('Live compute nodes: 3') &&
+                status.textContent.includes('Live compute nodes: 1') &&
                 status.textContent.includes('Updated')
             );
         }
         """
     )
-    assert "Live compute nodes: 3" in status.inner_text()
+    assert "Live compute nodes: 1" in status.inner_text()
     assert "Updated" in status.inner_text()
 
-    page.evaluate("document.querySelector('#app').__vue__.refreshComputeNodeCount()")
     page.wait_for_function(
         """
         () => {
             const status = document.querySelector('.compute-node-status');
             return Boolean(
                 status &&
-                status.textContent.includes('Live compute nodes: 5') &&
+                status.textContent.includes('Live compute nodes: 0') &&
                 status.textContent.includes('Updated')
             );
         }
-        """
+        """,
+        timeout=2500,
     )
-    assert "Live compute nodes: 5" in status.inner_text()
+    assert call_count["value"] >= 2
+    assert "Live compute nodes: 0" in status.inner_text()
     assert "Updated" in status.inner_text()
 
 

--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -6749,3 +6749,37 @@ def test_worker_diagnostic_sanitizer_allows_qwen_plain_completion_variant_fields
     assert "prompt" not in safe
     assert "token_ids" not in safe
     assert "SECRET_PROMPT" not in json.dumps(safe)
+
+
+def test_api_v1_in_flight_heartbeat_does_not_resurrect_after_stop():
+    relay_client = _api_v1_validation_client()
+    relay_client._api_v1_registered_relays.add(relay_client.relay_url)
+    relay_client._api_v1_last_heartbeat_at[relay_client.relay_url] = 0.0
+    relay_client._api_v1_relay_wait_hints = {
+        relay_client.relay_url: {"next_ping_in_x_seconds": 1, "poll_wait_seconds": 1}
+    }
+    heartbeat_started = threading.Event()
+    release_heartbeat = threading.Event()
+
+    def register(url):
+        assert url == relay_client.relay_url
+        heartbeat_started.set()
+        assert release_heartbeat.wait(timeout=2.0)
+        return {"next_ping_in_x_seconds": 1, "poll_wait_seconds": 1}
+
+    relay_client.register_api_v1_compute_node = register
+    worker = threading.Thread(target=relay_client._api_v1_heartbeat_worker)
+    worker.start()
+    assert heartbeat_started.wait(timeout=1.0)
+
+    relay_client.stop_polling = True
+    relay_client._polling_stopped_by_request = True
+    relay_client._api_v1_heartbeat_stop.set()
+    relay_client._api_v1_registered_relays.clear()
+    relay_client._api_v1_last_heartbeat_at.clear()
+    release_heartbeat.set()
+    worker.join(timeout=2.0)
+
+    assert not worker.is_alive()
+    assert relay_client._api_v1_registered_relays == set()
+    assert relay_client._api_v1_last_heartbeat_at == {}

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -1104,6 +1104,15 @@ class RelayClient:
                     )
                     continue
                 if isinstance(response, dict) and not response.get("error"):
+                    if self._api_v1_heartbeat_stop.is_set() or getattr(
+                        self, "_polling_stopped_by_request", False
+                    ):
+                        log_info(
+                            "server.heartbeat.background_skipped relay={} reason=stop_requested key_fingerprint={}",
+                            _sanitize_relay_target(candidate_url),
+                            self._api_v1_public_key_fingerprint(self.crypto_manager.public_key_b64),
+                        )
+                        break
                     refreshed_lease = self._normalise_positive_seconds(
                         response.get("next_ping_in_x_seconds"), lease
                     )


### PR DESCRIPTION
### Motivation
- The landing page polled `/relay/diagnostics` only every 30s, leaving a successful unregister visually stale for up to 30s. 
- The Tauri stop path allowed the bridge only a very short (~1s) wait before force-kill, which could kill a healthy bridge before it finished unregistering. 
- An in-flight API-v1 heartbeat response could re-populate local registration state after stop began, risking a false-positive registered state.

### Description
- Reduce and rework the landing-page poller: set `COMPUTE_NODE_COUNT_POLL_INTERVAL_MS` to 1000ms and replace the overlapping `setInterval` with a bounded timeout loop, add `skipIfInFlight` suppression, `visibilitychange` immediate refresh, and proper timer/listener cleanup in `static/chat.js`.
- Extend the Tauri bridge shutdown contract to 15s before hard-kill in `desktop-tauri/src-tauri/src/compute_node.rs` so the Python bridge has bounded time to finish unregister and emit stopped before force-kill.
- Guard heartbeat worker: stop the heartbeat background flow from re-registering when a stop/unregister is underway and emit a sanitized log message, in `utils/networking/relay_client.py`.
- Add regression tests: update `tests/e2e/test_ui.py` to assert the landing widget auto-refreshes from 1→0 within the SLA (without calling the refresh helper), add a unit test in `tests/unit/test_relay_client.py` to assert in-flight heartbeat does not resurrect registration after stop, and add a Rust unit test in `desktop-tauri/src-tauri/src/compute_node.rs` verifying bridge cleanup honored before kill fallback.

### Testing
- Installed focused verification deps: `pip install -r config/requirements_codex_verification.txt` (succeeded).
- Python unit/integration tests run:
  - `python -m pytest tests/test_relay.py -k "unregister or diagnostics" -v` — passed.
  - `python -m pytest tests/unit/test_relay_client.py -k "unregister or stop or heartbeat" -v` — passed (includes new heartbeat test).
  - `python -m pytest tests/unit/test_compute_node_runtime.py -k "stop or unregister" -v` — passed.
  - `python -m pytest tests/unit/test_desktop_compute_node_bridge.py -k "stop or unregister or registered" -v` — passed.
  - `python -m pytest tests/e2e/test_ui.py -k "compute_node_count" -v` — could not run to completion in this environment because Playwright Chromium failed to launch due to missing system library `libatk-1.0.so.0` (environment limitation); the E2E test was added/updated and should pass in CI with Playwright browsers available.
- Rust tests: attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node` but the build could not complete in this environment due to missing system pkg-config/deps (`glib-2.0.pc`), so the new Rust test was added but not executed here.
- Desktop frontend: `npm --prefix desktop-tauri install` and `npm --prefix desktop-tauri test -- src/App.test.tsx` were run and the desktop JS tests passed.
- Repository checks: `git diff --check` and `pre-commit run --all-files` completed locally (pre-commit hooks and project checks ran and passed where applicable).

Notes/limits: Playwright Chromium and Cargo native build required system libraries that are not available in this container (`libatk-1.0.so.0` and `glib-2.0.pc`), so the environment-blocked E2E and full cargo runs could not be executed here; those should be exercised in CI or a dev machine with the required native packages installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59d303b0e0832fa86478630482f536)