### PR TITLE
Add desktop API v1 cancellation control

### DIFF
--- a/tests/unit/test_relay_client.py
+++ b/tests/unit/test_relay_client.py
@@ -7013,3 +7013,127 @@ def test_api_v1_background_heartbeat_preserves_and_rotates_control_credential(mo
 
     assert observed == ['current-secret', 'current-secret']
     assert client._api_v1_control_credential_for_relay('http://localhost:5000') == 'rotated-secret'
+
+
+def _make_api_v1_control_test_client():
+    crypto = MagicMock()
+    crypto.public_key_b64 = "server-key"
+    model_manager = MagicMock()
+    model_manager.llm_lock = threading.Lock()
+    model_manager.llm = None
+    with patch('utils.networking.relay_client.get_config_lazy') as mock_get_config:
+        config = MagicMock()
+        config.get.side_effect = lambda key, default=None: {'relay.request_timeout': 1}.get(key, default)
+        mock_get_config.return_value = config
+        client = RelayClient("http://localhost", 5000, crypto, model_manager)
+        client.stop_polling = False
+        client._polling_stopped_by_request = False
+        return client
+
+
+def test_api_v1_deadline_helpers_clamp_and_never_extend(monkeypatch):
+    now = 100.0
+    assert relay_client_module._api_v1_initial_deadline(5, 9, now=now) == 105.0
+    assert relay_client_module._api_v1_initial_deadline(True, "bad", -1, now=now) == now + relay_client_module.DEFAULT_API_V1_LEASE_SECONDS
+    assert relay_client_module._api_v1_bounded_next_poll_seconds(0.25) == 1.0
+    assert relay_client_module._api_v1_bounded_next_poll_seconds(999) == 10.0
+    assert relay_client_module._api_v1_bounded_next_poll_seconds("bad") == 1.0
+
+
+def test_api_v1_control_poll_shortens_but_never_extends_deadline(monkeypatch):
+    relay_client = _make_api_v1_control_test_client()
+    times = iter([100.0, 100.0])
+    monkeypatch.setattr(relay_client_module.time, "monotonic", lambda: next(times))
+    assert relay_client._api_v1_shorten_deadline_from_control(110.0, {"request_deadline_remaining_seconds": 3}) == 103.0
+    times = iter([100.0, 100.0])
+    assert relay_client._api_v1_shorten_deadline_from_control(110.0, {"request_deadline_remaining_seconds": 99}) == 110.0
+
+
+@patch('utils.networking.relay_client.requests.post')
+def test_api_v1_control_request_fails_closed_without_credential(mock_post):
+    relay_client = _make_api_v1_control_test_client()
+    result = relay_client._api_v1_control_request(
+        relay_url=relay_client.relay_url,
+        request_id="req-missing-owner-proof",
+        acknowledge=False,
+        timeout=0.1,
+    )
+    assert result["state"] == "owner_proof_failed"
+    mock_post.assert_not_called()
+
+
+@patch('utils.networking.relay_client.requests.post')
+def test_api_v1_control_request_uses_stored_credential_and_acknowledges(mock_post):
+    relay_client = _make_api_v1_control_test_client()
+    relay_client._store_api_v1_control_credential(relay_client.relay_url, "secret-owner-proof")
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"state": "cancelled", "next_poll_seconds": 1}
+    mock_post.return_value = response
+    result = relay_client._api_v1_control_request(
+        relay_url=relay_client.relay_url,
+        request_id="req-control",
+        acknowledge=True,
+        timeout=0.2,
+    )
+    assert result["state"] == "cancelled"
+    assert mock_post.call_args.args[0].endswith('/api/v1/relay/servers/control')
+    assert mock_post.call_args.kwargs["json"] == {
+        "server_public_key": relay_client.crypto_manager.public_key_b64,
+        "request_id": "req-control",
+        "control_credential": "secret-owner-proof",
+        "acknowledge": True,
+    }
+
+
+def test_api_v1_desktop_control_cancellation_stops_worker_and_suppresses_submission(monkeypatch):
+    relay_client = _make_api_v1_control_test_client()
+    relay_client._store_api_v1_control_credential(relay_client.relay_url, "owner-proof")
+    cancelled = []
+    def slow_generation(**_kwargs):
+        time.sleep(5)
+        return {"request_id": "req-cancel", "api_v1_response": {"message": {"role": "assistant", "content": "late"}}}
+    monkeypatch.setattr(relay_client, "_generate_api_v1_response_with_runtime_model", slow_generation)
+    monkeypatch.setattr(relay_client, "_api_v1_cancel_current_worker", lambda reason: cancelled.append(reason))
+    calls = []
+    def fake_control(**kwargs):
+        calls.append(kwargs)
+        return {"state": "cancelled", "next_poll_seconds": 1}
+    monkeypatch.setattr(relay_client, "_api_v1_control_request", fake_control)
+
+    response, outcome = relay_client._generate_api_v1_response_with_desktop_control(
+        api_v1_request_payload={
+            "request_id": "req-cancel",
+            "model": "llama-3-8b-instruct",
+            "messages": [{"role": "user", "content": "hi"}],
+            "options": {},
+            "routing": {"context_tier": "8k-fast"},
+            "request_deadline_remaining_seconds": 30,
+        },
+        relay_url=relay_client.relay_url,
+    )
+    assert response is None
+    assert outcome == "cancelled"
+    assert cancelled == ["api_v1_control_cancelled"]
+    assert calls[-1]["acknowledge"] is True
+
+
+def test_api_v1_desktop_control_deadline_beats_next_poll(monkeypatch):
+    relay_client = _make_api_v1_control_test_client()
+    cancelled = []
+    monkeypatch.setattr(relay_client, "_api_v1_cancel_current_worker", lambda reason: cancelled.append(reason))
+    monkeypatch.setattr(relay_client, "_api_v1_control_request", lambda **kwargs: {"state": "active", "next_poll_seconds": 10})
+    monkeypatch.setattr(relay_client, "_generate_api_v1_response_with_runtime_model", lambda **_kwargs: time.sleep(5))
+    response, outcome = relay_client._generate_api_v1_response_with_desktop_control(
+        api_v1_request_payload={
+            "request_id": "req-deadline",
+            "model": "llama-3-8b-instruct",
+            "messages": [],
+            "options": {},
+            "routing": {"context_tier": "8k-fast"},
+            "request_deadline_remaining_seconds": 0.2,
+        },
+        relay_url=relay_client.relay_url,
+    )
+    assert response is None
+    assert outcome == "expired"
+    assert cancelled == ["api_v1_authoritative_deadline_expired"]

