### PR TITLE
API v1 desktop cancellation: control polling and worker termination

### DIFF
--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -7013,3 +7013,88 @@ def test_api_v1_background_heartbeat_preserves_and_rotates_control_credential(mo
 
     assert observed == ['current-secret', 'current-secret']
     assert client._api_v1_control_credential_for_relay('http://localhost:5000') == 'rotated-secret'
+
+
+def test_api_v1_control_poll_hint_clamps_and_handles_malformed():
+    assert RelayClient._api_v1_control_poll_hint(0.25) == 1.0
+    assert RelayClient._api_v1_control_poll_hint(15) == 10.0
+    assert RelayClient._api_v1_control_poll_hint('bad') == 1.0
+    assert RelayClient._api_v1_control_poll_hint(3) == 3.0
+
+
+def test_api_v1_deadline_uses_smaller_remaining_and_only_shortens(monkeypatch):
+    client = _standalone_relay_client()
+    ticks = iter([100.0, 110.0, 120.0])
+    monkeypatch.setattr(relay_client_module.time, 'monotonic', lambda: next(ticks))
+    deadline = client._api_v1_local_deadline_from_work({
+        'request_deadline_remaining_seconds': 30,
+        'request_ttl_seconds': 20,
+    })
+    assert deadline == 120.0
+    assert client._api_v1_shorten_deadline(deadline, {'request_deadline_remaining_seconds': 50}) == deadline
+    assert client._api_v1_shorten_deadline(deadline, {'request_deadline_remaining_seconds': 5}) == deadline
+
+
+@patch('utils.networking.relay_client.requests.post')
+def test_api_v1_registration_heartbeat_omitting_control_credential_does_not_erase(mock_post):
+    client = _standalone_relay_client()
+    target = 'http://localhost:5000'
+    first = MagicMock(status_code=200)
+    first.json.return_value = {'control_credential': 'secret-one'}
+    second = MagicMock(status_code=200)
+    second.json.return_value = {'next_ping_in_x_seconds': 30}
+    mock_post.side_effect = [first, second]
+
+    client.register_api_v1_compute_node(target)
+    client.register_api_v1_compute_node(target)
+
+    assert client._api_v1_control_credential_for_relay(target) == 'secret-one'
+
+
+@patch('utils.networking.relay_client.requests.post')
+def test_api_v1_unregister_clears_only_matching_relay_credential(mock_post):
+    client = _standalone_relay_client()
+    relay_a = 'http://relay-a:5000'
+    relay_b = 'http://relay-b:5000'
+    client._relay_urls = [relay_a, relay_b]
+    client._api_v1_registered_relays.add(relay_a)
+    client._store_api_v1_control_credential(relay_a, 'secret-a')
+    client._store_api_v1_control_credential(relay_b, 'secret-b')
+    success = MagicMock(status_code=200)
+    mock_post.return_value = success
+
+    assert client.unregister_from_relay() is True
+
+    assert client._api_v1_control_credential_for_relay(relay_a) == ''
+    assert client._api_v1_control_credential_for_relay(relay_b) == 'secret-b'
+
+
+@patch('utils.networking.relay_client.requests.post')
+def test_api_v1_control_request_uses_matching_credential_and_token(mock_post):
+    client = _standalone_relay_client()
+    client._registration_token = 'registration-token'
+    target = 'http://localhost:5000'
+    client._store_api_v1_control_credential(target, 'owner-secret')
+    response = MagicMock(status_code=200)
+    response.json.return_value = {'status': 'active', 'next_poll_seconds': 2}
+    mock_post.return_value = response
+
+    result = client.control_api_v1_request(request_id='req-control', relay_url=target, acknowledge=True)
+
+    assert result['status'] == 'active'
+    payload = mock_post.call_args.kwargs['json']
+    assert payload == {
+        'server_public_key': client.crypto_manager.public_key_b64,
+        'request_id': 'req-control',
+        'control_credential': 'owner-secret',
+        'acknowledge': True,
+    }
+    assert mock_post.call_args.kwargs['headers']['X-Relay-Server-Token'] == 'registration-token'
+
+
+def test_api_v1_control_request_without_credential_fails_closed_without_http():
+    client = _standalone_relay_client()
+
+    result = client.control_api_v1_request(request_id='req-control', relay_url='http://localhost:5000')
+
+    assert result == {'status': 'owner-proof-failed', 'http_status': 403}

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import base64
+import concurrent.futures
 import binascii
 import importlib
 import ipaddress
@@ -1459,7 +1460,6 @@ class RelayClient:
         self._unregister_complete = True
         if len(unregistered_relays) == len(target_urls):
             self._api_v1_registered_relays.clear()
-            self._clear_api_v1_control_credentials()
             self._api_v1_last_heartbeat_at.clear()
             relay_wait_hints.clear()
         return True
@@ -2159,6 +2159,100 @@ class RelayClient:
             'error': 'No relay targets responded',
             'next_ping_in_x_seconds': self._request_timeout,
         }
