### PR TITLE
Harden Claude workflow commit and tool policy

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -76,13 +76,11 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      # Bash is already omitted from --allowedTools, which the action's own
-      # docs describe as a real allow/deny list (Bash is disabled unless
-      # explicitly granted). The PreToolUse hook below is a second,
-      # independently-coded layer: it hard-denies every Bash call and
-      # confines file-editing tools to paths that resolve inside the
-      # checkout, so a permissions-schema surprise in the action can't
-      # silently widen what an untrusted comment/PR body can make Claude do.
+      # The CLI tool list is a documented convenience layer, not the
+      # authoritative sandbox. The PreToolUse hook below independently
+      # hard-denies every Bash call and confines file-editing tools to paths
+      # that resolve inside the checkout, so a permissions-schema surprise in
+      # the action cannot silently widen what untrusted comment/PR text can do.
       - name: Create ordinary-path tool guard
         id: guard
         env:
@@ -111,7 +109,7 @@ jobs:
             Bash)
               deny "Bash is disabled for the ordinary @claude path. Ask for @claude-exec if a validation command is required."
               ;;
-            Read|Edit|Write|NotebookEdit|Glob|Grep)
+            Read|Edit|Write|Glob|Grep)
               candidate="$(printf '%s' "${payload}" | jq -r '.tool_input.file_path // .tool_input.path // .tool_input.notebook_path // empty')"
               if [[ -n "${candidate}" ]]; then
                 if ! resolved="$(realpath -m -- "${candidate}" 2>/dev/null)"; then
@@ -140,19 +138,20 @@ jobs:
           include_comments_by_actor: "futuroptimist"
 
           # Scope Claude's OIDC-issued GitHub App token. The normal @claude path
-          # can edit ordinary repository files through GitHub MCP/API commits,
-          # but cannot request workflows: write or run general Bash.
+          # can edit ordinary repository files through the action-native signed
+          # GitHub commit path, but cannot request workflows: write or run
+          # general Bash/direct git commands.
           additional_permissions: |
             actions: read
 
           # Belt-and-suspenders: settings.permissions.deny + the PreToolUse
           # hook are an independent, code-level Bash ban and workspace file
           # boundary (see the guard script above), layered underneath the
-          # documented --disallowedTools grant below.
+          # documented --allowedTools/--disallowedTools lists below.
           settings: |
             {
               "permissions": {
-                "deny": ["Bash"]
+                "deny": ["Bash", "WebFetch", "WebSearch"]
               },
               "hooks": {
                 "PreToolUse": [
@@ -169,10 +168,15 @@ jobs:
               }
             }
 
+          # Implementation sessions checkpoint before long validation so safe,
+          # reviewable work is not lost to late environmental or timeout failures.
           claude_args: |
             --setting-sources user
             --strict-mcp-config
-            --disallowedTools "Bash"
+            --max-turns 120
+            --allowedTools "Read,Edit,Write,Glob,Grep"
+            --disallowedTools "Bash,WebFetch,WebSearch"
+            --append-system-prompt 'When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy/full validation, and before the final third of the session. Use the action-native signed commit/push mechanism; never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable.'
 
   claude-exec:
     if: |
@@ -493,7 +497,7 @@ jobs:
                   ;;
               esac
               ;;
-            Read|Edit|Write|NotebookEdit|Glob|Grep)
+            Read|Edit|Write|Glob|Grep)
               candidate="$(printf '%s' "${payload}" | jq -r '.tool_input.file_path // .tool_input.path // .tool_input.notebook_path // empty')"
               if [[ -n "${candidate}" ]]; then
                 if ! resolved="$(realpath -m -- "${candidate}" 2>/dev/null)"; then
@@ -540,10 +544,23 @@ jobs:
             workflows: write
 
           # See the guard.sh generated above: it is the authoritative,
