### PR TITLE
Disable Windows NVIDIA release gate and adjust publish job

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -540,13 +540,15 @@ jobs:
           path: desktop-tauri/release-artifacts/*
           if-no-files-found: error
 
-  # Publication intentionally depends on this real self-hosted Windows x64 NVIDIA/RTX gate;
-  # mocked CUDA checks must not satisfy release hardware validation.
+  # Temporarily disabled until a matching self-hosted Windows x64 NVIDIA/RTX
+  # runner is configured. GitHub cannot fall through after a short queue wait.
+  # When hardware is ready, restore this job's release-event condition and add
+  # windows-nvidia-release-gate back to publish.needs.
   windows-nvidia-release-gate:
     name: Windows x64 NVIDIA artifact smoke gate
     needs: build
     runs-on: [self-hosted, Windows, X64, NVIDIA, RTX]
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}
+    if: ${{ false }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -566,7 +568,8 @@ jobs:
 
   publish:
     name: Publish GitHub Release
-    needs: [build, windows-nvidia-release-gate]
+    # Intentionally bypass the hardware smoke gate while no matching self-hosted runner exists.
+    needs: build
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}
     permissions:


### PR DESCRIPTION
Temporarily disable the Windows x64 NVIDIA artifact gate and bypass it in the publish job due to the absence of a matching self-hosted runner.

## Summary
- **Type of change:** _feature_, _fix_, or _docs_
- **Related issues:** closes #

## Checklist
- [ ] Linted
- [ ] Tests added/updated
- [ ] Docs updated
- [ ] AGENTS.md updated if applicable

## Notes
Describe any notable changes or additional context.