--- a/utils/networking/relay_client.py
+++ b/utils/networking/relay_client.py
@@ -14,6 +14,7 @@ import re
 import sys
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Set, Tuple, Union
 
 from utils.processing_result import RelayProcessingResult
@@ -838,7 +839,34 @@ def _extract_api_v1_request_payload(
         "messages": messages,
         "options": options,
         "routing": {"context_tier": context_tier},
+        "request_deadline_remaining_seconds": decrypted_payload.get("request_deadline_remaining_seconds"),
+        "request_ttl_seconds": decrypted_payload.get("request_ttl_seconds"),
     }
+
+
+def _api_v1_valid_remaining_seconds(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    try:
+        remaining = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(remaining) or remaining < 0:
+        return None
+    return remaining
+
+
+def _api_v1_initial_deadline(*values: Any, now: Optional[float] = None) -> float:
+    valid = [v for v in (_api_v1_valid_remaining_seconds(value) for value in values) if v is not None]
+    remaining = min(valid) if valid else DEFAULT_API_V1_LEASE_SECONDS
+    return (time.monotonic() if now is None else now) + remaining
+
+
+def _api_v1_bounded_next_poll_seconds(value: Any) -> float:
+    seconds = _api_v1_valid_remaining_seconds(value)
+    if seconds is None or seconds <= 0:
+        return 1.0
+    return min(10.0, max(1.0, seconds))
 
 
 class RelayClient:
@@ -2159,6 +2187,128 @@ class RelayClient:
             'error': 'No relay targets responded',
             'next_ping_in_x_seconds': self._request_timeout,
         }
