### PR TITLE
Fix desktop release publish artifact checkout order

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -705,6 +705,12 @@ jobs:
             exit 1
           fi
 
+      - name: Check out repository for immutable tag verification
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+          fetch-depth: 0
+
       - name: Download macOS artifacts
         uses: actions/download-artifact@v5
         with:
@@ -716,12 +722,6 @@ jobs:
         with:
           name: windows-x64-bundles
           path: release-assets/windows
-
-      - name: Check out repository for immutable tag verification
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ steps.tag.outputs.tag }}
-          fetch-depth: 0
 
       - name: Verify immutable tag, release absence, and artifact provenance
         env:

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -3271,6 +3271,42 @@ def _load_publish_manifest_provenance_source() -> str:
     return script[start:end]
 
 
+def test_publish_job_checks_out_immutable_tag_before_downloading_release_artifacts() -> None:
+    import yaml
+
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding='utf-8'))
+    steps = workflow['jobs']['publish']['steps']
+    step_names = [step.get('name') for step in steps]
+
+    resolve_index = step_names.index('Resolve release tag')
+    checkout_index = step_names.index('Check out repository for immutable tag verification')
+    macos_download_index = step_names.index('Download macOS artifacts')
+    windows_download_index = step_names.index('Download Windows artifacts')
+    verify_index = step_names.index('Verify immutable tag, release absence, and artifact provenance')
+    create_index = step_names.index('Create immutable GitHub Release')
+
+    assert resolve_index < checkout_index < macos_download_index < windows_download_index < verify_index < create_index
+
+    checkout_step = steps[checkout_index]
+    assert checkout_step['uses'] == 'actions/checkout@v5'
+    assert checkout_step['with']['ref'] == '${{ steps.tag.outputs.tag }}'
+    assert checkout_step['with']['fetch-depth'] == 0
+    assert 'clean' not in checkout_step.get('with', {})
+
+    macos_download = steps[macos_download_index]
+    assert macos_download['uses'] == 'actions/download-artifact@v5'
+    assert macos_download['with'] == {
+        'name': 'macos-arm64-bundles',
+        'path': 'release-assets/macos',
+    }
+
+    windows_download = steps[windows_download_index]
+    assert windows_download['uses'] == 'actions/download-artifact@v5'
+    assert windows_download['with'] == {
+        'name': 'windows-x64-bundles',
+        'path': 'release-assets/windows',
+    }
+
 def test_publish_release_creation_is_create_only_with_no_overwrite_path() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
     assert 'softprops/action-gh-release' not in text


### PR DESCRIPTION
### Motivation
- The publish job checked out the repository after downloading release artifacts, and checkout's default `clean: true` removed `release-assets/` causing provenance verification to fail with missing manifests. 
- The goal is a minimal ordering fix so the immutable-tag checkout runs before any artifact download while preserving all existing validation and immutability safeguards.

### Description
- Moved the `Check out repository for immutable tag verification` step to immediately follow `Resolve release tag` and kept `uses: actions/checkout@v5` with `ref: ${{ steps.tag.outputs.tag }}` and `fetch-depth: 0` so checkout cleaning runs before artifact downloads. 
- Left the macOS and Windows artifact downloads as `actions/download-artifact@v5` with `name: macos-arm64-bundles`/`windows-x64-bundles` and `path: release-assets/macos`/`release-assets/windows` respectively. 
- Kept the existing `Verify immutable tag, release absence, and artifact provenance` and `Create immutable GitHub Release` steps and all manifest/sha/provenance expectations unchanged. 
- Added a focused regression test `test_publish_job_checks_out_immutable_tag_before_downloading_release_artifacts` in `tests/unit/test_desktop_release_artifacts.py` that asserts the ordering and verifies checkout options and artifact names/paths.

### Testing
- Exact reordered steps introduced: `Resolve release tag` → `Check out repository for immutable tag verification` (`actions/checkout@v5`, `ref: ${{ steps.tag.outputs.tag }}`, `fetch-depth: 0`) → `Download macOS artifacts` (`actions/download-artifact@v5`, name `macos-arm64-bundles`, path `release-assets/macos`) → `Download Windows artifacts` (`actions/download-artifact@v5`, name `windows-x64-bundles`, path `release-assets/windows`) → `Verify immutable tag, release absence, and artifact provenance` → `Create immutable GitHub Release`. 
- Regression test added: `tests/unit/test_desktop_release_artifacts.py::test_publish_job_checks_out_immutable_tag_before_downloading_release_artifacts` which checks publish job step ordering, checkout `ref`/`fetch-depth`, absence of `clean` override, and the macOS/Windows download contracts. 
- Verification commands run and results: `python -m pip install -r config/requirements_codex_verification.txt` (succeeded); `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` (205 passed); `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` (29 passed); `pre-commit run --all-files` (passed); `git diff --check` (no issues); `actionlint .github/workflows/desktop-release.yml` (not installed in environment). 
- Confirmations: no desktop version bump, no tag/release creation in this PR, no artifact name/path/content/retention change, no change to the NVIDIA self-hosted gate or build matrix, and no weakening of immutable-tag, provenance, or release-absence validation. 
- Operator recovery instruction: after this fix lands on `main`, manually dispatch the Desktop Tauri Release workflow from `main` with `tag_name=desktop-v0.1.3` and leave “Build only” unchecked; do not rerun the original failed job because it uses the old workflow snapshot.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61b514af4c832f8a9a88f7303acc90)