+
+
+    @staticmethod
+    def _api_v1_control_seconds(value: Any) -> Optional[float]:
+        if isinstance(value, bool):
+            return None
+        try:
+            seconds = float(value)
+        except (TypeError, ValueError):
+            return None
+        return seconds if math.isfinite(seconds) and seconds > 0 else None
+
+    @classmethod
+    def _api_v1_local_deadline_from_work(cls, work: Dict[str, Any]) -> float:
+        values = [
+            cls._api_v1_control_seconds(work.get('request_deadline_remaining_seconds')),
+            cls._api_v1_control_seconds(work.get('request_ttl_seconds')),
+        ]
+        valid = [value for value in values if value is not None]
+        # Compatibility with older relays: never wait indefinitely for an
+        # owner-control route that predates deadline metadata.
+        remaining = min(valid) if valid else DEFAULT_API_V1_LEASE_SECONDS
+        return time.monotonic() + remaining
+
+    @staticmethod
+    def _api_v1_control_poll_hint(value: Any) -> float:
+        if isinstance(value, bool):
+            return 1.0
+        try:
+            seconds = float(value)
+        except (TypeError, ValueError):
+            return 1.0
+        if not math.isfinite(seconds):
+            return 1.0
+        return min(10.0, max(1.0, seconds))
+
+    def _api_v1_shorten_deadline(self, deadline: float, payload: Dict[str, Any]) -> float:
+        values = [
+            self._api_v1_control_seconds(payload.get('request_deadline_remaining_seconds')),
+            self._api_v1_control_seconds(payload.get('request_ttl_seconds')),
+        ]
+        valid = [value for value in values if value is not None]
+        if not valid:
+            return deadline
+        candidate = time.monotonic() + min(valid)
+        return min(deadline, candidate)
+
+    def control_api_v1_request(
+        self,
+        *,
+        request_id: str,
+        relay_url: Optional[str] = None,
+        acknowledge: bool = False,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        target_url = relay_url or self._api_v1_response_relay_url()
+        credential = self._api_v1_control_credential_for_relay(target_url)
+        if not credential:
+            return {'status': 'owner-proof-failed', 'http_status': 403}
+        payload = {
+            'server_public_key': self.crypto_manager.public_key_b64,
+            'request_id': request_id,
+            'control_credential': credential,
+            'acknowledge': bool(acknowledge),
+        }
+        headers = self._auth_headers()
+        kwargs: Dict[str, Any] = {'json': payload, 'timeout': timeout or self._request_timeout}
+        if headers:
+            kwargs['headers'] = headers
+        url = self._build_api_v1_url(target_url, '/relay/servers/control')
+        response = requests.post(url, **kwargs)
+        if response.status_code in {401, 403}:
+            return {'status': 'owner-proof-failed', 'http_status': response.status_code}
+        if response.status_code != 200:
+            if response.status_code in {429, 500, 502, 503, 504}:
+                return {'status': 'transient-failure', 'http_status': response.status_code}
+            return {'status': 'control-failure', 'http_status': response.status_code}
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {'status': 'control-failure'}
+
+    def _api_v1_terminate_runtime_worker(self, reason: str) -> None:
+        llm = getattr(self.model_manager, 'llm', None)
+        invalidator = getattr(self.model_manager, '_invalidate_llm_if_current', None)
+        if callable(invalidator) and llm is not None:
+            invalidator(llm, reason)
+            return
+        close = getattr(llm, 'close', None)
+        if callable(close):
+            close()
+        if llm is not None:
+            try:
+                setattr(self.model_manager, 'llm', None)
+            except Exception:
+                pass
 
     def _api_v1_response_relay_url(self) -> str:
         """Return the relay URL that supplied the current API v1 work item."""
@@ -4402,13 +4496,100 @@ class RelayClient:
                 try:
                     if getattr(self, "_api_v1_registered_relays", set()):
                         self._api_v1_start_heartbeat_worker()
-                    response_envelope = self._generate_api_v1_response_with_runtime_model(
-                        request_id=api_v1_request_payload["request_id"],
-                        model_id=api_v1_request_payload["model"],
-                        messages=api_v1_request_payload["messages"],
-                        options=dict(api_v1_request_payload["options"]),
-                        requested_context_tier=api_v1_request_payload["routing"]["context_tier"],
-                    )
+                    request_id = api_v1_request_payload["request_id"]
+                    work_relay_url = self._api_v1_response_relay_url()
+                    has_live_registration = work_relay_url in getattr(self, '_api_v1_registered_relays', set())
+                    control_available = bool(self._api_v1_control_credential_for_relay(work_relay_url))
+                    local_deadline = self._api_v1_local_deadline_from_work(request_data)
+
+                    def _generate() -> Dict[str, Any]:
+                        return self._generate_api_v1_response_with_runtime_model(
+                            request_id=request_id,
+                            model_id=api_v1_request_payload["model"],
+                            messages=api_v1_request_payload["messages"],
+                            options=dict(api_v1_request_payload["options"]),
+                            requested_context_tier=api_v1_request_payload["routing"]["context_tier"],
+                        )
+
+                    terminal_status: Optional[str] = None
+                    terminal_reason: Optional[str] = None
+                    next_poll_seconds = 1.0
+                    backoff_seconds = 1.0
+                    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1, thread_name_prefix='api_v1_inference')
+                    future = executor.submit(_generate)
+                    try:
+                        while True:
+                            if future.done():
+                                response_envelope = future.result()
+                                break
+                            now = time.monotonic()
+                            remaining = local_deadline - now
+                            if remaining <= 0:
+                                terminal_status = 'expired'
+                                terminal_reason = 'local_authoritative_deadline'
+                                break
+                            if getattr(self, '_polling_stopped_by_request', False):
+                                terminal_status = 'operator-stop'
+                                terminal_reason = 'operator_stop'
+                                break
+                            try:
+                                if not control_available:
+                                    if has_live_registration:
+                                        terminal_status = 'owner-proof-failed'
+                                        terminal_reason = 'owner_proof_failed'
+                                        break
+                                    next_poll_seconds = min(10.0, max(1.0, remaining))
+                                    raise requests.RequestException('control unavailable')
+                                control_timeout = max(0.1, min(self._request_timeout, remaining, 5.0) * 0.8)
+                                control = self.control_api_v1_request(
+                                    request_id=request_id,
+                                    relay_url=work_relay_url,
+                                    timeout=control_timeout,
+                                )
+                                status = str(control.get('status') or '').lower()
+                                local_deadline = self._api_v1_shorten_deadline(local_deadline, control)
+                                if status == 'active':
+                                    next_poll_seconds = self._api_v1_control_poll_hint(control.get('next_poll_seconds'))
+                                    backoff_seconds = 1.0
+                                elif status in {'cancelled', 'expired', 'completed/unavailable'}:
+                                    terminal_status = status
+                                    terminal_reason = status.replace('/', '_')
+                                    break
+                                elif status == 'owner-proof-failed':
+                                    terminal_status = 'owner-proof-failed'
+                                    terminal_reason = 'owner_proof_failed'
+                                    break
+                                else:
+                                    next_poll_seconds = backoff_seconds
+                                    backoff_seconds = min(10.0, backoff_seconds * 2.0)
+                            except requests.RequestException:
+                                next_poll_seconds = backoff_seconds
+                                backoff_seconds = min(10.0, backoff_seconds * 2.0)
+                            sleep_for = min(next_poll_seconds, max(0.0, local_deadline - time.monotonic()))
+                            if sleep_for > 0 and not future.done():
+                                try:
+                                    response_envelope = future.result(timeout=sleep_for)
+                                    break
+                                except concurrent.futures.TimeoutError:
+                                    pass
+                        if terminal_status is not None:
+                            self._api_v1_terminate_runtime_worker(terminal_reason or terminal_status)
+                            if terminal_status in {'cancelled', 'expired'}:
+                                try:
+                                    self.control_api_v1_request(
+                                        request_id=request_id,
+                                        relay_url=work_relay_url,
+                                        acknowledge=True,
+                                        timeout=min(2.0, self._request_timeout),
+                                    )
+                                except Exception:
+                                    pass
+                            return RelayProcessingResult.submission_failed(
+                                safe_error_code='request_cancelled' if terminal_status == 'cancelled' else terminal_reason,
+                                runtime_healthy=False,
+                            )
+                    finally:
+                        executor.shutdown(wait=False, cancel_futures=True)
                     api_v1_response = response_envelope.get("api_v1_response", {})
                     error = api_v1_response.get("error") if isinstance(api_v1_response, dict) else None
                     safe_error_code = error.get("code") if isinstance(error, dict) else None