+
+
+    def _api_v1_control_request(self, *, relay_url: str, request_id: str, acknowledge: bool, timeout: float) -> Dict[str, Any]:
+        credential = self._api_v1_control_credential_for_relay(relay_url)
+        if not credential:
+            return {"state": "owner_proof_failed", "http_status": 403}
+        payload = {
+            "server_public_key": getattr(self.crypto_manager, "public_key_b64", ""),
+            "request_id": request_id,
+            "control_credential": credential,
+            "acknowledge": bool(acknowledge),
+        }
+        kwargs: Dict[str, Any] = {"json": payload}
+        headers = self._auth_headers()
+        if headers:
+            kwargs["headers"] = headers
+        response = requests.post(
+            self._build_api_v1_url(relay_url, "/relay/servers/control"),
+            timeout=max(0.05, timeout),
+            **kwargs,
+        )
+        if response.status_code in {401, 403}:
+            return {"state": "owner_proof_failed", "http_status": response.status_code}
+        if response.status_code in {429, 500, 502, 503, 504}:
+            return {"state": "transient_failure", "http_status": response.status_code}
+        if response.status_code != 200:
+            return {"state": "transient_failure", "http_status": response.status_code}
+        body = response.json()
+        return body if isinstance(body, dict) else {"state": "transient_failure"}
+
+    def _api_v1_shorten_deadline_from_control(self, deadline: float, control: Dict[str, Any]) -> float:
+        now = time.monotonic()
+        candidates = [
+            _api_v1_valid_remaining_seconds(control.get("request_deadline_remaining_seconds")),
+            _api_v1_valid_remaining_seconds(control.get("request_ttl_seconds")),
+        ]
+        valid = [value for value in candidates if value is not None]
+        if not valid:
+            return deadline
+        return min(deadline, now + min(valid))
+
+    def _api_v1_cancel_current_worker(self, reason: str) -> None:
+        manager = self.model_manager
+        with getattr(manager, "llm_lock", threading.Lock()):
+            llm = getattr(manager, "llm", None)
+        invalidate = getattr(manager, "_invalidate_llm_if_current", None)
+        if callable(invalidate) and llm is not None:
+            invalidate(llm, RuntimeError(reason))
+            return
+        close = getattr(llm, "close", None)
+        if callable(close):
+            close()
+
+    def _generate_api_v1_response_with_desktop_control(
+        self,
+        *,
+        api_v1_request_payload: Dict[str, Any],
+        relay_url: str,
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+        request_id = api_v1_request_payload["request_id"]
+        deadline = _api_v1_initial_deadline(
+            api_v1_request_payload.get("request_deadline_remaining_seconds"),
+            api_v1_request_payload.get("request_ttl_seconds"),
+        )
+        terminal_ack = False
+        executor = ThreadPoolExecutor(max_workers=1)
+        try:
+            future = executor.submit(
+                self._generate_api_v1_response_with_runtime_model,
+                request_id=request_id,
+                model_id=api_v1_request_payload["model"],
+                messages=api_v1_request_payload["messages"],
+                options=dict(api_v1_request_payload["options"]),
+                requested_context_tier=api_v1_request_payload["routing"]["context_tier"],
+            )
+            backoff = 1.0
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    self._api_v1_cancel_current_worker("api_v1_authoritative_deadline_expired")
+                    terminal_ack = True
+                    outcome = "expired"
+                    break
+                try:
+                    return future.result(timeout=min(remaining, 0.05)), None
+                except FutureTimeoutError:
+                    pass
+                if getattr(self, "_polling_stopped_by_request", False) or getattr(self, "stop_polling", False):
+                    self._api_v1_cancel_current_worker("api_v1_operator_stop")
+                    outcome = "operator_stop"
+                    break
+                timeout = min(max(0.05, remaining / 2.0), 2.0)
+                try:
+                    control = self._api_v1_control_request(relay_url=relay_url, request_id=request_id, acknowledge=False, timeout=timeout)
+                except requests.RequestException:
+                    control = {"state": "transient_failure"}
+                state = str(control.get("state") or control.get("status") or "active").lower()
+                deadline = self._api_v1_shorten_deadline_from_control(deadline, control)
+                if state == "active" or state == "transient_failure":
+                    sleep_for = backoff if state == "transient_failure" else _api_v1_bounded_next_poll_seconds(control.get("next_poll_seconds"))
+                    backoff = min(10.0, backoff * 2.0) if state == "transient_failure" else 1.0
+                    try:
+                        return future.result(timeout=min(max(0.0, deadline - time.monotonic()), sleep_for)) , None
+                    except FutureTimeoutError:
+                        continue
+                if state in {"cancelled", "expired", "completed", "unavailable", "owner_proof_failed"}:
+                    self._api_v1_cancel_current_worker(f"api_v1_control_{state}")
+                    terminal_ack = state in {"cancelled", "expired"}
+                    outcome = state
+                    break
+            try:
+                future.result(timeout=1.5)
+            except Exception:
+                pass
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
+        if terminal_ack:
+            try:
+                self._api_v1_control_request(relay_url=relay_url, request_id=request_id, acknowledge=True, timeout=1.0)
+            except Exception:
+                pass
+        return None, outcome
 
     def _api_v1_response_relay_url(self) -> str:
         """Return the relay URL that supplied the current API v1 work item."""
@@ -4402,13 +4552,29 @@ class RelayClient:
                 try:
                     if getattr(self, "_api_v1_registered_relays", set()):
                         self._api_v1_start_heartbeat_worker()
-                    response_envelope = self._generate_api_v1_response_with_runtime_model(
-                        request_id=api_v1_request_payload["request_id"],
-                        model_id=api_v1_request_payload["model"],
-                        messages=api_v1_request_payload["messages"],
-                        options=dict(api_v1_request_payload["options"]),
-                        requested_context_tier=api_v1_request_payload["routing"]["context_tier"],
-                    )
+                    if getattr(self, "_api_v1_registered_relays", set()):
+                        response_envelope, terminal_outcome = self._generate_api_v1_response_with_desktop_control(
+                            api_v1_request_payload=api_v1_request_payload,
+                            relay_url=self._api_v1_response_relay_url(),
+                        )
+                    else:
+                        response_envelope = self._generate_api_v1_response_with_runtime_model(
+                            request_id=api_v1_request_payload["request_id"],
+                            model_id=api_v1_request_payload["model"],
+                            messages=api_v1_request_payload["messages"],
+                            options=dict(api_v1_request_payload["options"]),
+                            requested_context_tier=api_v1_request_payload["routing"]["context_tier"],
+                        )
+                        terminal_outcome = None
+                    if response_envelope is None:
+                        return RelayProcessingResult(
+                            inference_succeeded=False,
+                            submitted=False,
+                            safe_error_code=terminal_outcome,
+                            runtime_healthy=True,
+                            recovery_attempted=True,
+                            recovery_succeeded=True,
+                        )
                     api_v1_response = response_envelope.get("api_v1_response", {})
                     error = api_v1_response.get("error") if isinstance(api_v1_response, dict) else None
                     safe_error_code = error.get("code") if isinstance(error, dict) else None


### PR DESCRIPTION
### Motivation

- Implement the P1 API v1 compute-control contract so browser cancellation, relay expiry, authoritative deadlines, or operator Stop reliably terminate active Metal/CUDA inference instead of leaving the llama subprocess consuming compute. 
- Preserve existing in-memory per-relay owner proof behaviour and enforce fail-closed owner-only control so control operations never leak credentials or run unauthenticated control requests.

### Description

- Capture API v1 deadline metadata from decrypted relay work and compute a one-time local monotonic deadline with validation and a compatibility fallback via `relay_client._api_v1_initial_deadline`, `relay_client._api_v1_valid_remaining_seconds`, and `relay_client._api_v1_bounded_next_poll_seconds`.
- Add owner-proofed control polling with `RelayClient._api_v1_control_request` that uses the existing in-memory credential map, treats 401/403 as owner-proof failure, handles transient 429/5xx responses with bounded classification, and clamps `next_poll_seconds` to the documented 1–10s range.
- Implement a desktop control monitor `RelayClient._generate_api_v1_response_with_desktop_control` that runs inference concurrently and observes: worker completion, local monotonic deadline, control poll state, and operator Stop; it cancels/invalidates the current worker on `cancelled`/`expired`/`completed`/`unavailable`/owner-proof-fail and best-effort acknowledges terminal `cancelled`/`expired` after cleanup to avoid late submissions.
- Provide a subprocess-level termination fallback via `RelayClient._api_v1_cancel_current_worker` that calls the model-manager invalidation/close hooks to ensure Metal/CUDA work is stopped even if runtime abort callbacks are unreliable.
- Wire control-monitor usage into API v1 dispatch so registered relays use the control flow while unregistered/legacy paths continue previous behaviour, and add deterministic unit tests covering deadline helpers, credential fail-closed behaviour, control request payloads/acknowledgements, cancellation suppression, and deadline-vs-next-poll ordering.
- Files changed: `utils/networking/relay_client.py` (control helpers, monitor, credential usage) and `tests/unit/test_relay_client.py` (new deterministic tests and fixtures).

### Testing

- Unit tests run (selected focused commands from verification): `python3 -m pytest -q tests/unit/test_relay_client.py::test_api_v1_deadline_helpers_clamp_and_never_extend tests/unit/test_relay_client.py::test_api_v1_control_poll_shortens_but_never_extends_deadline tests/unit/test_relay_client.py::test_api_v1_control_request_fails_closed_without_credential tests/unit/test_relay_client.py::test_api_v1_control_request_uses_stored_credential_and_acknowledges tests/unit/test_relay_client.py::test_api_v1_desktop_control_cancellation_stops_worker_and_suppresses_submission tests/unit/test_relay_client.py::test_api_v1_desktop_control_deadline_beats_next_poll` and `python3 -m pytest -q tests/unit/test_relay_client.py::TestRelayClient::test_process_client_request_api_v1_invalid_runtime_output_posts_encrypted_error`; all listed tests passed locally.
- Repo checks: `git diff --check` and `pre-commit run --all-files` executed and passed the configured hooks.
- Notes and residuals: end-to-end validation requires the P1 relay control-plane (`POST /api/v1/relay/servers/control`) to be deployed because the desktop behaviour depends on owner-bound control responses; a rebuilt desktop package is required to include these Python relay-client changes in packaged runtimes for real-device verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c6829e9c8832fb8aa5d1e2871a572)