-          # exact-match Bash gate. --allowedTools below is a second,
-          # documented layer using the action's own glob-based enforcement.
+          # exact-match Bash gate. --allowedTools below is only an additive,
+          # documented layer using the action's own pattern enforcement. The
+          # signed GitHub commit path remains usable through native action
+          # integration while direct Bash git commands remain prohibited.
           settings: |
             {
+              "permissions": {
+                "deny": [
+                  "WebFetch",
+                  "WebSearch",
+                  "Bash(git add:*)",
+                  "Bash(git commit:*)",
+                  "Bash(git push:*)",
+                  "Bash(git reset:*)",
+                  "Bash(git clean:*)"
+                ]
+              },
               "hooks": {
                 "PreToolUse": [
                   {
@@ -562,4 +579,7 @@ jobs:
           claude_args: |
             --setting-sources user
             --strict-mcp-config
-            --allowedTools "Bash(${{ steps.wrappers.outputs.dir }}/python-dependency-compatibility),Bash(${{ steps.wrappers.outputs.dir }}/python-tests),Bash(${{ steps.wrappers.outputs.dir }}/frontend-lint),Bash(${{ steps.wrappers.outputs.dir }}/repository-tests),Bash(${{ steps.wrappers.outputs.dir }}/env-network-check)"
+            --max-turns 120
+            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(${{ steps.wrappers.outputs.dir }}/python-dependency-compatibility),Bash(${{ steps.wrappers.outputs.dir }}/python-tests),Bash(${{ steps.wrappers.outputs.dir }}/frontend-lint),Bash(${{ steps.wrappers.outputs.dir }}/repository-tests),Bash(${{ steps.wrappers.outputs.dir }}/env-network-check)"
+            --disallowedTools "WebFetch,WebSearch,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git reset:*),Bash(git clean:*)"
+            --append-system-prompt 'When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy/full validation, and before the final third of the session. Use the action-native signed commit/push mechanism; never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable.'


### PR DESCRIPTION
### Motivation
- Encourage Claude implementation sessions to produce signed, pushed checkpoint commits early in the session rather than holding all changes locally until late validation.
- Make `--allowedTools`/`--disallowedTools` lists explicit and additive while preserving the repository's existing defense-in-depth guards (PreToolUse hooks, wrapper caps, Bubblewrap isolation, fork rejection, signed commits, and strict MCP config).
- Prevent accidental broadening of execution power by explicitly denying web fetch/search and destructive git Bash patterns in both the JSON `settings` and CLI `claude_args` where supported.

### Description
- Added a bounded turn limit to both jobs by inserting `--max-turns 120` into each `claude_args` block (kept job `timeout-minutes: 45` unchanged).
- Appended a safely quoted `--append-system-prompt` to both jobs that requires producing and pushing an early coherent checkpoint commit for implementation requests and reserves the final turns for review/commit; the prompt enforces use of the action-native signed commit/push mechanism and forbids Bash `git` commands.
- Made tool policies explicit: ordinary `@claude` now has `--allowedTools "Read,Edit,Write,Glob,Grep"` and `--disallowedTools "Bash,WebFetch,WebSearch"`; protected `@claude-exec` adds the five exact Bash wrapper grants to `--allowedTools` and a conservative `--disallowedTools` list including `WebFetch`, `WebSearch`, and `Bash(git add:*)`, `Bash(git commit:*)`, `Bash(git push:*)`, `Bash(git reset:*)`, `Bash(git clean:*)` while retaining the PreToolUse exact-match guard.
- Strengthened the JSON `settings.permissions.deny` entries to include `WebFetch`/`WebSearch` (ordinary path) and destructive `Bash(git ...)` patterns (exec path) while preserving the PreToolUse hooks, wrapper counters, Bubblewrap sandbox, cleared env, and other existing protections.
- Added concise inline comments explaining why implementation sessions checkpoint before long validation, why the native signed GitHub commit path remains usable while direct Bash `git` commands are prohibited, and why PreToolUse hooks remain authoritative.

### Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude.yml"); puts "yaml ok"'` — Passed, workflow YAML parses.
- `git diff --check` — Passed, no trailing-whitespace or index issues from this change.
- `actionlint .github/workflows/claude.yml` — Passed, workflow linted cleanly.
- Custom invariant/quoting checks (Python): parsed both `claude_args` blocks, confirmed `--append-system-prompt` appears exactly once per block, `--max-turns 120` present, ordinary trigger still excludes `@claude-exec`, `use_commit_signing: true` and `--strict-mcp-config` remain, wrapper paths and caps remain; all checks passed.
- `pre-commit run --all-files` — Not fully green in this environment due to pre-existing repository issues outside the workflow diff (codespell flagged existing tokens in `desktop-tauri/src-tauri/src/compute_node.rs` and `./run_all_tests.sh` failed due to missing Python deps such as `requests`/`cryptography`), so hooks were not completed here (failures are unrelated to the workflow change).

Effective Claude arguments (as committed):
- Ordinary `@claude` `claude_args` value:
  `--setting-sources user --strict-mcp-config --max-turns 120 --allowedTools "Read,Edit,Write,Glob,Grep" --disallowedTools "Bash,WebFetch,WebSearch" --append-system-prompt 'When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy/full validation, and before the final third of the session. Use the action-native signed commit/push mechanism; never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable.'`
- Protected `@claude-exec` `claude_args` value:
  `--setting-sources user --strict-mcp-config --max-turns 120 --allowedTools "Read,Edit,Write,Glob,Grep,Bash(${{ steps.wrappers.outputs.dir }}/python-dependency-compatibility),Bash(${{ steps.wrappers.outputs.dir }}/python-tests),Bash(${{ steps.wrappers.outputs.dir }}/frontend-lint),Bash(${{ steps.wrappers.outputs.dir }}/repository-tests),Bash(${{ steps.wrappers.outputs.dir }}/env-network-check)" --disallowedTools "WebFetch,WebSearch,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git reset:*),Bash(git clean:*)" --append-system-prompt 'When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy/full validation, and before the final third of the session. Use the action-native signed commit/push mechanism; never use Bash for git add, git commit, or git push. Continue with follow-up commits as necessary; do not hold all work locally until every possible test finishes. A failure caused by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, or timed-out check should be reported honestly but should not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing/pushing, and reporting results. Before ending, inspect the working tree and either commit/push the requested safe changes or state the exact blocker. Do not fabricate commits for analysis-only requests or no-op work, and never commit secrets, temporary debugging, generated junk, or code known to be broken. A checkpoint commit does not make failing CI mergeable.'`

Commit SHA: `e4d7c0d435908bdb67adb5eae4bb1c848365600b`

Residual risks / notes: pre-commit hook failures observed are pre-existing and unrelated to this workflow change; notebook editing was not enabled because no tracked `.ipynb` files were found in the repository. No permissions-bypass flags (e.g. `--dangerously-skip-permissions`) or `workflows: write` grants outside the protected `@claude-exec` environment were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6066ab1290832fbab7426ad066ff33)