### PR TITLE
Harden Claude workflow commit policy

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+env:
+  CLAUDE_CHECKPOINT_SYSTEM_PROMPT: >-
+    When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy/full validation, and before the final third of the session. Use the action native signed commit/push mechanism. Never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable.
+
 jobs:
   claude:
     if: |
@@ -123,6 +127,12 @@ jobs:
                 esac
               fi
               ;;
+            "")
+              deny "Tool name is required."
+              ;;
+            *)
+              deny "Tool ${tool_name} is not allowed by this workflow guard."
+              ;;
           esac
 
           exit 0
@@ -182,8 +192,8 @@ jobs:
             --setting-sources user
             --strict-mcp-config
             --max-turns 120
-            --append-system-prompt 'When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy/full validation, and before the final third of the session. Use the action native signed commit/push mechanism. Never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable.'
-            --allowedTools "Read,Edit,Write,Glob,Grep"
+            --append-system-prompt "${{ env.CLAUDE_CHECKPOINT_SYSTEM_PROMPT }}"
+            --allowedTools "Read,Edit,Write,NotebookEdit,Glob,Grep"
             --disallowedTools "Bash,WebFetch,WebSearch"
 
   claude-exec:
@@ -517,6 +527,12 @@ jobs:
                 esac
               fi
               ;;
+            "")
+              deny "Tool name is required."
+              ;;
+            *)
+              deny "Tool ${tool_name} is not allowed by this workflow guard."
+              ;;
           esac
 
           exit 0
@@ -582,6 +598,6 @@ jobs:
             --setting-sources user
             --strict-mcp-config
             --max-turns 120
-            --append-system-prompt 'When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy/full validation, and before the final third of the session. Use the action native signed commit/push mechanism. Never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable.'
-            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(${{ steps.wrappers.outputs.dir }}/python-dependency-compatibility),Bash(${{ steps.wrappers.outputs.dir }}/python-tests),Bash(${{ steps.wrappers.outputs.dir }}/frontend-lint),Bash(${{ steps.wrappers.outputs.dir }}/repository-tests),Bash(${{ steps.wrappers.outputs.dir }}/env-network-check)"
+            --append-system-prompt "${{ env.CLAUDE_CHECKPOINT_SYSTEM_PROMPT }}"
+            --allowedTools "Read,Edit,Write,NotebookEdit,Glob,Grep,Bash(${{ steps.wrappers.outputs.dir }}/python-dependency-compatibility),Bash(${{ steps.wrappers.outputs.dir }}/python-tests),Bash(${{ steps.wrappers.outputs.dir }}/frontend-lint),Bash(${{ steps.wrappers.outputs.dir }}/repository-tests),Bash(${{ steps.wrappers.outputs.dir }}/env-network-check)"
             --disallowedTools "WebFetch,WebSearch,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rm:*),Bash(gh:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,9 +10,6 @@ on:
   pull_request_review:
     types: [submitted]
 
-env:
-  CLAUDE_CHECKPOINT_SYSTEM_PROMPT: >-
-    When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy/full validation, and before the final third of the session. Use the action native signed commit/push mechanism. Never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable.
 
 jobs:
   claude:
@@ -48,7 +45,7 @@ jobs:
 
     steps:
       # Claude receives untrusted repository and PR/comment content. Keep the
-      # normal path default-deny for executable tools and fail closed for forks.
+      # normal path executable tools disabled and reject fork pull requests.
       - name: Reject fork pull requests
         if: |
           (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
@@ -80,13 +77,9 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      # Bash is already omitted from --allowedTools, which the action's own
-      # docs describe as a real allow/deny list (Bash is disabled unless
-      # explicitly granted). The PreToolUse hook below is a second,
-      # independently-coded layer: it hard-denies every Bash call and
-      # confines file-editing tools to paths that resolve inside the
-      # checkout, so a permissions-schema surprise in the action can't
-      # silently widen what an untrusted comment/PR body can make Claude do.
+      # Ordinary path enforcement is layered: JSON/CLI rules deny Bash and web
+      # tools, while this PreToolUse hook independently hard-denies Bash and
+      # confines path-bearing file tools to the checkout workspace.
       - name: Create ordinary-path tool guard
         id: guard
         env:
@@ -127,12 +120,6 @@ jobs:
                 esac
               fi
               ;;
-            "")
-              deny "Tool name is required."
-              ;;
-            *)
-              deny "Tool ${tool_name} is not allowed by this workflow guard."
-              ;;
           esac
 
           exit 0
