### PR TITLE
Fix publish job ordering so checkout runs before downloading release artifacts

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -705,6 +705,12 @@ jobs:
             exit 1
           fi
 
+      - name: Check out repository for immutable tag verification
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+          fetch-depth: 0
+
       - name: Download macOS artifacts
         uses: actions/download-artifact@v5
         with:
@@ -716,12 +722,6 @@ jobs:
         with:
           name: windows-x64-bundles
           path: release-assets/windows
-
-      - name: Check out repository for immutable tag verification
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ steps.tag.outputs.tag }}
-          fetch-depth: 0
 
       - name: Verify immutable tag, release absence, and artifact provenance
         env:

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -3271,6 +3271,45 @@ def _load_publish_manifest_provenance_source() -> str:
     return script[start:end]
 
 
+def test_publish_job_checks_out_immutable_tag_before_downloading_release_assets() -> None:
+    import yaml
+
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding='utf-8'))
+    steps = workflow['jobs']['publish']['steps']
+    step_names = [step.get('name') for step in steps]
+
+    expected_order = [
+        'Resolve release tag',
+        'Check out repository for immutable tag verification',
+        'Download macOS artifacts',
+        'Download Windows artifacts',
+        'Verify immutable tag, release absence, and artifact provenance',
+        'Create immutable GitHub Release',
+    ]
+    positions = {name: step_names.index(name) for name in expected_order}
+    assert [positions[name] for name in expected_order] == sorted(positions.values())
+
+    checkout_step = steps[positions['Check out repository for immutable tag verification']]
+    assert checkout_step['uses'] == 'actions/checkout@v5'
+    assert checkout_step['with']['ref'] == '${{ steps.tag.outputs.tag }}'
+    assert checkout_step['with']['fetch-depth'] == 0
+    assert 'clean' not in checkout_step.get('with', {})
+
+    macos_step = steps[positions['Download macOS artifacts']]
+    assert macos_step['uses'] == 'actions/download-artifact@v5'
+    assert macos_step['with'] == {
+        'name': 'macos-arm64-bundles',
+        'path': 'release-assets/macos',
+    }
+
+    windows_step = steps[positions['Download Windows artifacts']]
+    assert windows_step['uses'] == 'actions/download-artifact@v5'
+    assert windows_step['with'] == {
+        'name': 'windows-x64-bundles',
+        'path': 'release-assets/windows',
+    }
+
+
 def test_publish_release_creation_is_create_only_with_no_overwrite_path() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
     assert 'softprops/action-gh-release' not in text


### PR DESCRIPTION
### Motivation
- The `publish` job checked out the immutable tag after downloading artifacts, allowing `actions/checkout`'s default `clean: true` behavior to delete previously downloaded `release-assets/*` and causing missing-manifest provenance failures.

### Description
- Move the publish job immutable-tag checkout step to run immediately after `Resolve release tag` and before both `Download macOS artifacts` and `Download Windows artifacts`, keeping `ref: ${{ steps.tag.outputs.tag }}` and `fetch-depth: 0` intact.
- Preserve all existing verification and creation logic for immutable-tag validation, provenance checks, and release creation; do not change validations, artifact names/paths, or immutability policies.
- Add a focused regression test `test_publish_job_checks_out_immutable_tag_before_downloading_release_assets` in `tests/unit/test_desktop_release_artifacts.py` that asserts the publish-step ordering, verifies the checkout `uses`/`ref`/`fetch-depth`, and verifies the download steps’ artifact `name`/`path` values.

### Testing
- Exact reordered steps (now enforced in the workflow): `Resolve release tag` → `Check out repository for immutable tag verification` → `Download macOS artifacts` → `Download Windows artifacts` → `Verify immutable tag, release absence, and artifact provenance` → `Create immutable GitHub Release`.
- Regression test added: `test_publish_job_checks_out_immutable_tag_before_downloading_release_assets` (file `tests/unit/test_desktop_release_artifacts.py`).
- Commands run and results: `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` — all tests passed (205 passed); `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` — all tests passed (29 passed); `pre-commit run --all-files` — passed; `git diff --check` — no problems; `actionlint .github/workflows/desktop-release.yml` — not executed because `actionlint` is not installed in this environment (`command not found`).
- Confirmations: no desktop version bump, no tag/release/asset renames or retention changes, the Windows NVIDIA gate and build matrix were not modified, and immutability/provenance/manifest validation logic was preserved.
- Operator recovery: after this fix reaches `main`, manually dispatch the Desktop Tauri Release from `main` with `tag_name=desktop-v0.1.3` and uncheck `Build only`; do not rerun the original failed job because it uses the prior (broken) workflow snapshot.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61b523a8b0832f8588ea40fa31d149)