### PR TITLE
Harden Claude workflow commit policy

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -111,7 +111,7 @@ jobs:
             Bash)
               deny "Bash is disabled for the ordinary @claude path. Ask for @claude-exec if a validation command is required."
               ;;
-            Read|Edit|Write|NotebookEdit|Glob|Grep)
+            Read|Edit|Write|Glob|Grep)
               candidate="$(printf '%s' "${payload}" | jq -r '.tool_input.file_path // .tool_input.path // .tool_input.notebook_path // empty')"
               if [[ -n "${candidate}" ]]; then
                 if ! resolved="$(realpath -m -- "${candidate}" 2>/dev/null)"; then
@@ -146,13 +146,13 @@ jobs:
             actions: read
 
           # Belt-and-suspenders: settings.permissions.deny + the PreToolUse
-          # hook are an independent, code-level Bash ban and workspace file
+          # hook are an independent, code-level Bash/web ban and workspace file
           # boundary (see the guard script above), layered underneath the
-          # documented --disallowedTools grant below.
+          # documented --allowedTools/--disallowedTools lists below.
           settings: |
             {
               "permissions": {
-                "deny": ["Bash"]
+                "deny": ["Bash", "WebFetch", "WebSearch"]
               },
               "hooks": {
                 "PreToolUse": [
@@ -169,10 +169,20 @@ jobs:
               }
             }
 
+          # Implementation sessions should checkpoint before long validation so
+          # reviewable work is persisted even when slow or environmental checks
+          # time out near the end of a bounded run. The action's base GitHub
+          # tools remain available for signed API commits/pushes; direct Bash
+          # git commands stay prohibited by CLI/settings denies and the hook.
+          # --allowedTools is additive, not the authoritative sandbox: the
+          # PreToolUse guard above remains the fail-closed enforcement layer.
           claude_args: |
             --setting-sources user
             --strict-mcp-config
-            --disallowedTools "Bash"
+            --max-turns 120
+            --append-system-prompt "When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy or full validation, and before the final third of the session. Use the action native signed commit and push mechanism. Never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing and pushing, and reporting results. Before ending, inspect the working tree and either commit and push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable."
+            --allowedTools "Read,Edit,Write,Glob,Grep"
+            --disallowedTools "Bash,WebFetch,WebSearch"
 
   claude-exec:
     if: |
@@ -493,7 +503,7 @@ jobs:
                   ;;
               esac
               ;;
-            Read|Edit|Write|NotebookEdit|Glob|Grep)
+            Read|Edit|Write|Glob|Grep)
               candidate="$(printf '%s' "${payload}" | jq -r '.tool_input.file_path // .tool_input.path // .tool_input.notebook_path // empty')"
               if [[ -n "${candidate}" ]]; then
                 if ! resolved="$(realpath -m -- "${candidate}" 2>/dev/null)"; then
@@ -540,10 +550,25 @@ jobs:
             workflows: write
 
           # See the guard.sh generated above: it is the authoritative,