@@ -155,13 +142,10 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Belt-and-suspenders: settings.permissions.deny + the PreToolUse
-          # hook are an independent, code-level Bash/web ban and workspace
-          # file boundary (see the guard script above), layered underneath the
-          # documented --allowedTools/--disallowedTools lists below. The CLI
-          # lists make the desired policy explicit, but the hook remains the
-          # authoritative fail-closed guard if parser or permission semantics
-          # change.
+          # Ordinary path: settings/CLI permissions deny Bash and web tools.
+          # The PreToolUse hook above separately hard-denies Bash and confines
+          # path-bearing file tools to the workspace; it is not a catch-all
+          # default-deny guard for action-native or newly introduced tools.
           settings: |
             {
               "permissions": {
@@ -184,16 +168,17 @@ jobs:
 
           # Implementation sessions checkpoint before long validation so
           # reviewable, safe work is not lost to runner timeouts.
-          # --allowedTools is additive to the action's tag-mode base tools;
+          # Keep NotebookEdit out of the explicit allow-list because this repo
+          # has no tracked notebooks; guard it defensively above in case
+          # upstream/base-tool semantics expose notebook edits.
           # use_commit_signing keeps native GitHub file-ops commit tools
-          # available, while direct Bash git remains denied in settings,
-          # CLI policy, and the PreToolUse guard.
+          # available, while direct Bash git remains denied.
           claude_args: |
             --setting-sources user
             --strict-mcp-config
             --max-turns 120
-            --append-system-prompt "${{ env.CLAUDE_CHECKPOINT_SYSTEM_PROMPT }}"
-            --allowedTools "Read,Edit,Write,NotebookEdit,Glob,Grep"
+            --append-system-prompt "When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy/full validation, and before the final third of the session. Use the action native signed commit/push mechanism. Never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable."
+            --allowedTools "Read,Edit,Write,Glob,Grep"
             --disallowedTools "Bash,WebFetch,WebSearch"
 
   claude-exec:
@@ -527,12 +512,6 @@ jobs:
                 esac
               fi
               ;;
-            "")
-              deny "Tool name is required."
-              ;;
-            *)
-              deny "Tool ${tool_name} is not allowed by this workflow guard."
-              ;;
           esac
 
           exit 0
@@ -567,14 +546,16 @@ jobs:
             actions: read
             workflows: write
 
