### PR TITLE
Fix desktop release publish artifact checkout order

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -705,6 +705,12 @@ jobs:
             exit 1
           fi
 
+      - name: Check out repository for immutable tag verification
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+          fetch-depth: 0
+
       - name: Download macOS artifacts
         uses: actions/download-artifact@v5
         with:
@@ -716,12 +722,6 @@ jobs:
         with:
           name: windows-x64-bundles
           path: release-assets/windows
-
-      - name: Check out repository for immutable tag verification
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ steps.tag.outputs.tag }}
-          fetch-depth: 0
 
       - name: Verify immutable tag, release absence, and artifact provenance
         env:

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -3271,6 +3271,50 @@ def _load_publish_manifest_provenance_source() -> str:
     return script[start:end]
 
 
+def test_publish_job_checks_out_immutable_tag_before_downloading_release_artifacts() -> None:
+    import yaml
+
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding='utf-8'))
+    steps = workflow['jobs']['publish']['steps']
+    step_names = [step.get('name') for step in steps]
+
+    resolve_index = step_names.index('Resolve release tag')
+    checkout_index = step_names.index('Check out repository for immutable tag verification')
+    macos_download_index = step_names.index('Download macOS artifacts')
+    windows_download_index = step_names.index('Download Windows artifacts')
+    verify_index = step_names.index('Verify immutable tag, release absence, and artifact provenance')
+    create_index = step_names.index('Create immutable GitHub Release')
+
+    assert (
+        resolve_index
+        < checkout_index
+        < macos_download_index
+        < windows_download_index
+        < verify_index
+        < create_index
+    )
+
+    checkout_step = steps[checkout_index]
+    assert checkout_step['uses'] == 'actions/checkout@v5'
+    assert checkout_step['with']['ref'] == '${{ steps.tag.outputs.tag }}'
+    assert checkout_step['with']['fetch-depth'] == 0
+    assert 'clean' not in checkout_step.get('with', {})
+
+    macos_step = steps[macos_download_index]
+    assert macos_step['uses'] == 'actions/download-artifact@v5'
+    assert macos_step['with'] == {
+        'name': 'macos-arm64-bundles',
+        'path': 'release-assets/macos',
+    }
+
+    windows_step = steps[windows_download_index]
+    assert windows_step['uses'] == 'actions/download-artifact@v5'
+    assert windows_step['with'] == {
+        'name': 'windows-x64-bundles',
+        'path': 'release-assets/windows',
+    }
+
+
 def test_publish_release_creation_is_create_only_with_no_overwrite_path() -> None:
     text = WORKFLOW.read_text(encoding='utf-8')
     assert 'softprops/action-gh-release' not in text


### PR DESCRIPTION
### Motivation

- The publish job performed an `actions/checkout` after downloading release artifacts, and checkout’s default `clean: true` workspace behavior removed the downloaded manifest/artifact files and caused provenance verification to fail.

### Description

- Reordered the `publish` job steps so they execute in this immutable-tag-first sequence: `Resolve release tag`, `Check out repository for immutable tag verification` (uses `actions/checkout@v5` with `ref: ${{ steps.tag.outputs.tag }}` and `fetch-depth: 0`), `Download macOS artifacts` (`actions/download-artifact@v5` name `macos-arm64-bundles` path `release-assets/macos`), `Download Windows artifacts` (`actions/download-artifact@v5` name `windows-x64-bundles` path `release-assets/windows`), `Verify immutable tag, release absence, and artifact provenance`, and `Create immutable GitHub Release`.
- Added a focused regression test `test_publish_job_checks_out_immutable_tag_before_downloading_release_artifacts` in `tests/unit/test_desktop_release_artifacts.py` that asserts the publish-step ordering, verifies the macOS/Windows artifact names and destination paths, checks the checkout `ref` and `fetch-depth` values, and asserts no `clean` override is present.
- Preserved the existing provenance, manifest, checksum, immutable-tag, release-absence, target-triple, bundled-runtime, and release-creation logic and left the release creation step unchanged after verification.
- Kept all other policies and settings unchanged (no version bump, no tag/release mutation, no artifact name/path/retention/content changes, and no changes to the NVIDIA gate or build matrix).

### Testing

- Ran `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` which passed (`205 passed`).
- Ran `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` which passed (`29 passed`).
- Ran `pre-commit run --all-files` and `git diff --check`, both of which passed, and `actionlint .github/workflows/desktop-release.yml` was not available in this environment.
- Operator recovery instruction: after this fix lands on `main`, manually dispatch the Desktop Tauri Release workflow from `main` with `tag_name=desktop-v0.1.3` and leave “Build only” unchecked rather than re-running the original failed job.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61b52be650832f85f154834f8ac437)