### PR TITLE
Add desktop cancellation platform regressions

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -156,6 +156,8 @@ jobs:
           python -m pytest tests/unit/test_desktop_runtime_setup.py -q
           python -m pytest tests/unit/test_model_manager.py -q
           python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q
+          python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q -k cancellation
+          cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml terminate_bridge_process_tree -- --nocapture
           cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml operator_logs
 
       - name: Upload desktop relay parity logs on failure (Windows)
@@ -230,6 +232,11 @@ jobs:
         env:
           TOKEN_PLACE_INSPECT_ONLY: "1"
         run: python desktop-tauri/scripts/test_packaged_operator_e2e.py
+
+      - name: Run focused packaged cancellation regressions (macOS)
+        run: |
+          python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q -k cancellation
+          cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml terminate_bridge_process_tree -- --nocapture
 
       - name: Run shared desktop parity checks (macOS)
         run: python desktop-tauri/scripts/run_desktop_parity_checks.py

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -5707,6 +5707,123 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    fn unix_process_alive(pid: u32) -> bool {
+        unsafe { kill(pid as i32, 0) == 0 }
+    }
+
+    #[cfg(unix)]
+    async fn wait_unix_process_dead(pid: u32, label: &str) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if !unix_process_alive(pid) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        panic!("{label} pid {pid} still alive after process-tree termination");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn terminate_bridge_process_tree_kills_isolated_unix_descendant() {
+        let temp = TempDir::new().expect("tempdir");
+        let child_pid_path = temp.path().join("child.pid");
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("trap '' TERM; sh -c 'trap \"\" TERM; while :; do sleep 1; done' & echo $! > \"$1\"; wait")
+            .arg("sh")
+            .arg(&child_pid_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        isolate_bridge_process_tree(&mut command);
+        let mut root = command.spawn().expect("spawn isolated root");
+        let root_pid = root.id().expect("root pid");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !child_pid_path.exists() {
+            assert!(Instant::now() < deadline, "descendant pid was not written");
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        let child_pid: u32 = std::fs::read_to_string(&child_pid_path)
+            .expect("read child pid")
+            .trim()
+            .parse()
+            .expect("parse child pid");
+        assert!(unix_process_alive(root_pid));
+        assert!(unix_process_alive(child_pid));
+
+        terminate_bridge_process_tree(root_pid).await;
+        let _ = tokio::time::timeout(Duration::from_secs(5), root.wait())
+            .await
+            .expect("root reaped after tree termination");
+        wait_unix_process_dead(root_pid, "root").await;
+        wait_unix_process_dead(child_pid, "descendant").await;
+    }
+
+    #[cfg(windows)]
+    fn windows_process_alive(pid: u32) -> bool {
+        std::process::Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-Command",
+                &format!("if (Get-Process -Id {} -ErrorAction SilentlyContinue) {{ exit 0 }} else {{ exit 1 }}", pid),
+            ])
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    #[cfg(windows)]
+    async fn wait_windows_process_dead(pid: u32, label: &str) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            if !windows_process_alive(pid) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("{label} pid {pid} still alive after taskkill tree termination");
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn terminate_bridge_process_tree_kills_isolated_windows_descendant() {
+        let temp = TempDir::new().expect("tempdir");
+        let child_pid_path = temp.path().join("child.pid");
+        let script = format!(
+            "$child = Start-Process powershell -ArgumentList '-NoProfile','-Command','while ($true) {{ Start-Sleep -Seconds 1 }}' -PassThru; Set-Content -Path '{}' -Value $child.Id; while ($true) {{ Start-Sleep -Seconds 1 }}",
+            child_pid_path.display()
+        );
+        let mut command = Command::new("powershell");
+        command
+            .args(["-NoProfile", "-Command", &script])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        isolate_bridge_process_tree(&mut command);
+        let mut root = command.spawn().expect("spawn isolated windows root");
+        let root_pid = root.id().expect("root pid");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !child_pid_path.exists() {
+            assert!(Instant::now() < deadline, "descendant pid was not written");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        let child_pid: u32 = std::fs::read_to_string(&child_pid_path)
+            .expect("read child pid")
+            .trim()
+            .parse()
+            .expect("parse child pid");
+        assert!(windows_process_alive(root_pid));
+        assert!(windows_process_alive(child_pid));
+
+        terminate_bridge_process_tree(root_pid).await;
+        let _ = tokio::time::timeout(Duration::from_secs(10), root.wait()).await;
+        wait_windows_process_dead(root_pid, "root").await;
+        wait_windows_process_dead(child_pid, "descendant").await;
+    }
+
     #[cfg(not(windows))]
     #[tokio::test]
     async fn stdout_eof_before_startup_caches_specific_bridge_exit_error() {

--- a/tests/integration/test_desktop_qwen64k_packaged_runtime.py
+++ b/tests/integration/test_desktop_qwen64k_packaged_runtime.py
@@ -1,6 +1,10 @@
 import json
 import importlib.util
 import io
+import subprocess
+import sys
+import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -11,6 +15,7 @@ from utils.compute_node_runtime import ComputeNodeRuntime, ComputeNodeRuntimeCon
 from utils.context_profiles import apply_context_profile
 from utils.llm import model_manager as model_manager_module
 from utils.llm.model_manager import LlamaCppInferenceRequestError, ModelManager
+from utils.networking.relay_client import RelayClient
 
 BRIDGE_MODULE_PATH = (
     Path(__file__).resolve().parents[2]
@@ -896,3 +901,103 @@ def test_qwen64k_packaged_profile_recovery_all_profiles_exhausted_fails_closed()
     assert recovery_calls[2][0] is q4_runtime
     assert manager._qwen_64k_first_readiness_failure_category == "backend_graph_compute_failure"
     assert manager._qwen_64k_profile_recovery_count == 3
+
+
+def test_packaged_fake_metal_cancellation_terminates_worker_and_recovers(tmp_path):
+    worker_script = tmp_path / 'fake_metal_worker.py'
+    stale_output = tmp_path / 'stale-output.txt'
+    worker_script.write_text(
+        "import pathlib, signal, sys, time\n"
+        "path = pathlib.Path(sys.argv[1])\n"
+        "signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))\n"
+        "while True:\n"
+        "    time.sleep(0.1)\n"
+        "    if path.exists():\n"
+        "        path.write_text(path.read_text() + 'STALE_ASSISTANT_OUTPUT')\n",
+        encoding='utf-8',
+    )
+    stale_output.write_text('', encoding='utf-8')
+
+    crypto = MagicMock(public_key_b64='server-key')
+    manager = MagicMock()
+    worker_started = threading.Event()
+    worker_terminated = threading.Event()
+    next_inference_started = threading.Event()
+    workers: list[subprocess.Popen] = []
+    acknowledgments = []
+    generated_requests = []
+
+    class _PackagedFakeMetalManager:
+        def __init__(self):
+            self.replacements = 0
+
+        def terminate_active_worker_for_cancellation(self, *, reason='cancelled', recreate=True, fatal_callback=None):
+            assert reason == 'cancelled'
+            assert recreate is True
+            proc = workers[-1]
+            proc.terminate()
+            proc.wait(timeout=3)
+            worker_terminated.set()
+            self.replacements += 1
+            return True
+
+    packaged_manager = _PackagedFakeMetalManager()
+    client = RelayClient('https://relay.example', 443, crypto, packaged_manager)
+    client._last_api_v1_work_relay_url = 'https://relay.example'
+    client._api_v1_registered_relays.add('https://relay.example')
+    client._api_v1_control_credentials_by_relay['https://relay.example'] = 'owner-credential'
+
+    def generate(**kwargs):
+        generated_requests.append(kwargs['request_id'])
+        if kwargs['request_id'] == 'req-cancel':
+            proc = subprocess.Popen([sys.executable, str(worker_script), str(stale_output)])
+            workers.append(proc)
+            worker_started.set()
+            worker_terminated.wait(timeout=3)
+            return {'request_id': 'req-cancel', 'api_v1_response': {'message': {'content': 'late'}}}
+        next_inference_started.set()
+        return {'request_id': kwargs['request_id'], 'api_v1_response': {'message': {'content': 'clean'}}}
+
+    def control(**kwargs):
+        if kwargs.get('acknowledge'):
+            acknowledgments.append(kwargs['request_id'])
+            return {'status': 'cancelled'}
+        assert worker_started.wait(timeout=3)
+        return {'status': 'cancelled'}
+
+    client._generate_api_v1_response_with_runtime_model = generate
+    client._post_api_v1_request_control = control
+
+    outcome = client._supervise_api_v1_inference({
+        'request_id': 'req-cancel',
+        'model': 'qwen3-8b-q4-k-m',
+        'messages': [{'role': 'user', 'content': 'SECRET_PROMPT'}],
+        'options': {},
+        'routing': {'context_tier': '64k-full'},
+        'request_ttl_seconds': 30,
+    })
+
+    assert outcome.response_envelope is None
+    assert outcome.terminal_code == 'cancelled'
+    assert outcome.submission_allowed is False
+    assert worker_terminated.is_set()
+    assert workers[-1].poll() is not None
+    assert acknowledgments == ['req-cancel']
+    assert packaged_manager.replacements == 1
+
+    followup = client._supervise_api_v1_inference({
+        'request_id': 'req-next',
+        'model': 'qwen3-8b-q4-k-m',
+        'messages': [{'role': 'user', 'content': 'next'}],
+        'options': {},
+        'routing': {'context_tier': '64k-full'},
+        'request_ttl_seconds': 30,
+    })
+
+    assert next_inference_started.is_set()
+    assert followup.response_envelope['request_id'] == 'req-next'
+    assert generated_requests == ['req-cancel', 'req-next']
+    assert stale_output.read_text(encoding='utf-8') == ''
+    combined_logs = stale_output.read_text(encoding='utf-8')
+    for sentinel in (*UNSAFE_READINESS_SENTINELS, 'owner-credential', 'req-cancel'):
+        assert sentinel not in combined_logs

--- a/tests/unit/test_model_manager.py
+++ b/tests/unit/test_model_manager.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 # Import the module to test
 from utils.llm.model_manager import ModelManager
+from utils.llm import model_manager as model_manager_module
 
 
 class _ToDictOnly:
@@ -11042,3 +11043,31 @@ def test_subprocess_worker_identity_mismatch_fails_before_constructor_without_le
     assert str(module_path) not in message
     assert str(other) not in message
     assert probe['llama_module_identity'] not in message
+
+
+def test_processless_close_hard_exit_uses_privacy_safe_reason(monkeypatch, capsys):
+    class _ExitSentinel(Exception):
+        def __init__(self, code):
+            super().__init__("exit sentinel")
+            self.code = code
+
+    calls = []
+
+    def fake_exit(code):
+        calls.append(code)
+        raise _ExitSentinel(code)
+
+    monkeypatch.setattr(model_manager_module.os, "_exit", fake_exit)
+    secret_reason = "SECRET_CREDENTIAL prompt body model output"
+    safe_reason = "api_v1_worker_processless_close_timeout"
+
+    with pytest.raises(_ExitSentinel) as exc_info:
+        model_manager_module._processless_close_hard_exit(reason=safe_reason)
+
+    assert exc_info.value.code == 1
+    assert calls == [1]
+    captured = capsys.readouterr()
+    assert f"reason={safe_reason}" in captured.err
+    assert secret_reason not in captured.err
+    assert "SECRET_CREDENTIAL" not in captured.err
+    assert captured.out == ""


### PR DESCRIPTION
### Motivation
- Close platform-regression gaps around bridge process-tree termination and packaged-runtime cancellation by adding native platform tests that exercise the real SIGTERM→SIGKILL and Windows `taskkill /T /F` flows and the packaged Metal cancellation contract. 
- Provide deterministic regressions and coverage for the processless hard-exit path and privacy-safe logging so cancellation/kill paths are tested without leaking secrets or leaving executor/threads/processes behind. 

### Description
- Add Unix and Windows Rust tests that spawn an isolated bridge root plus a real descendant, call `terminate_bridge_process_tree(root_pid)`, reap the root, and deadline-boundedly assert both root and descendant are dead; exercise `isolate_bridge_process_tree()` and the real escalation paths. (file: `desktop-tauri/src-tauri/src/compute_node.rs`).
- Add a deterministic packaged fake-Metal cancellation integration test that spawns a hanging subprocess-backed fake worker, drives an authoritative `cancelled` control result, asserts the worker is terminated, exactly one acknowledge, no response/error submission, a verified clean replacement for the next inference, and that no secret/stale output is written. (file: `tests/integration/test_desktop_qwen64k_packaged_runtime.py`).
- Add an in-process regression for `_processless_close_hard_exit()` that monkeypatches `os._exit` to raise a private sentinel, asserts the sentinel and exit code `1`, and verifies logs contain only a stable privacy-safe reason (no credentials, prompts, or model output). (file: `tests/unit/test_model_manager.py`).
- Wire focused CI invocations for the new regressions into the existing Windows and macOS packaged-e2e jobs in the desktop operator workflow so the platform jobs run the cancellation and process-tree tests. (file: `.github/workflows/desktop-operator-e2e.yml`).

### Testing
- Ran the new packaged-metal integration regression: `python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -k cancellation` — PASSED. 
- Ran focused unit suites: `python -m pytest -q tests/unit/test_model_manager.py tests/unit/test_desktop_compute_node_bridge.py` — PASSED (all unit tests in these suites passed locally).
- Ran the full enabled test runner and coverage: `TEST_COVERAGE=1 ./run_all_tests.sh` which executed the Python unit/integration/API suites and produced a local coverage report showing overall coverage ~94% and `utils/llm/model_manager.py` / `desktop-tauri/src-tauri/python/compute_node_bridge.py` above 90%. 
- Attempted the Rust `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml terminate_bridge_process_tree -- --nocapture` locally and observed system dependency failures (`pkg-config` / missing `glib-2.0.pc`) in this environment; the CI workflow now invokes the same cargo test on Windows/macOS jobs so the platform regressions will be exercised in CI where the native deps are present. 
- Ran `pre-commit run --all-files`, `git diff --check`, and static checks; they passed.

Files changed (focus): `.github/workflows/desktop-operator-e2e.yml`, `desktop-tauri/src-tauri/src/compute_node.rs`, `tests/integration/test_desktop_qwen64k_packaged_runtime.py`, `tests/unit/test_model_manager.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fbaecc444832fb22b5342267ab779)