-          # See the guard.sh generated above: it is the authoritative,
-          # exact-match Bash gate. --allowedTools below is a second,
-          # documented layer using the action's own glob-based enforcement.
-          # The CLI policy is intentionally not the sandbox: the PreToolUse
-          # guard, Bubblewrap no-network namespace, cleared environment, and
-          # immutable call-cap wrappers remain the fail-closed controls.
+          # Exec path: PreToolUse is authoritative for the exact five-wrapper
+          # Bash gate. JSON/CLI rules deny web and direct-git tools, while
+          # Bubblewrap, a cleared environment, no-network isolation, and wrapper
+          # counters enforce runtime isolation. The hook is not a catch-all
+          # default-deny guard for action-native GitHub MCP tools.
           settings: |
             {
+              "permissions": {
+                "deny": ["WebFetch", "WebSearch", "Bash(git add:*)", "Bash(git commit:*)", "Bash(git push:*)", "Bash(git rm:*)", "Bash(gh:*)"]
+              },
               "hooks": {
                 "PreToolUse": [
                   {
@@ -591,13 +572,14 @@ jobs:
             }
 
           # This path may run only the five immutable validation wrappers.
-          # Native signed GitHub file-ops commits remain available through the
-          # action when use_commit_signing is true; direct Bash git commands
-          # are denied so they cannot bypass reviewable action-managed commits.
+          # Keep NotebookEdit out of the explicit allow-list because this repo
+          # has no tracked notebooks; guard it defensively above in case
+          # upstream/base-tool semantics expose notebook edits. Native signed
+          # GitHub file-ops commits remain available through the action.
           claude_args: |
             --setting-sources user
             --strict-mcp-config
             --max-turns 120
-            --append-system-prompt "${{ env.CLAUDE_CHECKPOINT_SYSTEM_PROMPT }}"
-            --allowedTools "Read,Edit,Write,NotebookEdit,Glob,Grep,Bash(${{ steps.wrappers.outputs.dir }}/python-dependency-compatibility),Bash(${{ steps.wrappers.outputs.dir }}/python-tests),Bash(${{ steps.wrappers.outputs.dir }}/frontend-lint),Bash(${{ steps.wrappers.outputs.dir }}/repository-tests),Bash(${{ steps.wrappers.outputs.dir }}/env-network-check)"
+            --append-system-prompt "When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy/full validation, and before the final third of the session. Use the action native signed commit/push mechanism. Never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable."
+            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(${{ steps.wrappers.outputs.dir }}/python-dependency-compatibility),Bash(${{ steps.wrappers.outputs.dir }}/python-tests),Bash(${{ steps.wrappers.outputs.dir }}/frontend-lint),Bash(${{ steps.wrappers.outputs.dir }}/repository-tests),Bash(${{ steps.wrappers.outputs.dir }}/env-network-check)"
             --disallowedTools "WebFetch,WebSearch,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rm:*),Bash(gh:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -146,13 +146,16 @@ jobs:
             actions: read
 
           # Belt-and-suspenders: settings.permissions.deny + the PreToolUse
-          # hook are an independent, code-level Bash ban and workspace file
-          # boundary (see the guard script above), layered underneath the
-          # documented --disallowedTools grant below.
+          # hook are an independent, code-level Bash/web ban and workspace
+          # file boundary (see the guard script above), layered underneath the
+          # documented --allowedTools/--disallowedTools lists below. The CLI
+          # lists make the desired policy explicit, but the hook remains the
+          # authoritative fail-closed guard if parser or permission semantics
+          # change.
           settings: |
             {
               "permissions": {
-                "deny": ["Bash"]
+                "deny": ["Bash", "WebFetch", "WebSearch"]
               },
               "hooks": {
                 "PreToolUse": [
@@ -169,10 +172,19 @@ jobs:
               }
             }
 
+          # Implementation sessions checkpoint before long validation so
+          # reviewable, safe work is not lost to runner timeouts.
+          # --allowedTools is additive to the action's tag-mode base tools;
+          # use_commit_signing keeps native GitHub file-ops commit tools
+          # available, while direct Bash git remains denied in settings,
+          # CLI policy, and the PreToolUse guard.
           claude_args: |
             --setting-sources user
             --strict-mcp-config
-            --disallowedTools "Bash"
+            --max-turns 120
+            --append-system-prompt 'When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy/full validation, and before the final third of the session. Use the action native signed commit/push mechanism. Never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable.'
+            --allowedTools "Read,Edit,Write,Glob,Grep"
+            --disallowedTools "Bash,WebFetch,WebSearch"
 
   claude-exec:
     if: |
@@ -542,6 +554,9 @@ jobs:
           # See the guard.sh generated above: it is the authoritative,
           # exact-match Bash gate. --allowedTools below is a second,
           # documented layer using the action's own glob-based enforcement.
+          # The CLI policy is intentionally not the sandbox: the PreToolUse
+          # guard, Bubblewrap no-network namespace, cleared environment, and
+          # immutable call-cap wrappers remain the fail-closed controls.
           settings: |
             {
               "hooks": {
@@ -559,7 +574,14 @@ jobs:
               }
             }
 
+          # This path may run only the five immutable validation wrappers.
+          # Native signed GitHub file-ops commits remain available through the
+          # action when use_commit_signing is true; direct Bash git commands
+          # are denied so they cannot bypass reviewable action-managed commits.
           claude_args: |
             --setting-sources user
             --strict-mcp-config
-            --allowedTools "Bash(${{ steps.wrappers.outputs.dir }}/python-dependency-compatibility),Bash(${{ steps.wrappers.outputs.dir }}/python-tests),Bash(${{ steps.wrappers.outputs.dir }}/frontend-lint),Bash(${{ steps.wrappers.outputs.dir }}/repository-tests),Bash(${{ steps.wrappers.outputs.dir }}/env-network-check)"
+            --max-turns 120
+            --append-system-prompt 'When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy/full validation, and before the final third of the session. Use the action native signed commit/push mechanism. Never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable.'
+            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(${{ steps.wrappers.outputs.dir }}/python-dependency-compatibility),Bash(${{ steps.wrappers.outputs.dir }}/python-tests),Bash(${{ steps.wrappers.outputs.dir }}/frontend-lint),Bash(${{ steps.wrappers.outputs.dir }}/repository-tests),Bash(${{ steps.wrappers.outputs.dir }}/env-network-check)"
+            --disallowedTools "WebFetch,WebSearch,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rm:*),Bash(gh:*)"


### PR DESCRIPTION
### Motivation

- Encourage implementation-oriented Claude sessions to produce early, reviewable checkpoint commits instead of losing coherent work to lengthy validation or runner timeouts.
- Make the action-level tool policy explicit and defense-in-depth without weakening the repository’s existing owner/fork protections, signed commits, protected exec environment, wrapper restrictions, Bubblewrap isolation, call caps, secret handling, or strict MCP configuration.

### Summary

- Added `--max-turns 120` to both the ordinary `@claude` and protected `@claude-exec` jobs.
- Added the same safely quoted `--append-system-prompt` to both jobs. It requires early signed checkpoint commits for implementation requests, reserves the final ten turns for review and finalization, distinguishes code-caused failures from environmental failures, and forbids committing secrets, junk, or known-broken code.
- Added explicit additive tool lists:
  - Ordinary `@claude`: `Read`, `Edit`, `Write`, `Glob`, and `Grep`.
  - Protected `@claude-exec`: the same file tools plus the five existing exact validation-wrapper Bash grants.
- Ordinary JSON and CLI policy both deny `Bash`, `WebFetch`, and `WebSearch`.
- Exec JSON and CLI policy both deny `WebFetch`, `WebSearch`, direct Bash git mutation commands, and direct `gh` commands.
- Kept the action-native signed GitHub file-operation tools available through `use_commit_signing: true`; no direct Bash git permission was introduced.
- Added concise comments documenting the boundaries between CLI/settings policy, PreToolUse enforcement, and the Bubblewrap runtime sandbox.

### Security and reviewer resolution

- `--allowedTools` remains additive to the action’s implicit base tools; it is not treated as the authoritative sandbox.
- The ordinary PreToolUse hook remains authoritative for denying Bash and confining path-bearing file tools to the repository workspace.
- The exec PreToolUse hook remains authoritative for allowing only the five exact immutable wrapper commands through Bash.
- The hooks intentionally are not catch-all deny lists for unknown or action-native GitHub MCP tools. A catch-all branch would risk blocking the signed native commit mechanism; the workflow comments now state this boundary explicitly.
- `NotebookEdit` is intentionally absent from both explicit allow lists because the repository has no tracked notebooks. It remains covered by both path-confinement guards defensively in case upstream/base-tool semantics expose it.
- The identical system prompt remains inline in both jobs intentionally, keeping the change confined to one workflow file without adding prompt-loading steps or another tracked file.
- The existing 45-minute job timeouts, triggers, GitHub permissions, fork rejection, protected environment, wrapper implementations and caps, Bubblewrap configuration, cleared environment, no-network behavior, signed commits, and strict MCP configuration remain unchanged.

### Effective workflow-configured Claude arguments

These arguments are additive to the action’s implicit tag-mode base tools, including its native signed GitHub file operations.

Ordinary `@claude`:

~~~text
--setting-sources user
--strict-mcp-config
--max-turns 120
--append-system-prompt "When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy/full validation, and before the final third of the session. Use the action native signed commit/push mechanism. Never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable."
--allowedTools "Read,Edit,Write,Glob,Grep"
--disallowedTools "Bash,WebFetch,WebSearch"
~~~

Protected `@claude-exec`:

~~~text
--setting-sources user
--strict-mcp-config
--max-turns 120
--append-system-prompt "When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy/full validation, and before the final third of the session. Use the action native signed commit/push mechanism. Never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable."
--allowedTools "Read,Edit,Write,Glob,Grep,Bash(${{ steps.wrappers.outputs.dir }}/python-dependency-compatibility),Bash(${{ steps.wrappers.outputs.dir }}/python-tests),Bash(${{ steps.wrappers.outputs.dir }}/frontend-lint),Bash(${{ steps.wrappers.outputs.dir }}/repository-tests),Bash(${{ steps.wrappers.outputs.dir }}/env-network-check)"
--disallowedTools "WebFetch,WebSearch,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rm:*),Bash(gh:*)"
~~~

### Verification

- Parsed `.github/workflows/claude.yml` as YAML.
- Parsed both `claude_args` blocks with `shlex` and verified:
  - one valid appended-system-prompt argument per job;
  - identical prompt contents;
  - `--max-turns 120`;
  - the expected allowed and denied tool sets;
  - matching JSON and CLI deny lists.
- Verified the ordinary trigger still excludes `@claude-exec`.
- Verified the protected environment, signed commits, strict MCP configuration, wrapper grants, workspace confinement, call caps, Bubblewrap no-network isolation, and cleared environment remain present.
- `pre-commit run check-yaml --files .github/workflows/claude.yml` — passed.
- `actionlint .github/workflows/claude.yml` — passed.
- `git diff --check` — passed.
- Confirmed the PR changes only `.github/workflows/claude.yml`.
- A full `pre-commit run --all-files` was not used as acceptance evidence in the Codex container because that environment lacked `requests`/`cryptography` and encountered existing `FO` codespell findings outside this PR’s diff.

Latest remote PR head: `27725a93ca02bb3e86986be83de7a79fe0b5a5c9`

------

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60668c21e8832f913e3aae349d46de)