### PR TITLE
Fix desktop release publish artifact checkout order

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -705,6 +705,12 @@ jobs:
             exit 1
           fi
 
+      - name: Check out repository for immutable tag verification
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+          fetch-depth: 0
+
       - name: Download macOS artifacts
         uses: actions/download-artifact@v5
         with:
@@ -716,12 +722,6 @@ jobs:
         with:
           name: windows-x64-bundles
           path: release-assets/windows
-
-      - name: Check out repository for immutable tag verification
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ steps.tag.outputs.tag }}
-          fetch-depth: 0
 
       - name: Verify immutable tag, release absence, and artifact provenance
         env:

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -3271,6 +3271,43 @@ def _load_publish_manifest_provenance_source() -> str:
     return script[start:end]
 
 
+def test_publish_job_checks_out_immutable_tag_before_downloading_artifacts() -> None:
+    import yaml
+
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding='utf-8'))
+    steps = workflow['jobs']['publish']['steps']
+    names = [step.get('name') for step in steps]
+
+    resolve_index = names.index('Resolve release tag')
+    checkout_index = names.index('Check out repository for immutable tag verification')
+    macos_index = names.index('Download macOS artifacts')
+    windows_index = names.index('Download Windows artifacts')
+    verify_index = names.index('Verify immutable tag, release absence, and artifact provenance')
+    create_index = names.index('Create immutable GitHub Release')
+
+    assert resolve_index < checkout_index < macos_index < windows_index < verify_index < create_index
+
+    checkout_step = steps[checkout_index]
+    assert checkout_step['uses'] == 'actions/checkout@v5'
+    assert checkout_step['with']['ref'] == '${{ steps.tag.outputs.tag }}'
+    assert checkout_step['with']['fetch-depth'] == 0
+    assert 'clean' not in checkout_step.get('with', {})
+
+    macos_step = steps[macos_index]
+    assert macos_step['uses'] == 'actions/download-artifact@v5'
+    assert macos_step['with'] == {
+        'name': 'macos-arm64-bundles',
+        'path': 'release-assets/macos',
+    }
+
+    windows_step = steps[windows_index]
+    assert windows_step['uses'] == 'actions/download-artifact@v5'
+    assert windows_step['with'] == {
+        'name': 'windows-x64-bundles',
+        'path': 'release-assets/windows',
+    }
+
+
 def test_publish_release_creation_is_create_only_with_no_overwrite_path() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
     assert 'softprops/action-gh-release' not in text

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -3285,7 +3285,8 @@ def test_publish_job_checks_out_immutable_tag_before_downloading_artifacts() -> 
     verify_index = names.index('Verify immutable tag, release absence, and artifact provenance')
     create_index = names.index('Create immutable GitHub Release')
 
-    assert resolve_index < checkout_index < macos_index < windows_index < verify_index < create_index
+    assert checkout_index == resolve_index + 1
+    assert checkout_index < macos_index < windows_index < verify_index < create_index
 
     checkout_step = steps[checkout_index]
     assert checkout_step['uses'] == 'actions/checkout@v5'


### PR DESCRIPTION
### Motivation
- The `publish` job previously ran `actions/checkout` after downloading release artifacts, and checkout’s default `clean: true` removed the downloaded `release-assets/*`, causing provenance verification to fail with missing manifests.  
- The change ensures the immutable-tag checkout happens before any artifact download so workspace cleaning cannot erase artifacts needed for verification.

### Description
- Move the `Check out repository for immutable tag verification` step to immediately follow `Resolve release tag` in `.github/workflows/desktop-release.yml`, before both `Download macOS artifacts` and `Download Windows artifacts`.  
- Add a focused regression test `test_publish_job_checks_out_immutable_tag_before_downloading_artifacts` to `tests/unit/test_desktop_release_artifacts.py` that asserts the publish-job ordering, that the checkout uses `actions/checkout@v5` with `ref: ${{ steps.tag.outputs.tag }}` and `fetch-depth: 0`, that artifact download steps use `actions/download-artifact@v5` with the expected names and `release-assets/macos` and `release-assets/windows` paths, and that verification and release-creation remain after downloads.  
- Preserve all existing validations and policies: immutable-tag lookup, release-absence check, manifest/checksum/provenance verification, artifact names/paths, build matrix, NVIDIA gate, and `workflow_dispatch` behavior.  
- No version bump, tag manipulation, release publishing, artifact renaming, overwrite behavior, or recovery-mode behavior was introduced.

### Testing
- Reordered publish steps (exact sequence verified): `Resolve release tag` → `Check out repository for immutable tag verification` → `Download macOS artifacts` → `Download Windows artifacts` → `Verify immutable tag, release absence, and artifact provenance` → `Create immutable GitHub Release`.  
- Added regression test: `test_publish_job_checks_out_immutable_tag_before_downloading_artifacts` in `tests/unit/test_desktop_release_artifacts.py`.  
- Commands run and results: `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` passed (205 tests passed), `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` passed (29 tests passed), `pre-commit run --all-files` passed, and `git diff --check` reported no issues; `actionlint .github/workflows/desktop-release.yml` was not available in the environment.  
- Confirmation: no desktop version, tag, release, artifact name/path/content, build matrix, NVIDIA gate, or immutability policy was changed; after merge, manually dispatch the Desktop Tauri Release from `main` with `tag_name=desktop-v0.1.3` and `Build only` unchecked (do not rerun the original failed job which used the old workflow snapshot).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61b51d2308832f9bf309874035e699)