### PR DESCRIPTION
### Motivation
- Ensure desktop inference obeys the API v1 compute-control contract so browser cancellation, relay expiry, authoritative deadlines, or operator Stop reliably terminate Metal/CUDA (llama) subprocesses and prevent wasted compute.

### Description
- Add owner-control helpers and polling logic to `utils/networking/relay_client.py` to compute local monotonic deadlines, clamp `next_poll_seconds` to the P1 1–10s range, send authenticated `/api/v1/relay/servers/control` requests, and classify control outcomes (active, cancelled, expired, completed/unavailable, owner-proof failure, transient failure). 
- Wrap API v1 desktop generation in a monitored worker future that concurrently observes relay control state, the local monotonic deadline, operator Stop, and transient control failures, and which invalidates/kills the runtime on terminal control outcomes. 
- Preserve per-relay in-memory control credentials and adjust unregister behavior to clear only matching credentials for relays that were successfully unregistered. 
- Add tests and helpers in `tests/unit/test_relay_client.py` to cover poll-hint clamping, deadline calculation/shortening, heartbeat omission preserving credentials, per-relay unregister cleanup, authenticated control requests including `X-Relay-Server-Token`, and fail-closed behavior when a credential is missing. 
- Files changed: `utils/networking/relay_client.py`, `tests/unit/test_relay_client.py`.

### Testing
- Type-check/compile: `python -m py_compile utils/networking/relay_client.py` succeeded. 
- Unit tests: `pytest -q tests/unit/test_relay_client.py` ran and all tests passed (summary shown by test run: 331 passed). 
- Repo checks: `pre-commit run --all-files` completed and hooks passed (codespell/vulture/bandit and repo checks ran). 
- Notes/limits: end-to-end cancellation requires the P1 `/api/v1/relay/servers/control` route to be deployed for true integration validation, and desktop operators must rebuild/repackage the desktop app to pick up the runtime/worker-recovery behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c681bbd70832f8b1352a648215268)