-          # exact-match Bash gate. --allowedTools below is a second,
-          # documented layer using the action's own glob-based enforcement.
+          # exact-match Bash gate. --allowedTools below is additive and only a
+          # documented second layer using the action's own glob-based
+          # enforcement. The action's base GitHub tools remain available for
+          # signed API commits/pushes, while direct Bash git commands are
+          # denied here and cannot match the wrapper-only PreToolUse guard.
+          # Checkpoint before long validation so coherent fixes survive bounded
+          # sessions; a checkpoint still does not make failing CI mergeable.
           settings: |
             {
+              "permissions": {
+                "deny": [
+                  "WebFetch",
+                  "WebSearch",
+                  "Bash(git *)",
+                  "Bash(git)",
+                  "Bash(* git *)",
+                  "Bash(* git)"
+                ]
+              },
               "hooks": {
                 "PreToolUse": [
                   {
@@ -562,4 +587,7 @@ jobs:
           claude_args: |
             --setting-sources user
             --strict-mcp-config
-            --allowedTools "Bash(${{ steps.wrappers.outputs.dir }}/python-dependency-compatibility),Bash(${{ steps.wrappers.outputs.dir }}/python-tests),Bash(${{ steps.wrappers.outputs.dir }}/frontend-lint),Bash(${{ steps.wrappers.outputs.dir }}/repository-tests),Bash(${{ steps.wrappers.outputs.dir }}/env-network-check)"
+            --max-turns 120
+            --append-system-prompt "When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy or full validation, and before the final third of the session. Use the action native signed commit and push mechanism. Never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing and pushing, and reporting results. Before ending, inspect the working tree and either commit and push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable."
+            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(${{ steps.wrappers.outputs.dir }}/python-dependency-compatibility),Bash(${{ steps.wrappers.outputs.dir }}/python-tests),Bash(${{ steps.wrappers.outputs.dir }}/frontend-lint),Bash(${{ steps.wrappers.outputs.dir }}/repository-tests),Bash(${{ steps.wrappers.outputs.dir }}/env-network-check)"
+            --disallowedTools "WebFetch,WebSearch,Bash(git *),Bash(git),Bash(* git *),Bash(* git)"


### PR DESCRIPTION
### Motivation

- Ensure implementation-focused Claude sessions prioritize producing signed, pushed checkpoint commits early in a bounded run rather than holding changes locally until long validations complete. 
- Make `--allowedTools`/`--disallowedTools` explicit and additive while preserving the repository's existing layered, fail-closed defenses. 
- Preserve existing protections (wrapper-only validation, Bubblewrap isolation, protected `claude-exec` environment, cleared secrets, no-network policy, and signed-commit workflow) while making the tool policy and session budget clearer.

### Description

- Add `--max-turns 120` and a safely quoted `--append-system-prompt` to both `claude` and `claude-exec` `claude_args` to require early, reviewable checkpoint commits, reserve final turns for review/commit/push, and forbid committing secrets or broken/junk code. 
- Make the ordinary `@claude` tool policy explicit by adding `--allowedTools "Read,Edit,Write,Glob,Grep"` and `--disallowedTools "Bash,WebFetch,WebSearch"` and by updating the job JSON `permissions.deny` to include `Bash`, `WebFetch`, and `WebSearch` alongside the existing PreToolUse guard that enforces workspace path confinement. 
- Keep `@claude-exec`’s exact wrapper-only Bash grants but add the same safe file tools to the allowed list, add CLI/JSON denies for web fetch/search and explicit Bash/git patterns (e.g. `Bash(git *)`, `Bash(* git *)`) so direct/destructive Bash git commands are blocked while the action-native signed commit/push mechanism remains usable. 
- Add concise inline workflow comments explaining why checkpointing before long validation is required, why the native signed commit path remains allowed while direct Bash git commands are prohibited, and why the PreToolUse guards remain the authoritative fail-closed enforcement layer.

### Testing

- Parsed the modified workflow with a `python` snippet using `yaml.safe_load` and `shlex.split` to extract and validate both `claude_args`, confirming `--max-turns 120` is present and the appended system prompt is produced as one CLI argument (passed). 
- Verified ordinary `@claude` conditional does not match `@claude-exec` and validated presence of key invariants such as `persist-credentials: false`, `environment: claude-exec`, wrapper names and caps, and that no bypass flags like `--dangerously-skip-permissions` were introduced (passed). 
- Ran `git diff --check` which passed cleanly (passed). 
- Attempted `actionlint` but it is not installed in the execution environment (not run), and ran `pre-commit run --all-files` after installing `pre-commit`, which surfaced pre-existing repository issues: `codespell` flagged existing text in `desktop-tauri/src-tauri/src/compute_node.rs` and several Python tests failed due to missing local environment dependencies (`playwright`, `cryptography`), while JavaScript tests and many other checks within the pre-commit run succeeded (partial; pre-existing failures remain).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6066964a58832f952a21c03254a0e9)