### PR TITLE
Fix Windows desktop operator startup gating and bundled-runtime discovery (prepare 0.1.4)

### DIFF
--- a/.github/workflows/desktop-operator-e2e.yml
+++ b/.github/workflows/desktop-operator-e2e.yml
@@ -118,6 +118,9 @@ jobs:
           pip install -r config/requirements_codex_verification.txt
           pip install selenium
 
+      - name: Run full Rust suite
+        run: cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml
+
       - name: Run desktop operator UI e2e
         run: xvfb-run -a python desktop-tauri/scripts/test_desktop_operator_ui_e2e.py
 
@@ -166,8 +169,7 @@ jobs:
           python -m pytest tests/unit/test_desktop_runtime_setup.py -q
           python -m pytest tests/unit/test_model_manager.py -q
           python -m pytest tests/integration/test_desktop_qwen64k_packaged_runtime.py -q
-          cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml operator_logs
-          cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml compute_node
+          cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml
 
       - name: Upload desktop relay parity logs on failure (Windows)
         if: failure()

--- a/desktop-tauri/package-lock.json
+++ b/desktop-tauri/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-place-desktop-tauri",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "token-place-desktop-tauri",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/desktop-tauri/package.json
+++ b/desktop-tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "token-place-desktop-tauri",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop-tauri/scripts/test_windows_installer_identity.py
+++ b/desktop-tauri/scripts/test_windows_installer_identity.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Callable, Iterable
 
 EXPECTED_VERSION = "0.1.4"
+EXPECTED_MODEL_ARTIFACT_FILENAME = "Qwen3-8B-Q4_K_M.gguf"
 EXPECTED_RUNTIME_ID = "bundled-cpython-3.11-win-x86_64-cu124"
 RUNTIME_PROVENANCE_NAME = "embedded_python_runtime_provenance.json"
 OBSOLETE_RUNTIME_PROVENANCE_NAME = "tokenplace-runtime-" + "provenance.json"
@@ -676,8 +677,14 @@ def assert_operator_record(text: str, expected_tier: str | None = None, launch_n
     if data.get("model_artifact_inspect") != "ok":
         raise InstallerIdentityError("operator-session smoke did not run GUI-equivalent model artifact inspection")
     model_filename = data.get("model_artifact_filename")
-    if not isinstance(model_filename, str) or not model_filename.endswith(".gguf") or "/" in model_filename or "\\" in model_filename:
-        raise InstallerIdentityError("operator-session smoke did not report a safe model artifact filename")
+    if (
+        not isinstance(model_filename, str)
+        or model_filename != EXPECTED_MODEL_ARTIFACT_FILENAME
+        or not model_filename.endswith(".gguf")
+        or "/" in model_filename
+        or "\\" in model_filename
+    ):
+        raise InstallerIdentityError("operator-session smoke did not report the expected safe model artifact filename")
     if expected_tier is not None:
         expected_n_ctx = {"8k-fast": 8192, "64k-full": 65536}.get(expected_tier)
         if data.get("context_tier") != expected_tier or data.get("effective_n_ctx") != expected_n_ctx or data.get("n_ctx") != expected_n_ctx:

--- a/desktop-tauri/scripts/test_windows_installer_identity.py
+++ b/desktop-tauri/scripts/test_windows_installer_identity.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterable
 
-EXPECTED_VERSION = "0.1.3"
+EXPECTED_VERSION = "0.1.4"
 EXPECTED_RUNTIME_ID = "bundled-cpython-3.11-win-x86_64-cu124"
 RUNTIME_PROVENANCE_NAME = "embedded_python_runtime_provenance.json"
 OBSOLETE_RUNTIME_PROVENANCE_NAME = "tokenplace-runtime-" + "provenance.json"
@@ -673,6 +673,11 @@ def assert_operator_record(text: str, expected_tier: str | None = None, launch_n
         raise InstallerIdentityError(f"operator-session record missing or mismatched {missing}")
     if data.get("bridge_preflight") != "ok":
         raise InstallerIdentityError("operator-session smoke did not run bridge-command preflight")
+    if data.get("model_artifact_inspect") != "ok":
+        raise InstallerIdentityError("operator-session smoke did not run GUI-equivalent model artifact inspection")
+    model_filename = data.get("model_artifact_filename")
+    if not isinstance(model_filename, str) or not model_filename.endswith(".gguf") or "/" in model_filename or "\\" in model_filename:
+        raise InstallerIdentityError("operator-session smoke did not report a safe model artifact filename")
     if expected_tier is not None:
         expected_n_ctx = {"8k-fast": 8192, "64k-full": 65536}.get(expected_tier)
         if data.get("context_tier") != expected_tier or data.get("effective_n_ctx") != expected_n_ctx or data.get("n_ctx") != expected_n_ctx:

--- a/desktop-tauri/src-tauri/Cargo.lock
+++ b/desktop-tauri/src-tauri/Cargo.lock
@@ -4167,7 +4167,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-place-desktop-tauri"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aes",
  "anyhow",

--- a/desktop-tauri/src-tauri/Cargo.toml
+++ b/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "token-place-desktop-tauri"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -6313,8 +6313,14 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn isolate_and_terminate_bridge_process_tree_unix_stops_root_and_descendant() {
+        let tmp_dir = TempDir::new().expect("create temp dir");
+        let pid_path = tmp_dir.path().join("descendant_pid.txt");
+        let script = format!(
+            "sleep 30 & printf '%s\n' \"$!\" > {}; wait",
+            pid_path.display()
+        );
         let mut cmd = Command::new("sh");
-        cmd.args(["-c", "sleep 30 & wait"]);
+        cmd.args(["-c", &script]);
         isolate_bridge_process_tree(&mut cmd);
         let mut child = cmd
             .stdin(Stdio::null())
@@ -6323,59 +6329,99 @@ mod tests {
             .spawn()
             .expect("spawn root");
         let root_pid = child.id().expect("root pid");
+        let pgid = root_pid as i32;
 
-        // Give the shell time to fork the sleep child.
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        // Terminate the isolated process group (SIGTERM then SIGKILL to -pgid).
-        terminate_bridge_process_tree(root_pid).await;
-
-        // Boundedly prove root stopped.
-        let deadline = Instant::now() + Duration::from_secs(3);
-        let root_stopped = loop {
-            match child.try_wait() {
-                Ok(Some(_)) => break true,
-                Ok(None) => {
-                    if Instant::now() >= deadline {
-                        // Force cleanup to avoid CI leak before failing.
-                        let _ = child.kill().await;
-                        let _ = child.wait().await;
-                        break false;
-                    }
-                    tokio::time::sleep(Duration::from_millis(50)).await;
-                }
-                Err(_) => break true,
+        let cleanup_group = |pgid: i32| {
+            // SAFETY: test cleanup sends SIGKILL to the isolated process group.
+            unsafe {
+                kill(-pgid, SIGKILL);
             }
         };
-        assert!(
-            root_stopped,
-            "root process did not stop after terminate_bridge_process_tree"
-        );
-
-        // Boundedly prove the process group is gone by polling kill(-pgid, 0).
-        // SAFETY: kill(-pgid, 0) is a signal-existence probe; no actual signal is delivered.
-        let pgid = root_pid as i32;
-        let pg_deadline = Instant::now() + Duration::from_millis(500);
-        loop {
-            // SAFETY: sending signal 0 only checks for process group existence.
-            let result = unsafe { kill(-pgid, 0) };
-            if result == -1 {
-                let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
-                // ESRCH = 3: process group does not exist — descendant cleaned up.
-                // EPERM means the group still exists but we lack permission (same-user
-                // spawned processes should not hit this; treat it as still-alive).
-                if errno == 3 {
-                    break;
-                }
-                // Any other errno (e.g., EPERM) means the group is still present.
+        let pid_stopped = |pid: i32| -> bool {
+            // SAFETY: sending signal 0 only checks process existence.
+            if unsafe { kill(pid, 0) } == -1
+                && std::io::Error::last_os_error().raw_os_error() == Some(3)
+            {
+                return true;
             }
-            if Instant::now() >= pg_deadline {
-                // Force-kill any survivor before failing.
-                // SAFETY: sending SIGKILL to the process group for cleanup.
-                unsafe {
-                    kill(-pgid, SIGKILL);
+            std::fs::read_to_string(format!("/proc/{pid}/stat"))
+                .ok()
+                .and_then(|stat| {
+                    stat.split(')')
+                        .nth(1)
+                        .map(str::trim_start)
+                        .map(str::to_owned)
+                })
+                .and_then(|after_name| after_name.chars().next())
+                == Some('Z')
+        };
+        let process_group_has_live_member = |pgid: i32| -> bool {
+            let Ok(entries) = std::fs::read_dir("/proc") else {
+                return false;
+            };
+            for entry in entries.flatten() {
+                let Ok(pid) = entry.file_name().to_string_lossy().parse::<i32>() else {
+                    continue;
+                };
+                let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+                    continue;
+                };
+                let Some(after_name) = stat.split(')').nth(1).map(str::trim_start) else {
+                    continue;
+                };
+                let mut fields = after_name.split_whitespace();
+                let state = fields.next();
+                let _ppid = fields.next();
+                let pgrp = fields.next().and_then(|field| field.parse::<i32>().ok());
+                if pgrp == Some(pgid) && state != Some("Z") {
+                    return true;
                 }
-                panic!("descendant in isolated process group still alive after terminate");
+            }
+            false
+        };
+
+        let readiness_deadline = Instant::now() + Duration::from_secs(3);
+        let descendant_pid = loop {
+            if let Ok(pid_text) = std::fs::read_to_string(&pid_path) {
+                if let Ok(pid) = pid_text.trim().parse::<i32>() {
+                    if pid > 0 {
+                        // SAFETY: sending signal 0 only checks process existence.
+                        if unsafe { kill(pid, 0) } == 0 {
+                            break pid;
+                        }
+                    }
+                }
+            }
+            if Instant::now() >= readiness_deadline {
+                cleanup_group(pgid);
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                panic!("descendant pid was not published before termination");
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        };
+
+        terminate_bridge_process_tree(root_pid).await;
+
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            let root_done = match child.try_wait() {
+                Ok(Some(_)) | Err(_) => true,
+                Ok(None) => false,
+            };
+            let descendant_done = pid_stopped(descendant_pid);
+            let group_done = !process_group_has_live_member(pgid);
+
+            if root_done && descendant_done && group_done {
+                break;
+            }
+            if Instant::now() >= deadline {
+                cleanup_group(pgid);
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                panic!(
+                    "isolated process tree still alive after terminate: root_done={root_done} descendant_done={descendant_done} group_done={group_done}"
+                );
             }
             tokio::time::sleep(Duration::from_millis(20)).await;
         }

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::BTreeMap;
 #[cfg(unix)]
-use std::os::unix::process::{CommandExt, ExitStatusExt};
+use std::os::unix::process::ExitStatusExt;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
 use std::path::Path;
@@ -444,6 +444,24 @@ fn is_python_script(path: &str) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
 }
 
+fn build_installed_context_probe_command(
+    launcher: &PythonLauncher,
+    bridge_script: &Path,
+    context: &BridgeResourceContext<'_>,
+    config: &DesktopConfig,
+) -> std::process::Command {
+    let mut command = launcher.command_for_script_blocking(bridge_script);
+    configure_runtime_pythonpath(
+        &mut command,
+        context.manifest_dir,
+        bridge_script,
+        context.exe_path,
+        context.tauri_resource_dir,
+    );
+    configure_runtime_bootstrap_env(&mut command, &config.preferred_mode);
+    command
+}
+
 fn bridge_script_candidates(
     exe_path: Option<&Path>,
     manifest_dir: &Path,
@@ -543,9 +561,12 @@ where
     import_root
 }
 
-fn configure_runtime_bootstrap_env(command: &mut Command, mode: &ComputeMode) {
+fn configure_runtime_bootstrap_env<C>(command: &mut C, mode: &ComputeMode)
+where
+    C: PythonEnvCommand,
+{
     if should_enable_runtime_bootstrap(mode) {
-        command.env(ENABLE_RUNTIME_BOOTSTRAP_ENV, "1");
+        command.set_env(ENABLE_RUNTIME_BOOTSTRAP_ENV, "1");
     }
 }
 
@@ -557,6 +578,22 @@ fn command_env_value(command: &Command, key: &str) -> Option<String> {
         .find_map(|(env_key, value)| (env_key == key).then_some(value))
         .flatten()
         .map(|value| value.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+fn std_command_env_value(command: &std::process::Command, key: &str) -> Option<String> {
+    command
+        .get_envs()
+        .find_map(|(env_key, value)| (env_key == key).then_some(value))
+        .flatten()
+        .map(|value| value.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+fn std_command_env_removed(command: &std::process::Command, key: &str) -> bool {
+    command
+        .get_envs()
+        .any(|(env_key, value)| env_key == key && value.is_none())
 }
 
 fn sanitize_relay_target(relay_url: &str) -> String {
@@ -1609,24 +1646,18 @@ pub(crate) fn operator_session_smoke_record(config: &DesktopConfig) -> anyhow::R
     let model_inspect_stdout = String::from_utf8_lossy(&model_inspect_output.stdout);
     let model_inspect_json: Value = serde_json::from_str(model_inspect_stdout.trim())?;
     let model_artifact_filename = inspect_model_artifact_filename(&model_inspect_json)?;
-    let mut bridge_command = build_bridge_command(&bridge_script, Some(launcher.clone()))?;
-    let import_root = configure_runtime_pythonpath(
-        &mut bridge_command,
-        manifest_dir,
-        Path::new(&bridge_script),
-        context.exe_path,
-        context.tauri_resource_dir,
-    );
-    configure_runtime_bootstrap_env(&mut bridge_command, &config.preferred_mode);
+    let bridge_script_path = Path::new(&bridge_script);
     let (selected_resource_root, selected_layout) =
-        context.describe_resource_layout(Path::new(&bridge_script));
+        context.describe_resource_layout(bridge_script_path);
+    let import_root = resolve_runtime_import_root(Some(bridge_script_path), context.manifest_dir);
     let identity = crate::build_identity::build_identity();
     let launcher_source = match launcher.source {
         PythonLauncherSource::BundledRuntime => "bundled",
         PythonLauncherSource::EnvironmentOverride => "environment_override",
         PythonLauncherSource::SystemDevelopmentRuntime => "system_development",
     };
-    let mut context_probe_command = launcher.command_for_script_blocking(&bridge_script);
+    let mut context_probe_command =
+        build_installed_context_probe_command(&launcher, bridge_script_path, &context, config);
     context_probe_command.arg("--installed-context-smoke");
     context_probe_command
         .arg("--context-tier")
@@ -5954,6 +5985,63 @@ mod tests {
             None
         );
         assert_eq!(safe_model_artifact_filename(""), None);
+    }
+
+    #[test]
+    fn installed_context_probe_helper_configures_executed_command_environment() {
+        let temp = TempDir::new().expect("tempdir");
+        let manifest_dir = temp
+            .path()
+            .join("repo")
+            .join("desktop-tauri")
+            .join("src-tauri");
+        let exe_dir = temp.path().join("installed").join("bin");
+        let resource_root = exe_dir.join("resources");
+        let python_dir = resource_root.join("python");
+        std::fs::create_dir_all(&python_dir).expect("create python dir");
+        std::fs::create_dir_all(resource_root.join("utils")).expect("create import utils dir");
+        std::fs::create_dir_all(&manifest_dir).expect("create manifest dir");
+        std::fs::create_dir_all(&exe_dir).expect("create exe dir");
+        let bridge_script = python_dir.join("compute_node_bridge.py");
+        std::fs::write(&bridge_script, "# compute bridge\n").expect("write bridge script");
+        let exe_path = exe_dir.join("token.place");
+        std::fs::write(&exe_path, "").expect("write exe");
+        let launcher = PythonLauncher {
+            program: "python3".into(),
+            args: Vec::new(),
+            source: PythonLauncherSource::BundledRuntime,
+            runtime_id: "test-runtime".into(),
+        };
+        let context = BridgeResourceContext {
+            exe_path: Some(&exe_path),
+            manifest_dir: &manifest_dir,
+            tauri_resource_dir: Some(&resource_root),
+        };
+        let config = DesktopConfig::default();
+
+        let command =
+            build_installed_context_probe_command(&launcher, &bridge_script, &context, &config);
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            args.first().map(String::as_str),
+            Some(bridge_script.to_str().unwrap())
+        );
+        assert!(!args.first().unwrap().is_empty());
+        assert_eq!(
+            std_command_env_value(&command, "PYTHONNOUSERSITE").as_deref(),
+            Some("1")
+        );
+        assert_eq!(
+            std_command_env_value(&command, "TOKEN_PLACE_PYTHON_IMPORT_ROOT").as_deref(),
+            Some(resource_root.to_str().unwrap())
+        );
+        assert!(std_command_env_value(&command, "PYTHONPATH").is_some());
+        assert!(std_command_env_removed(&command, "PYTHONHOME"));
+        assert!(std_command_env_removed(&command, "PYTHONUSERBASE"));
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -9,7 +9,7 @@ use crate::python_runtime::{
     bridge_script_candidates_from_resource_roots, configure_python_subprocess_env_for_layout,
     describe_resource_layout, disable_python_user_site, resolve_bridge_script_path,
     resolve_python_launcher_resource_aware, resolve_runtime_import_root,
-    should_enable_runtime_bootstrap, PythonEnvCommand, PythonLauncher,
+    should_enable_runtime_bootstrap, BridgeResourceContext, PythonEnvCommand, PythonLauncher,
     PythonLauncherResolutionOptions, PythonLauncherSource, ENABLE_RUNTIME_BOOTSTRAP_ENV,
 };
 use crate::subprocess_logging::{SubprocessLogFilter, SubprocessLogPolicy};
@@ -31,7 +31,7 @@ use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::oneshot;
 use tokio::sync::{Mutex, Notify};
 
-const EXPECTED_MODEL_ARTIFACT_FILENAME: &str = "qwen3.gguf";
+const EXPECTED_MODEL_ARTIFACT_FILENAME: &str = "Qwen3-8B-Q4_K_M.gguf";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComputeNodeRequest {
@@ -1571,40 +1571,35 @@ fn packaged_launcher_source_is_valid(
 pub(crate) fn operator_session_smoke_record(config: &DesktopConfig) -> anyhow::Result<Value> {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let current_exe = std::env::current_exe().ok();
-    let packaged =
-        crate::python_runtime::is_packaged_execution(current_exe.as_deref(), manifest_dir);
-    let launcher = resolve_python_launcher_resource_aware(PythonLauncherResolutionOptions {
-        override_var_name: "TOKEN_PLACE_SIDECAR_PYTHON",
-        tauri_resource_dir: None,
-        current_exe_path: current_exe.as_deref(),
+    let context = BridgeResourceContext {
+        exe_path: current_exe.as_deref(),
         manifest_dir,
-        packaged,
-    })?;
+        tauri_resource_dir: None,
+    };
+    let packaged = context.packaged();
+    let launcher = resolve_python_launcher_resource_aware(
+        context.launcher_options("TOKEN_PLACE_SIDECAR_PYTHON"),
+    )?;
     if !packaged_launcher_source_is_valid(packaged, Some(&launcher.source)) {
         anyhow::bail!("desktop_python_runtime_invalid: packaged Windows/macOS operator must use bundled runtime");
     }
     let bridge_script = resolve_bridge_script_for(
-        current_exe.as_deref(),
-        manifest_dir,
-        None,
+        context.exe_path,
+        context.manifest_dir,
+        context.tauri_resource_dir,
         Some(&launcher.program),
     )
     .map_err(anyhow::Error::msg)?;
-    let model_bridge_script = resolve_bridge_script_path(
-        "model_bridge.py",
-        current_exe.as_deref(),
-        manifest_dir,
-        None,
-        Some(&launcher.program),
-    )
-    .map_err(anyhow::Error::msg)?;
+    let model_bridge_script = context
+        .resolve_bridge_script_path("model_bridge.py", Some(&launcher.program))
+        .map_err(anyhow::Error::msg)?;
     let mut model_inspect_command = launcher.command_for_script_blocking(&model_bridge_script);
     configure_runtime_pythonpath(
         &mut model_inspect_command,
         manifest_dir,
         &model_bridge_script,
-        current_exe.as_deref(),
-        None,
+        context.exe_path,
+        context.tauri_resource_dir,
     );
     model_inspect_command.arg("inspect");
     let model_inspect_output = model_inspect_command.output()?;
@@ -1619,16 +1614,12 @@ pub(crate) fn operator_session_smoke_record(config: &DesktopConfig) -> anyhow::R
         &mut bridge_command,
         manifest_dir,
         Path::new(&bridge_script),
-        current_exe.as_deref(),
-        None,
+        context.exe_path,
+        context.tauri_resource_dir,
     );
     configure_runtime_bootstrap_env(&mut bridge_command, &config.preferred_mode);
-    let (selected_resource_root, selected_layout) = describe_resource_layout(
-        Path::new(&bridge_script),
-        current_exe.as_deref(),
-        manifest_dir,
-        None,
-    );
+    let (selected_resource_root, selected_layout) =
+        context.describe_resource_layout(Path::new(&bridge_script));
     let identity = crate::build_identity::build_identity();
     let launcher_source = match launcher.source {
         PythonLauncherSource::BundledRuntime => "bundled",
@@ -5979,10 +5970,10 @@ mod tests {
         for rejected in [
             serde_json::json!({"ok": false, "payload": {"filename": EXPECTED_MODEL_ARTIFACT_FILENAME}}),
             serde_json::json!({"ok": true, "payload": {"filename": "qwen3.bin"}}),
-            serde_json::json!({"ok": true, "payload": {"filename": "models/qwen3.gguf"}}),
-            serde_json::json!({"ok": true, "payload": {"filename": "models\\qwen3.gguf"}}),
-            serde_json::json!({"ok": true, "payload": {"filename": "/home/operator/qwen3.gguf"}}),
-            serde_json::json!({"ok": true, "payload": {"filename": "C:\\Users\\operator\\qwen3.gguf"}}),
+            serde_json::json!({"ok": true, "payload": {"filename": "models/Qwen3-8B-Q4_K_M.gguf"}}),
+            serde_json::json!({"ok": true, "payload": {"filename": "models\\Qwen3-8B-Q4_K_M.gguf"}}),
+            serde_json::json!({"ok": true, "payload": {"filename": "/home/operator/Qwen3-8B-Q4_K_M.gguf"}}),
+            serde_json::json!({"ok": true, "payload": {"filename": "C:\\Users\\operator\\Qwen3-8B-Q4_K_M.gguf"}}),
             serde_json::json!({"ok": true, "payload": {"filename": "other.gguf"}}),
             serde_json::json!({"ok": true, "payload": {"filename": ""}}),
         ] {

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -31,6 +31,8 @@ use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::oneshot;
 use tokio::sync::{Mutex, Notify};
 
+const EXPECTED_MODEL_ARTIFACT_FILENAME: &str = "qwen3.gguf";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComputeNodeRequest {
     pub model_path: String,
@@ -490,40 +492,52 @@ fn first_existing_script(candidates: Vec<std::path::PathBuf>) -> Option<String> 
         .map(|candidate| candidate.to_string_lossy().into_owned())
 }
 
-fn script_path_arg(path: &Path, label: &str) -> anyhow::Result<String> {
-    path.to_str()
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| anyhow::anyhow!("{label}: resolved script path is not valid UTF-8"))
-}
-
 fn safe_model_artifact_filename(filename: &str) -> Option<&str> {
     (!filename.is_empty()
+        && filename == EXPECTED_MODEL_ARTIFACT_FILENAME
         && filename.ends_with(".gguf")
         && !filename.contains('/')
-        && !filename.contains('\\'))
+        && !filename.contains('\\')
+        && Path::new(filename)
+            .file_name()
+            .and_then(|name| name.to_str())
+            == Some(filename))
     .then_some(filename)
+}
+
+fn inspect_model_artifact_filename(inspect_json: &Value) -> anyhow::Result<String> {
+    if inspect_json.get("ok").and_then(Value::as_bool) != Some(true) {
+        anyhow::bail!("model_artifact_inspect_failed: inspect did not return ok");
+    }
+    inspect_json
+        .get("payload")
+        .and_then(|payload| payload.get("filename"))
+        .and_then(Value::as_str)
+        .and_then(safe_model_artifact_filename)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "model_artifact_inspect_failed: inspect did not report the expected basename-only .gguf model filename"
+            )
+        })
 }
 
 fn configure_runtime_pythonpath<C>(
     command: &mut C,
     manifest_dir: &Path,
-    bridge_script: &str,
+    bridge_script: &Path,
+    exe_path: Option<&Path>,
+    resource_dir: Option<&Path>,
 ) -> Option<std::path::PathBuf>
 where
     C: PythonEnvCommand,
 {
     disable_python_user_site(command);
-    let import_root = resolve_runtime_import_root(Some(Path::new(bridge_script)), manifest_dir);
+    let import_root = resolve_runtime_import_root(Some(bridge_script), manifest_dir);
     if let Some(import_root) = import_root.as_deref() {
-        let (_, layout) = describe_resource_layout(
-            Path::new(bridge_script),
-            std::env::current_exe().ok().as_deref(),
-            manifest_dir,
-            None,
-        );
-        let current_exe = std::env::current_exe().ok();
-        let packaged =
-            crate::python_runtime::is_packaged_execution(current_exe.as_deref(), manifest_dir);
+        let (_, layout) =
+            describe_resource_layout(bridge_script, exe_path, manifest_dir, resource_dir);
+        let packaged = crate::python_runtime::is_packaged_execution(exe_path, manifest_dir);
         configure_python_subprocess_env_for_layout(command, import_root, layout, packaged);
     }
     import_root
@@ -1584,13 +1598,13 @@ pub(crate) fn operator_session_smoke_record(config: &DesktopConfig) -> anyhow::R
         Some(&launcher.program),
     )
     .map_err(anyhow::Error::msg)?;
-    let model_bridge_script_arg =
-        script_path_arg(&model_bridge_script, "model_artifact_inspect_failed")?;
-    let mut model_inspect_command = launcher.command_for_script_blocking(&model_bridge_script_arg);
+    let mut model_inspect_command = launcher.command_for_script_blocking(&model_bridge_script);
     configure_runtime_pythonpath(
         &mut model_inspect_command,
         manifest_dir,
-        &model_bridge_script_arg,
+        &model_bridge_script,
+        current_exe.as_deref(),
+        None,
     );
     model_inspect_command.arg("inspect");
     let model_inspect_output = model_inspect_command.output()?;
@@ -1599,20 +1613,15 @@ pub(crate) fn operator_session_smoke_record(config: &DesktopConfig) -> anyhow::R
     }
     let model_inspect_stdout = String::from_utf8_lossy(&model_inspect_output.stdout);
     let model_inspect_json: Value = serde_json::from_str(model_inspect_stdout.trim())?;
-    let model_artifact_filename = model_inspect_json
-        .get("payload")
-        .and_then(|payload| payload.get("filename"))
-        .and_then(Value::as_str)
-        .and_then(safe_model_artifact_filename)
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "model_artifact_inspect_failed: inspect did not report a basename-only .gguf model filename"
-            )
-        })?
-        .to_string();
+    let model_artifact_filename = inspect_model_artifact_filename(&model_inspect_json)?;
     let mut bridge_command = build_bridge_command(&bridge_script, Some(launcher.clone()))?;
-    let import_root =
-        configure_runtime_pythonpath(&mut bridge_command, manifest_dir, &bridge_script);
+    let import_root = configure_runtime_pythonpath(
+        &mut bridge_command,
+        manifest_dir,
+        Path::new(&bridge_script),
+        current_exe.as_deref(),
+        None,
+    );
     configure_runtime_bootstrap_env(&mut bridge_command, &config.preferred_mode);
     let (selected_resource_root, selected_layout) = describe_resource_layout(
         Path::new(&bridge_script),
@@ -1849,8 +1858,13 @@ pub async fn start_compute_node(
         manifest_dir,
         resource_dir.as_deref(),
     );
-    let import_root =
-        configure_runtime_pythonpath(&mut bridge_command, manifest_dir, &bridge_script);
+    let import_root = configure_runtime_pythonpath(
+        &mut bridge_command,
+        manifest_dir,
+        Path::new(&bridge_script),
+        exe_path.as_deref(),
+        resource_dir.as_deref(),
+    );
     let interpreter = bridge_command
         .as_std()
         .get_program()
@@ -2946,11 +2960,8 @@ mod tests {
         let manifest_dir = temp.path().join("missing-manifest");
         let mut command = Command::new("python");
 
-        let import_root = configure_runtime_pythonpath(
-            &mut command,
-            &manifest_dir,
-            bridge.to_str().expect("bridge path should be UTF-8"),
-        );
+        let import_root =
+            configure_runtime_pythonpath(&mut command, &manifest_dir, &bridge, None, None);
 
         assert!(import_root.is_none());
         assert_eq!(
@@ -5938,9 +5949,10 @@ mod tests {
     #[test]
     fn safe_model_artifact_filename_requires_basename_gguf() {
         assert_eq!(
-            safe_model_artifact_filename("token-place-0.1.4.gguf"),
-            Some("token-place-0.1.4.gguf")
+            safe_model_artifact_filename(EXPECTED_MODEL_ARTIFACT_FILENAME),
+            Some(EXPECTED_MODEL_ARTIFACT_FILENAME)
         );
+        assert_eq!(safe_model_artifact_filename("token-place-0.1.4.gguf"), None);
         assert_eq!(safe_model_artifact_filename("token-place.bin"), None);
         assert_eq!(
             safe_model_artifact_filename("models/token-place.gguf"),
@@ -5951,6 +5963,34 @@ mod tests {
             None
         );
         assert_eq!(safe_model_artifact_filename(""), None);
+    }
+
+    #[test]
+    fn inspect_model_artifact_filename_requires_ok_and_safe_expected_basename() {
+        let accepted = serde_json::json!({
+            "ok": true,
+            "payload": {"filename": EXPECTED_MODEL_ARTIFACT_FILENAME}
+        });
+        assert_eq!(
+            inspect_model_artifact_filename(&accepted).expect("accepted inspect"),
+            EXPECTED_MODEL_ARTIFACT_FILENAME
+        );
+
+        for rejected in [
+            serde_json::json!({"ok": false, "payload": {"filename": EXPECTED_MODEL_ARTIFACT_FILENAME}}),
+            serde_json::json!({"ok": true, "payload": {"filename": "qwen3.bin"}}),
+            serde_json::json!({"ok": true, "payload": {"filename": "models/qwen3.gguf"}}),
+            serde_json::json!({"ok": true, "payload": {"filename": "models\\qwen3.gguf"}}),
+            serde_json::json!({"ok": true, "payload": {"filename": "/home/operator/qwen3.gguf"}}),
+            serde_json::json!({"ok": true, "payload": {"filename": "C:\\Users\\operator\\qwen3.gguf"}}),
+            serde_json::json!({"ok": true, "payload": {"filename": "other.gguf"}}),
+            serde_json::json!({"ok": true, "payload": {"filename": ""}}),
+        ] {
+            assert!(
+                inspect_model_artifact_filename(&rejected).is_err(),
+                "rejected inspect payload should fail: {rejected}"
+            );
+        }
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -9,8 +9,8 @@ use crate::python_runtime::{
     bridge_script_candidates_from_resource_roots, configure_python_subprocess_env_for_layout,
     describe_resource_layout, disable_python_user_site, resolve_bridge_script_path,
     resolve_python_launcher_resource_aware, resolve_runtime_import_root,
-    should_enable_runtime_bootstrap, PythonLauncher, PythonLauncherResolutionOptions,
-    PythonLauncherSource, ENABLE_RUNTIME_BOOTSTRAP_ENV,
+    should_enable_runtime_bootstrap, PythonEnvCommand, PythonLauncher,
+    PythonLauncherResolutionOptions, PythonLauncherSource, ENABLE_RUNTIME_BOOTSTRAP_ENV,
 };
 use crate::subprocess_logging::{SubprocessLogFilter, SubprocessLogPolicy};
 use serde::{Deserialize, Serialize};
@@ -490,11 +490,28 @@ fn first_existing_script(candidates: Vec<std::path::PathBuf>) -> Option<String> 
         .map(|candidate| candidate.to_string_lossy().into_owned())
 }
 
-fn configure_runtime_pythonpath(
-    command: &mut Command,
+fn script_path_arg(path: &Path, label: &str) -> anyhow::Result<String> {
+    path.to_str()
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("{label}: resolved script path is not valid UTF-8"))
+}
+
+fn safe_model_artifact_filename(filename: &str) -> Option<&str> {
+    (!filename.is_empty()
+        && filename.ends_with(".gguf")
+        && !filename.contains('/')
+        && !filename.contains('\\'))
+    .then_some(filename)
+}
+
+fn configure_runtime_pythonpath<C>(
+    command: &mut C,
     manifest_dir: &Path,
     bridge_script: &str,
-) -> Option<std::path::PathBuf> {
+) -> Option<std::path::PathBuf>
+where
+    C: PythonEnvCommand,
+{
     disable_python_user_site(command);
     let import_root = resolve_runtime_import_root(Some(Path::new(bridge_script)), manifest_dir);
     if let Some(import_root) = import_root.as_deref() {
@@ -1567,8 +1584,14 @@ pub(crate) fn operator_session_smoke_record(config: &DesktopConfig) -> anyhow::R
         Some(&launcher.program),
     )
     .map_err(anyhow::Error::msg)?;
-    let mut model_inspect_command =
-        launcher.command_for_script_blocking(model_bridge_script.to_str().unwrap_or_default());
+    let model_bridge_script_arg =
+        script_path_arg(&model_bridge_script, "model_artifact_inspect_failed")?;
+    let mut model_inspect_command = launcher.command_for_script_blocking(&model_bridge_script_arg);
+    configure_runtime_pythonpath(
+        &mut model_inspect_command,
+        manifest_dir,
+        &model_bridge_script_arg,
+    );
     model_inspect_command.arg("inspect");
     let model_inspect_output = model_inspect_command.output()?;
     if !model_inspect_output.status.success() {
@@ -1580,10 +1603,10 @@ pub(crate) fn operator_session_smoke_record(config: &DesktopConfig) -> anyhow::R
         .get("payload")
         .and_then(|payload| payload.get("filename"))
         .and_then(Value::as_str)
-        .filter(|filename| !filename.contains('/') && !filename.contains('\\'))
+        .and_then(safe_model_artifact_filename)
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "model_artifact_inspect_failed: inspect did not report a safe model filename"
+                "model_artifact_inspect_failed: inspect did not report a basename-only .gguf model filename"
             )
         })?
         .to_string();
@@ -5910,6 +5933,24 @@ mod tests {
         let resolved = first_existing_script(candidates).expect("resolved bridge path");
 
         assert_eq!(Path::new(&resolved), resources_bridge);
+    }
+
+    #[test]
+    fn safe_model_artifact_filename_requires_basename_gguf() {
+        assert_eq!(
+            safe_model_artifact_filename("token-place-0.1.4.gguf"),
+            Some("token-place-0.1.4.gguf")
+        );
+        assert_eq!(safe_model_artifact_filename("token-place.bin"), None);
+        assert_eq!(
+            safe_model_artifact_filename("models/token-place.gguf"),
+            None
+        );
+        assert_eq!(
+            safe_model_artifact_filename("models\\token-place.gguf"),
+            None
+        );
+        assert_eq!(safe_model_artifact_filename(""), None);
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1559,6 +1559,34 @@ pub(crate) fn operator_session_smoke_record(config: &DesktopConfig) -> anyhow::R
         Some(&launcher.program),
     )
     .map_err(anyhow::Error::msg)?;
+    let model_bridge_script = resolve_bridge_script_path(
+        "model_bridge.py",
+        current_exe.as_deref(),
+        manifest_dir,
+        None,
+        Some(&launcher.program),
+    )
+    .map_err(anyhow::Error::msg)?;
+    let mut model_inspect_command =
+        launcher.command_for_script_blocking(model_bridge_script.to_str().unwrap_or_default());
+    model_inspect_command.arg("inspect");
+    let model_inspect_output = model_inspect_command.output()?;
+    if !model_inspect_output.status.success() {
+        anyhow::bail!("model_artifact_inspect_failed: bundled interpreter could not inspect packaged model artifact");
+    }
+    let model_inspect_stdout = String::from_utf8_lossy(&model_inspect_output.stdout);
+    let model_inspect_json: Value = serde_json::from_str(model_inspect_stdout.trim())?;
+    let model_artifact_filename = model_inspect_json
+        .get("payload")
+        .and_then(|payload| payload.get("filename"))
+        .and_then(Value::as_str)
+        .filter(|filename| !filename.contains('/') && !filename.contains('\\'))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "model_artifact_inspect_failed: inspect did not report a safe model filename"
+            )
+        })?
+        .to_string();
     let mut bridge_command = build_bridge_command(&bridge_script, Some(launcher.clone()))?;
     let import_root =
         configure_runtime_pythonpath(&mut bridge_command, manifest_dir, &bridge_script);
@@ -1603,6 +1631,8 @@ pub(crate) fn operator_session_smoke_record(config: &DesktopConfig) -> anyhow::R
         "context_tier": config.context_tier.as_str(),
         "preferred_mode": format!("{:?}", config.preferred_mode).to_lowercase(),
         "bridge_preflight": "ok",
+        "model_artifact_inspect": "ok",
+        "model_artifact_filename": model_artifact_filename,
     });
     if let (Value::Object(payload_map), Value::Object(probe_map)) = (&mut payload, context_probe) {
         for (key, value) in probe_map {
@@ -3083,7 +3113,7 @@ mod tests {
     ) {
         let summary = summarize_bridge_stdout_payload(&serde_json::json!({
             "type": "status",
-            "app_version": "0.1.3",
+            "app_version": "0.1.4",
             "build_id": "abcdef012345",
             "target_triple": "x86_64-pc-windows-msvc",
             "bundled_runtime_id": "bundled-cpython-3.11-win-x86_64-cu124",
@@ -3113,7 +3143,7 @@ mod tests {
         assert!(summary.len() <= 3500);
         assert_eq!(
             payload.get("app_version").and_then(Value::as_str),
-            Some("0.1.3")
+            Some("0.1.4")
         );
         assert_eq!(
             payload.get("build_id").and_then(Value::as_str),

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -89,20 +89,21 @@ fn resolve_model_bridge_script_path(interpreter: Option<&str>) -> Result<PathBuf
 fn configure_runtime_pythonpath_for(
     command: &mut std::process::Command,
     bridge_script: &Path,
+    exe_path: Option<&Path>,
     manifest_dir: &Path,
+    resource_dir: Option<&Path>,
 ) -> Option<PathBuf> {
     python_runtime::disable_python_user_site(command);
     let import_root =
         python_runtime::resolve_runtime_import_root(Some(bridge_script), manifest_dir);
     if let Some(import_root) = import_root.as_deref() {
-        let current_exe = std::env::current_exe().ok();
         let (_resource_root, layout) = python_runtime::describe_resource_layout(
             bridge_script,
-            current_exe.as_deref(),
+            exe_path,
             manifest_dir,
-            None,
+            resource_dir,
         );
-        let packaged = python_runtime::is_packaged_execution(current_exe.as_deref(), manifest_dir);
+        let packaged = python_runtime::is_packaged_execution(exe_path, manifest_dir);
         python_runtime::configure_python_subprocess_env_for_layout(
             command,
             import_root,
@@ -122,7 +123,9 @@ fn configure_runtime_pythonpath(
     configure_runtime_pythonpath_for(
         command,
         bridge_script,
+        std::env::current_exe().ok().as_deref(),
         Path::new(env!("CARGO_MANIFEST_DIR")),
+        None,
     )
 }
 
@@ -203,9 +206,14 @@ fn run_model_bridge(app: &tauri::AppHandle, action: &str) -> Result<ModelArtifac
         resource_dir.as_deref(),
         Some(&launcher.program),
     )?;
-    let mut bridge_command =
-        launcher.command_for_script_blocking(bridge_script.to_str().unwrap_or_default());
-    let import_root = configure_runtime_pythonpath(&mut bridge_command, &bridge_script);
+    let mut bridge_command = launcher.command_for_script_blocking(&bridge_script);
+    let import_root = configure_runtime_pythonpath_for(
+        &mut bridge_command,
+        &bridge_script,
+        exe_path.as_deref(),
+        manifest_dir,
+        resource_dir.as_deref(),
+    );
     let (selected_resource_root, selected_layout) = python_runtime::describe_resource_layout(
         &bridge_script,
         exe_path.as_deref(),
@@ -991,7 +999,8 @@ mod tests {
         let manifest_dir = temp.path().join("missing-manifest");
         let mut command = std::process::Command::new("python");
 
-        let import_root = configure_runtime_pythonpath_for(&mut command, &bridge, &manifest_dir);
+        let import_root =
+            configure_runtime_pythonpath_for(&mut command, &bridge, None, &manifest_dir, None);
 
         assert!(import_root.is_none());
         assert_eq!(

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -48,25 +48,30 @@ struct BridgeResponse {
     error: Option<String>,
 }
 
-fn model_bridge_script_candidates(exe_path: Option<&Path>, manifest_dir: &Path) -> Vec<PathBuf> {
+fn model_bridge_script_candidates(
+    exe_path: Option<&Path>,
+    manifest_dir: &Path,
+    resource_dir: Option<&Path>,
+) -> Vec<PathBuf> {
     python_runtime::bridge_script_candidates_from_resource_roots(
         "model_bridge.py",
         exe_path,
         manifest_dir,
-        None,
+        resource_dir,
     )
 }
 
 fn resolve_model_bridge_script_path_for(
     exe_path: Option<&Path>,
     manifest_dir: &Path,
+    resource_dir: Option<&Path>,
     interpreter: Option<&str>,
 ) -> Result<PathBuf, String> {
     python_runtime::resolve_bridge_script_path(
         "model_bridge.py",
         exe_path,
         manifest_dir,
-        None,
+        resource_dir,
         interpreter,
     )
 }
@@ -76,6 +81,7 @@ fn resolve_model_bridge_script_path(interpreter: Option<&str>) -> Result<PathBuf
     resolve_model_bridge_script_path_for(
         current_exe.as_deref(),
         Path::new(env!("CARGO_MANIFEST_DIR")),
+        None,
         interpreter,
     )
 }
@@ -180,17 +186,23 @@ fn sanitize_model_bridge_payload_field(key: &str, value: &Value) -> Value {
 fn run_model_bridge(app: &tauri::AppHandle, action: &str) -> Result<ModelArtifactInfo, String> {
     let exe_path = std::env::current_exe().ok();
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let resource_dir = app.path().resource_dir().ok();
     let launcher = python_runtime::resolve_python_launcher_resource_aware(
         python_runtime::PythonLauncherResolutionOptions {
             override_var_name: "TOKEN_PLACE_PYTHON",
-            tauri_resource_dir: app.path().resource_dir().ok().as_deref(),
+            tauri_resource_dir: resource_dir.as_deref(),
             current_exe_path: exe_path.as_deref(),
             manifest_dir,
             packaged: python_runtime::is_packaged_execution(exe_path.as_deref(), manifest_dir),
         },
     )
     .map_err(|e| format!("unable to resolve Python launcher for model bridge: {e}"))?;
-    let bridge_script = resolve_model_bridge_script_path(Some(&launcher.program))?;
+    let bridge_script = resolve_model_bridge_script_path_for(
+        exe_path.as_deref(),
+        manifest_dir,
+        resource_dir.as_deref(),
+        Some(&launcher.program),
+    )?;
     let mut bridge_command =
         launcher.command_for_script_blocking(bridge_script.to_str().unwrap_or_default());
     let import_root = configure_runtime_pythonpath(&mut bridge_command, &bridge_script);
@@ -198,7 +210,7 @@ fn run_model_bridge(app: &tauri::AppHandle, action: &str) -> Result<ModelArtifac
         &bridge_script,
         exe_path.as_deref(),
         manifest_dir,
-        None,
+        resource_dir.as_deref(),
     );
     let start_line = format!(
         "action={} bridge={} interpreter={} resource_root={} layout={:?} import_root={}",
@@ -736,7 +748,7 @@ mod tests {
             operator_session_id: Some("current-live".into()),
             context_tier: Some("64k-full".into()),
             log_file_path: Some(path.to_string_lossy().into_owned()),
-            app_version: "0.1.3".into(),
+            app_version: "0.1.4".into(),
             build_id: "current-build".into(),
             ..Default::default()
         }
@@ -779,7 +791,7 @@ mod tests {
             &current,
             "sixty-four-k-session",
             "64k-full",
-            "0.1.3",
+            "0.1.4",
             "new-build",
             "current ready\n",
         );
@@ -793,7 +805,7 @@ mod tests {
         assert!(output.contains(
             "session_id=eight-k-session context_tier=8k-fast app_version=0.1.2 build_id=old-build"
         ));
-        assert!(output.contains("session_id=sixty-four-k-session context_tier=64k-full app_version=0.1.3 build_id=new-build"));
+        assert!(output.contains("session_id=sixty-four-k-session context_tier=64k-full app_version=0.1.4 build_id=new-build"));
         assert!(output.contains("current ready"));
         assert!(output.len() <= 256 * 1024);
         assert!(!output.contains("current-live context_tier=8k-fast"));
@@ -810,7 +822,7 @@ mod tests {
                 &path,
                 &format!("s{index}"),
                 "8k-fast",
-                "0.1.3",
+                "0.1.4",
                 "b",
                 "body\n",
             );
@@ -820,7 +832,7 @@ mod tests {
             &current,
             "current-session",
             "64k-full",
-            "0.1.3",
+            "0.1.4",
             "current-build",
             "body\n",
         );
@@ -845,7 +857,7 @@ mod tests {
             &current,
             "current-session",
             "64k-full",
-            "0.1.3",
+            "0.1.4",
             "current-build",
             "ok\n",
         );
@@ -882,7 +894,7 @@ mod tests {
                 &path,
                 &format!("historical-{index}"),
                 "8k-fast",
-                "0.1.3",
+                "0.1.4",
                 "old-build",
                 &multibyte,
             );
@@ -892,7 +904,7 @@ mod tests {
             &current,
             "current-session",
             "64k-full",
-            "0.1.3",
+            "0.1.4",
             "current-build",
             &multibyte,
         );
@@ -1003,16 +1015,17 @@ mod tests {
         let error = resolve_model_bridge_script_path_for(
             Some(&exe_path),
             &manifest_dir,
+            None,
             Some("/usr/bin/python3"),
         )
         .expect_err("missing model bridge should fail closed");
 
         assert!(error.contains("model_bridge.py"));
         assert!(error.contains("attempted_resource_roots="));
-        assert!(error.contains("attempted_bridge_paths="));
+        assert!(error.contains("attempted_bridge_basenames="));
         assert!(error.contains("MacOsAppResources"));
-        assert!(error.contains("Contents/Resources/python/model_bridge.py"));
-        assert!(error.contains("interpreter=/usr/bin/python3"));
+        assert!(error.contains("model_bridge.py"));
+        assert!(error.contains("interpreter_basename=python3"));
     }
 
     #[test]
@@ -1026,7 +1039,7 @@ mod tests {
             .join("repo")
             .join("desktop-tauri")
             .join("src-tauri");
-        let candidates = model_bridge_script_candidates(Some(&exe_path), &manifest_dir);
+        let candidates = model_bridge_script_candidates(Some(&exe_path), &manifest_dir, None);
 
         assert!(candidates
             .iter()
@@ -1051,7 +1064,7 @@ mod tests {
         std::fs::write(&bridge, "print('ok')\n").expect("write model bridge");
 
         let exe_path = exe_dir.join("token.place");
-        let candidates = model_bridge_script_candidates(Some(&exe_path), temp.path());
+        let candidates = model_bridge_script_candidates(Some(&exe_path), temp.path(), None);
         let resolved = candidates
             .into_iter()
             .find(|candidate| candidate.is_file())
@@ -1070,7 +1083,7 @@ mod tests {
         std::fs::write(&bridge, "print('ok')\n").expect("write model bridge");
 
         let exe_path = exe_dir.join("token.place.exe");
-        let candidates = model_bridge_script_candidates(Some(&exe_path), temp.path());
+        let candidates = model_bridge_script_candidates(Some(&exe_path), temp.path(), None);
         let resolved = candidates
             .into_iter()
             .find(|candidate| candidate.is_file())
@@ -1094,7 +1107,7 @@ mod tests {
         std::fs::write(&resources_bridge, "print('resources')\n").expect("write resources bridge");
 
         let exe_path = exe_dir.join("token.place");
-        let candidates = model_bridge_script_candidates(Some(&exe_path), temp.path());
+        let candidates = model_bridge_script_candidates(Some(&exe_path), temp.path(), None);
         let resolved = candidates
             .into_iter()
             .find(|candidate| candidate.is_file())
@@ -1110,8 +1123,7 @@ mod tests {
         let resources = config
             .get("bundle")
             .and_then(|bundle| bundle.get("resources"))
-            .and_then(serde_json::Value::as_array)
-            .expect("bundle.resources array");
+            .expect("bundle.resources");
 
         let required = [
             "python/compute_node_bridge.py",
@@ -1129,23 +1141,34 @@ mod tests {
 
         // Intentional strict count: this guards against accidental bundle bloat.
         assert_eq!(
-            resources.len(),
-            required.len(),
-            "bundle.resources should only include required Python bridge/runtime resources"
+            resources.as_object().map(serde_json::Map::len).or_else(|| resources.as_array().map(Vec::len)),
+            Some(required.len() + 2),
+            "bundle.resources should only include required Python bridge/runtime resources plus runtime metadata"
         );
 
+        let contains_relay = resources
+            .as_array()
+            .map(|array| {
+                array
+                    .iter()
+                    .any(|entry| entry.as_str().unwrap_or_default().contains("relay.py"))
+            })
+            .unwrap_or_else(|| {
+                resources
+                    .as_object()
+                    .is_some_and(|object| object.keys().any(|entry| entry.contains("relay.py")))
+            });
         assert!(
-            resources
-                .iter()
-                .all(|entry| !entry.as_str().unwrap_or_default().contains("relay.py")),
+            !contains_relay,
             "bundle.resources must never include relay.py"
         );
 
         for script in required {
-            assert!(
-                resources.iter().any(|entry| entry.as_str() == Some(script)),
-                "missing bundled python resource: {script}"
-            );
+            let present = resources
+                .as_array()
+                .map(|array| array.iter().any(|entry| entry.as_str() == Some(script)))
+                .unwrap_or_else(|| resources.get(script).is_some());
+            assert!(present, "missing bundled python resource: {script}");
         }
     }
 }

--- a/desktop-tauri/src-tauri/src/main.rs
+++ b/desktop-tauri/src-tauri/src/main.rs
@@ -67,13 +67,12 @@ fn resolve_model_bridge_script_path_for(
     resource_dir: Option<&Path>,
     interpreter: Option<&str>,
 ) -> Result<PathBuf, String> {
-    python_runtime::resolve_bridge_script_path(
-        "model_bridge.py",
+    let context = python_runtime::BridgeResourceContext {
         exe_path,
         manifest_dir,
-        resource_dir,
-        interpreter,
-    )
+        tauri_resource_dir: resource_dir,
+    };
+    context.resolve_bridge_script_path("model_bridge.py", interpreter)
 }
 
 fn resolve_model_bridge_script_path(interpreter: Option<&str>) -> Result<PathBuf, String> {
@@ -93,22 +92,21 @@ fn configure_runtime_pythonpath_for(
     manifest_dir: &Path,
     resource_dir: Option<&Path>,
 ) -> Option<PathBuf> {
+    let context = python_runtime::BridgeResourceContext {
+        exe_path,
+        manifest_dir,
+        tauri_resource_dir: resource_dir,
+    };
     python_runtime::disable_python_user_site(command);
     let import_root =
-        python_runtime::resolve_runtime_import_root(Some(bridge_script), manifest_dir);
+        python_runtime::resolve_runtime_import_root(Some(bridge_script), context.manifest_dir);
     if let Some(import_root) = import_root.as_deref() {
-        let (_resource_root, layout) = python_runtime::describe_resource_layout(
-            bridge_script,
-            exe_path,
-            manifest_dir,
-            resource_dir,
-        );
-        let packaged = python_runtime::is_packaged_execution(exe_path, manifest_dir);
+        let (_resource_root, layout) = context.describe_resource_layout(bridge_script);
         python_runtime::configure_python_subprocess_env_for_layout(
             command,
             import_root,
             layout,
-            packaged,
+            context.packaged(),
         );
     }
     import_root
@@ -190,14 +188,13 @@ fn run_model_bridge(app: &tauri::AppHandle, action: &str) -> Result<ModelArtifac
     let exe_path = std::env::current_exe().ok();
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let resource_dir = app.path().resource_dir().ok();
+    let context = python_runtime::BridgeResourceContext {
+        exe_path: exe_path.as_deref(),
+        manifest_dir,
+        tauri_resource_dir: resource_dir.as_deref(),
+    };
     let launcher = python_runtime::resolve_python_launcher_resource_aware(
-        python_runtime::PythonLauncherResolutionOptions {
-            override_var_name: "TOKEN_PLACE_PYTHON",
-            tauri_resource_dir: resource_dir.as_deref(),
-            current_exe_path: exe_path.as_deref(),
-            manifest_dir,
-            packaged: python_runtime::is_packaged_execution(exe_path.as_deref(), manifest_dir),
-        },
+        context.launcher_options("TOKEN_PLACE_PYTHON"),
     )
     .map_err(|e| format!("unable to resolve Python launcher for model bridge: {e}"))?;
     let bridge_script = resolve_model_bridge_script_path_for(
@@ -214,12 +211,8 @@ fn run_model_bridge(app: &tauri::AppHandle, action: &str) -> Result<ModelArtifac
         manifest_dir,
         resource_dir.as_deref(),
     );
-    let (selected_resource_root, selected_layout) = python_runtime::describe_resource_layout(
-        &bridge_script,
-        exe_path.as_deref(),
-        manifest_dir,
-        resource_dir.as_deref(),
-    );
+    let (selected_resource_root, selected_layout) =
+        context.describe_resource_layout(&bridge_script);
     let start_line = format!(
         "action={} bridge={} interpreter={} resource_root={} layout={:?} import_root={}",
         action,

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -1283,6 +1283,18 @@ mod tests {
     use std::process::ExitStatus;
     use tempfile::TempDir;
 
+    fn command_env_value(command: &Command, key: &str) -> Option<String> {
+        command.get_envs().find_map(|(name, value)| {
+            (name == key).then(|| value.map(|v| v.to_string_lossy().into_owned()))?
+        })
+    }
+
+    fn command_env_removed(command: &Command, key: &str) -> bool {
+        command
+            .get_envs()
+            .any(|(name, value)| name == key && value.is_none())
+    }
+
     fn fake_output(success: bool, stdout: &str, stderr: &str) -> std::process::Output {
         std::process::Output {
             status: if success {
@@ -2019,11 +2031,18 @@ mod tests {
             .expect("compute script");
         let (model_root, model_layout) = context.describe_resource_layout(&resolved_model);
         let (compute_root, compute_layout) = context.describe_resource_layout(&resolved_compute);
-        let mut command = launcher.command_for_script_blocking(&resolved_model);
+        let mut model_command = launcher.command_for_script_blocking(&resolved_model);
         configure_python_subprocess_env_for_layout(
-            &mut command,
+            &mut model_command,
             &resource_root,
-            model_layout,
+            model_layout.clone(),
+            context.packaged(),
+        );
+        let mut compute_command = launcher.command_for_script_blocking(&resolved_compute);
+        configure_python_subprocess_env_for_layout(
+            &mut compute_command,
+            &resource_root,
+            compute_layout.clone(),
             context.packaged(),
         );
 
@@ -2034,23 +2053,35 @@ mod tests {
         assert_eq!(model_root, resource_root);
         assert_eq!(compute_root, model_root);
         assert_eq!(compute_layout, model_layout);
-        let args = command
+        let model_args = model_command
             .get_args()
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect::<Vec<_>>();
         assert_eq!(
-            args.first().map(String::as_str),
+            model_args.first().map(String::as_str),
             Some(model_script.to_str().unwrap())
         );
+        let compute_args = compute_command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
         assert_eq!(
-            std_command_env_value(&command, "PYTHONNOUSERSITE").as_deref(),
-            Some("1")
+            compute_args.first().map(String::as_str),
+            Some(compute_script.to_str().unwrap())
         );
-        assert_eq!(
-            std_command_env_value(&command, "TOKEN_PLACE_PYTHON_IMPORT_ROOT").as_deref(),
-            Some(resource_root.to_str().unwrap())
-        );
-        assert!(std_command_env_value(&command, "PYTHONPATH").is_some());
+        for command in [&model_command, &compute_command] {
+            assert_eq!(
+                command_env_value(command, "PYTHONNOUSERSITE").as_deref(),
+                Some("1")
+            );
+            assert_eq!(
+                command_env_value(command, "TOKEN_PLACE_PYTHON_IMPORT_ROOT").as_deref(),
+                Some(resource_root.to_str().unwrap())
+            );
+            assert!(command_env_value(command, "PYTHONPATH").is_some());
+            assert!(command_env_removed(command, "PYTHONHOME"));
+            assert!(command_env_removed(command, "PYTHONUSERBASE"));
+        }
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -567,14 +567,11 @@ fn canonical_resource_root(root: &Path) -> PathBuf {
 }
 
 fn bundled_runtime_candidate(opts: &PythonLauncherResolutionOptions<'_>) -> Option<PythonLauncher> {
-    let root_candidates = if let Some(resource_dir) = opts.tauri_resource_dir {
-        vec![ResourceRootCandidate {
-            root: resource_dir.to_path_buf(),
-            layout: ResourceLayoutKind::TauriResourceDir,
-        }]
-    } else {
-        resource_root_candidates(opts.current_exe_path, opts.manifest_dir, None)
-    };
+    let root_candidates = resource_root_candidates(
+        opts.current_exe_path,
+        opts.manifest_dir,
+        opts.tauri_resource_dir,
+    );
 
     let mut valid_roots: Vec<PathBuf> = Vec::new();
     let mut seen = std::collections::BTreeSet::new();
@@ -582,11 +579,8 @@ fn bundled_runtime_candidate(opts: &PythonLauncherResolutionOptions<'_>) -> Opti
         if !bundled_runtime_layout_is_eligible(&candidate.layout, opts.packaged) {
             continue;
         }
-        if !candidate
-            .root
-            .join(BUNDLED_RUNTIME_RELATIVE_PYTHON)
-            .is_file()
-        {
+        let runtime = candidate.root.join(BUNDLED_RUNTIME_RELATIVE_PYTHON);
+        if !runtime.is_file() {
             continue;
         }
         let canonical = canonical_resource_root(&candidate.root);
@@ -644,7 +638,7 @@ pub fn resolve_python_launcher_resource_aware(
             .current_exe_path
             .map(|p| p.components().any(|c| c.as_os_str() == "Contents"))
             .unwrap_or(false);
-    if is_bundled_required_platform || is_macos {
+    if opts.packaged || is_bundled_required_platform || is_macos {
         if let Some(candidate) = bundled_runtime_candidate(&opts) {
             if !Path::new(&candidate.program).exists() {
                 if opts.packaged {
@@ -1584,6 +1578,100 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "windows")]
+    fn bundled_runtime_candidate_uses_exe_relative_runtime_when_tauri_hint_is_stale() {
+        let temp = TempDir::new().expect("tempdir");
+        let exe = temp
+            .path()
+            .join("app")
+            .join("token-place-desktop-tauri.exe");
+        std::fs::create_dir_all(exe.parent().expect("exe parent")).expect("create exe dir");
+        std::fs::write(&exe, b"exe").expect("write exe");
+        let stale_resource_dir = temp.path().join("stale-resources");
+        std::fs::create_dir_all(&stale_resource_dir).expect("create stale resource dir");
+        let expected_runtime = write_bundled_runtime(exe.parent().expect("exe parent"));
+        let manifest_dir = temp
+            .path()
+            .join("repo")
+            .join("desktop-tauri")
+            .join("src-tauri");
+        let opts = PythonLauncherResolutionOptions {
+            override_var_name: "TOKEN_PLACE_TEST_PYTHON_NOT_SET",
+            tauri_resource_dir: Some(&stale_resource_dir),
+            current_exe_path: Some(&exe),
+            manifest_dir: &manifest_dir,
+            packaged: true,
+        };
+
+        let launcher = bundled_runtime_candidate(&opts).expect("runtime candidate");
+
+        assert_eq!(Path::new(&launcher.program), expected_runtime.as_path());
+    }
+
+    #[test]
+    fn bundled_runtime_candidate_deduplicates_equivalent_canonical_roots() {
+        let temp = TempDir::new().expect("tempdir");
+        let app_dir = temp.path().join("app");
+        let exe = app_dir.join("token-place-desktop-tauri.exe");
+        std::fs::create_dir_all(&app_dir).expect("create app dir");
+        std::fs::write(&exe, b"exe").expect("write exe");
+        let expected_runtime = write_bundled_runtime(&app_dir);
+        let alias = app_dir.join(".");
+        let manifest_dir = temp
+            .path()
+            .join("repo")
+            .join("desktop-tauri")
+            .join("src-tauri");
+        let opts = PythonLauncherResolutionOptions {
+            override_var_name: "TOKEN_PLACE_TEST_PYTHON_NOT_SET",
+            tauri_resource_dir: Some(&alias),
+            current_exe_path: Some(&exe),
+            manifest_dir: &manifest_dir,
+            packaged: true,
+        };
+
+        let launcher = bundled_runtime_candidate(&opts).expect("deduplicated runtime candidate");
+
+        assert_eq!(Path::new(&launcher.program), expected_runtime.as_path());
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn bundled_runtime_candidate_selects_windows_python_exe_layout() {
+        let temp = TempDir::new().expect("tempdir");
+        let exe = temp
+            .path()
+            .join("app")
+            .join("token-place-desktop-tauri.exe");
+        std::fs::create_dir_all(exe.parent().expect("exe parent")).expect("create exe dir");
+        std::fs::write(&exe, b"exe").expect("write exe");
+        let expected_runtime = exe
+            .parent()
+            .expect("exe parent")
+            .join("python-runtime")
+            .join("python.exe");
+        std::fs::create_dir_all(expected_runtime.parent().expect("runtime parent"))
+            .expect("create runtime dir");
+        std::fs::write(&expected_runtime, b"python").expect("write runtime");
+        let manifest_dir = temp
+            .path()
+            .join("repo")
+            .join("desktop-tauri")
+            .join("src-tauri");
+        let opts = PythonLauncherResolutionOptions {
+            override_var_name: "TOKEN_PLACE_TEST_PYTHON_NOT_SET",
+            tauri_resource_dir: None,
+            current_exe_path: Some(&exe),
+            manifest_dir: &manifest_dir,
+            packaged: true,
+        };
+
+        let launcher = bundled_runtime_candidate(&opts).expect("windows runtime candidate");
+
+        assert_eq!(Path::new(&launcher.program), expected_runtime.as_path());
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
     fn bundled_runtime_candidate_is_fail_closed_for_distinct_installed_roots() {
         let temp = TempDir::new().expect("tempdir");
         let exe = temp
@@ -2030,7 +2118,8 @@ mod tests {
         std::fs::create_dir_all(py.parent().unwrap()).unwrap();
         let runtime_root = resources.join("python-runtime");
         let probe = format!(
-            r#"{{"version":[3,11,13],"machine":"arm64","executable":"{}","prefix":"{}"}}"#,
+            r#"{{"version":[3,11,13],"machine":"{}","executable":"{}","prefix":"{}"}}"#,
+            expected_runtime_arch(),
             py.display(),
             runtime_root.display()
         );

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -557,6 +557,55 @@ pub fn is_unbundled_development_execution(
         == PythonExecutionLayout::UnbundledDevelopment
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct BridgeResourceContext<'a> {
+    pub exe_path: Option<&'a Path>,
+    pub manifest_dir: &'a Path,
+    pub tauri_resource_dir: Option<&'a Path>,
+}
+
+impl<'a> BridgeResourceContext<'a> {
+    pub fn packaged(&self) -> bool {
+        is_packaged_execution(self.exe_path, self.manifest_dir)
+    }
+
+    pub fn launcher_options(
+        &self,
+        override_var_name: &'a str,
+    ) -> PythonLauncherResolutionOptions<'a> {
+        PythonLauncherResolutionOptions {
+            override_var_name,
+            tauri_resource_dir: self.tauri_resource_dir,
+            current_exe_path: self.exe_path,
+            manifest_dir: self.manifest_dir,
+            packaged: self.packaged(),
+        }
+    }
+
+    pub fn resolve_bridge_script_path(
+        &self,
+        script_name: &str,
+        interpreter: Option<&str>,
+    ) -> Result<PathBuf, String> {
+        resolve_bridge_script_path(
+            script_name,
+            self.exe_path,
+            self.manifest_dir,
+            self.tauri_resource_dir,
+            interpreter,
+        )
+    }
+
+    pub fn describe_resource_layout(&self, script_path: &Path) -> (PathBuf, ResourceLayoutKind) {
+        describe_resource_layout(
+            script_path,
+            self.exe_path,
+            self.manifest_dir,
+            self.tauri_resource_dir,
+        )
+    }
+}
+
 pub fn is_packaged_execution(current_exe_path: Option<&Path>, manifest_dir: &Path) -> bool {
     !is_unbundled_development_execution(current_exe_path, manifest_dir)
 }
@@ -1914,6 +1963,94 @@ mod tests {
         assert!(compute_candidates.iter().any(|candidate| {
             candidate.ends_with("Contents/Resources/python/compute_node_bridge.py")
         }));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn explicit_bridge_resource_context_resolves_packaged_launcher_and_scripts() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().expect("tempdir");
+        let manifest_dir = temp
+            .path()
+            .join("repo")
+            .join("desktop-tauri")
+            .join("src-tauri");
+        std::fs::create_dir_all(&manifest_dir).expect("create manifest dir");
+        let exe_dir = temp.path().join("installed").join("bin");
+        let resource_root = exe_dir.join("resources");
+        let python_dir = resource_root.join("python");
+        let runtime_bin = resource_root.join("python-runtime").join("bin");
+        std::fs::create_dir_all(&python_dir).expect("create python dir");
+        std::fs::create_dir_all(&runtime_bin).expect("create runtime bin");
+        let model_script = python_dir.join("model_bridge.py");
+        let compute_script = python_dir.join("compute_node_bridge.py");
+        std::fs::write(&model_script, "# model bridge\n").expect("write model bridge");
+        std::fs::write(&compute_script, "# compute bridge\n").expect("write compute bridge");
+        let launcher_path = runtime_bin.join("python3");
+        let machine = expected_runtime_arch();
+        let launcher_body = format!(
+            "#!/bin/sh\nif [ \"$1\" = \"-c\" ]; then printf '{{\"version\":[3,11,13],\"machine\":\"{}\",\"executable\":\"{}\",\"prefix\":\"{}\"}}\\n'; exit 0; fi\nexit 0\n",
+            machine,
+            launcher_path.display(),
+            resource_root.join("python-runtime").display()
+        );
+        std::fs::write(&launcher_path, launcher_body).expect("write launcher");
+        let mut perms = std::fs::metadata(&launcher_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&launcher_path, perms).unwrap();
+        let exe_path = exe_dir.join("token.place");
+        std::fs::write(&exe_path, "").expect("write exe");
+
+        let context = BridgeResourceContext {
+            exe_path: Some(&exe_path),
+            manifest_dir: &manifest_dir,
+            tauri_resource_dir: Some(&resource_root),
+        };
+        let launcher = resolve_python_launcher_resource_aware(
+            context.launcher_options("TOKEN_PLACE_TEST_UNUSED_PYTHON"),
+        )
+        .expect("packaged launcher");
+        let resolved_model = context
+            .resolve_bridge_script_path("model_bridge.py", Some(&launcher.program))
+            .expect("model script");
+        let resolved_compute = context
+            .resolve_bridge_script_path("compute_node_bridge.py", Some(&launcher.program))
+            .expect("compute script");
+        let (model_root, model_layout) = context.describe_resource_layout(&resolved_model);
+        let (compute_root, compute_layout) = context.describe_resource_layout(&resolved_compute);
+        let mut command = launcher.command_for_script_blocking(&resolved_model);
+        configure_python_subprocess_env_for_layout(
+            &mut command,
+            &resource_root,
+            model_layout,
+            context.packaged(),
+        );
+
+        assert_eq!(launcher.source, PythonLauncherSource::BundledRuntime);
+        assert_eq!(Path::new(&launcher.program), launcher_path.as_path());
+        assert_eq!(resolved_model, model_script);
+        assert_eq!(resolved_compute, compute_script);
+        assert_eq!(model_root, resource_root);
+        assert_eq!(compute_root, model_root);
+        assert_eq!(compute_layout, model_layout);
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            args.first().map(String::as_str),
+            Some(model_script.to_str().unwrap())
+        );
+        assert_eq!(
+            std_command_env_value(&command, "PYTHONNOUSERSITE").as_deref(),
+            Some("1")
+        );
+        assert_eq!(
+            std_command_env_value(&command, "TOKEN_PLACE_PYTHON_IMPORT_ROOT").as_deref(),
+            Some(resource_root.to_str().unwrap())
+        );
+        assert!(std_command_env_value(&command, "PYTHONPATH").is_some());
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -65,14 +65,20 @@ impl PythonLauncher {
         cmd
     }
 
-    pub fn command_for_script(&self, script_path: &str) -> tokio::process::Command {
+    pub fn command_for_script<P>(&self, script_path: P) -> tokio::process::Command
+    where
+        P: AsRef<std::ffi::OsStr>,
+    {
         let mut cmd = tokio::process::Command::new(&self.program);
         cmd.args(&self.args);
         cmd.arg(script_path);
         cmd
     }
 
-    pub fn command_for_script_blocking(&self, script_path: &str) -> Command {
+    pub fn command_for_script_blocking<P>(&self, script_path: P) -> Command
+    where
+        P: AsRef<std::ffi::OsStr>,
+    {
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.args);
         cmd.arg(script_path);

--- a/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/desktop-tauri/src-tauri/src/sidecar.rs
@@ -11,7 +11,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::Mutex;
 
@@ -528,7 +528,8 @@ mod tests {
             .join("python")
             .join("inference_sidecar.py");
 
-        let mut child = Command::new("python3")
+        let mut command = Command::new("python3");
+        command
             .arg(sidecar_script)
             .arg("--model")
             .arg(model.path())
@@ -537,20 +538,63 @@ mod tests {
             .arg("--prompt")
             .arg("hello world")
             .env("USE_MOCK_LLM", "1")
+            .env_remove("PYTHONHOME")
+            .env_remove("PYTHONUSERBASE")
+            .env_remove("TOKEN_PLACE_DESKTOP_PYTHON")
+            .env_remove("TOKEN_PLACE_DESKTOP_DEPENDENCY_TARGET")
+            .env_remove("TOKEN_PLACE_DESKTOP_ENABLE_RUNTIME_BOOTSTRAP")
+            .env_remove("TOKEN_PLACE_DESKTOP_DEV_ALLOW_SOURCE_BUILD")
+            .env_remove("FORCE_CMAKE")
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
-            .spawn()
-            .expect("spawn bridge sidecar");
+            .stderr(Stdio::piped());
+
+        let mut child = command.spawn().expect("spawn bridge sidecar");
 
         let stdout = child.stdout.take().expect("stdout");
-        let events = collect_events_from_stdout(stdout)
+        let stderr = child.stderr.take().expect("stderr");
+        let events_result = collect_events_from_stdout(stdout);
+        let stderr_task = tokio::spawn(async move {
+            let mut stderr_text = String::new();
+            let mut reader = BufReader::new(stderr);
+            reader
+                .read_to_string(&mut stderr_text)
+                .await
+                .map(|_| stderr_text)
+        });
+
+        let events = match events_result.await {
+            Ok(events) => events,
+            Err(err) => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                panic!("collect events: {err}");
+            }
+        };
+        let status = child.wait().await.expect("wait bridge sidecar");
+        let stderr_text = stderr_task
             .await
-            .expect("collect events");
-        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Started)));
-        assert!(events
-            .iter()
-            .any(|e| matches!(e, SidecarEvent::Token { .. })));
-        assert!(events.iter().any(|e| matches!(e, SidecarEvent::Done)));
+            .expect("stderr task")
+            .expect("read stderr");
+
+        assert!(
+            events.iter().any(|e| matches!(e, SidecarEvent::Started)),
+            "missing Started event; stderr={stderr_text}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, SidecarEvent::Token { .. })),
+            "missing Token event; stderr={stderr_text}"
+        );
+        assert!(
+            events.iter().any(|e| matches!(e, SidecarEvent::Done)),
+            "missing Done event; stderr={stderr_text}"
+        );
+        assert!(
+            status.success(),
+            "bridge sidecar exited with {status}; stderr={stderr_text}"
+        );
     }
 
     #[tokio::test]

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "token.place desktop",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "place.token.desktop",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -257,6 +257,67 @@ describe('desktop app start failure handling', () => {
     );
   });
 
+
+  it.each(['desktop_python_runtime_missing', 'desktop_python_runtime_invalid'])(
+    'keeps Start operator enabled after mount-time %s model inspection failure',
+    async (code) => {
+      invokeMock.mockImplementation((command: string) => {
+        if (command === 'detect_backend') {
+          return Promise.resolve({
+            platform_label: 'windows-x64',
+            preferred_mode: 'gpu',
+            available_backend: 'cuda',
+            availability_label: 'CUDA-capable platform (Windows x64)',
+          });
+        }
+        if (command === 'load_config') {
+          return Promise.resolve({
+            model_path: 'C:\\Users\\operator\\Models\\qwen.gguf',
+            relay_base_url: 'https://token.place',
+            relay_base_urls: ['https://token.place'],
+            preferred_mode: 'gpu',
+          });
+        }
+        if (command === 'get_compute_node_status') {
+          return Promise.resolve({
+            running: false,
+            registered: false,
+            relay_runtime_state: 'idle',
+            runtime_provisioning_state: 'idle',
+            startup_phase: null,
+            active_relay_url: '',
+            requested_mode: 'gpu',
+            effective_mode: 'gpu',
+            backend_available: 'cuda',
+            backend_selected: 'cuda',
+            backend_used: 'cuda',
+            fallback_reason: null,
+            model_path: '',
+            last_error: null,
+          });
+        }
+        if (command === 'inspect_model_artifact') {
+          return Promise.reject(new Error(`${code}: bundled runtime could not launch from C:\\Users\\operator\\AppData`));
+        }
+        return Promise.resolve(undefined);
+      });
+
+      render(<App />);
+
+      await screen.findByText(/The bundled token\.place runtime is missing or damaged/);
+      expect(document.body.textContent ?? '').toContain(`Diagnostic code: ${code}`);
+      expect(document.body.textContent ?? '').not.toContain('AppData');
+      expect(((await screen.findByText('Start local inference')) as HTMLButtonElement).disabled).toBe(true);
+      expect(((await screen.findByText('Download')) as HTMLButtonElement).disabled).toBe(true);
+      const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+      await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+
+      fireEvent.click(startOperatorButton);
+
+      await waitFor(() => expect(invokeMock).toHaveBeenCalledWith('start_compute_node', expect.any(Object)));
+    }
+  );
+
   it('surfaces compute-node start failures in last error', async () => {
     invokeMock.mockImplementation((command: string) => {
       if (command === 'start_compute_node') {
@@ -2415,7 +2476,7 @@ describe('desktop Python runtime error normalization', () => {
     expect(body).not.toContain('TOKEN_PLACE_SIDECAR_PYTHON');
     expect(body).not.toContain('/Users/daniel');
     expect(((await screen.findByText('Start local inference')) as HTMLButtonElement).disabled).toBe(true);
-    expect(((await screen.findByText('Start operator')) as HTMLButtonElement).disabled).toBe(true);
+    expect(((await screen.findByText('Start operator')) as HTMLButtonElement).disabled).toBe(false);
     expect(((await screen.findByText('Download')) as HTMLButtonElement).disabled).toBe(true);
   });
 });

--- a/desktop-tauri/src/App.test.tsx
+++ b/desktop-tauri/src/App.test.tsx
@@ -441,6 +441,78 @@ describe('desktop app start failure handling', () => {
     resolveStart?.();
   });
 
+  it('disables Start operator when the operator is already running on load', async () => {
+    mockInitialComputeStatus({
+      running: true,
+      registered: true,
+      relay_runtime_state: 'ready',
+      warm_load_state: 'ready',
+      warm_load_enabled: true,
+      model_path: '/tmp/model.gguf',
+    });
+
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(true));
+
+    fireEvent.click(startOperatorButton);
+    expect(invokeMock.mock.calls.some(([command]) => command === 'start_compute_node')).toBe(false);
+  });
+
+  it('disables Start operator when the model path is empty', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '',
+          relay_base_url: 'https://token.place',
+          relay_base_urls: ['https://token.place'],
+          preferred_mode: 'auto',
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(true));
+
+    fireEvent.click(startOperatorButton);
+    expect(invokeMock.mock.calls.some(([command]) => command === 'start_compute_node')).toBe(false);
+  });
+
+  it('disables Start operator after clearing Relay URL 1 to whitespace', async () => {
+    render(<App />);
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    fireEvent.change(relayInput, { target: { value: '   ' } });
+
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(true));
+    fireEvent.click(startOperatorButton);
+    expect(invokeMock.mock.calls.some(([command]) => command === 'start_compute_node')).toBe(false);
+  });
+
+  it('still enables Start operator using the default relay when legacy config omits relay_base_urls', async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'load_config') {
+        return Promise.resolve({
+          model_path: '/tmp/model.gguf',
+          relay_base_url: '',
+          preferred_mode: 'auto',
+        });
+      }
+      return mockInitialCommand(command);
+    });
+
+    render(<App />);
+    const relayInput = (await screen.findByLabelText('Relay URL 1')) as HTMLInputElement;
+    await waitFor(() => expect(relayInput.value).toBe('https://token.place'));
+
+    const startOperatorButton = (await screen.findByText('Start operator')) as HTMLButtonElement;
+    await waitFor(() => expect(startOperatorButton.disabled).toBe(false));
+  });
+
   it('keeps model path blank on first launch when config has no persisted model path', async () => {
     invokeMock.mockImplementation((command: string) => {
       if (command === 'detect_backend') {

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -981,8 +981,13 @@ export function App() {
   );
 
   const canStartComputeNode = useMemo(
-    () => !pythonBridgeUnavailable && Boolean(config.model_path.trim()) && !computeStatus.running && !isStartingComputeNode && !isStoppingComputeNode,
-    [pythonBridgeUnavailable, config.model_path, computeStatus.running, isStartingComputeNode, isStoppingComputeNode]
+    () =>
+      Boolean(config.model_path.trim()) &&
+      normalizeRelayUrls(config.relay_base_urls, config.relay_base_url).length > 0 &&
+      !computeStatus.running &&
+      !isStartingComputeNode &&
+      !isStoppingComputeNode,
+    [config.model_path, config.relay_base_url, config.relay_base_urls, computeStatus.running, isStartingComputeNode, isStoppingComputeNode]
   );
   const operatorControlsDisabled = useMemo(
     () => (isStartingComputeNode && !computeStatus.running) || isStoppingComputeNode,

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -980,19 +980,19 @@ export function App() {
     [pythonBridgeUnavailable, config.model_path, prompt, status]
   );
 
-  const configuredRelayUrls = useMemo(
-    () => config.relay_base_urls.filter((relayUrl) => relayUrl.trim().length > 0),
+  const hasConfiguredRelayUrl = useMemo(
+    () => config.relay_base_urls.some((relayUrl) => relayUrl.trim().length > 0),
     [config.relay_base_urls]
   );
 
   const canStartComputeNode = useMemo(
     () =>
       Boolean(config.model_path.trim()) &&
-      configuredRelayUrls.length > 0 &&
+      hasConfiguredRelayUrl &&
       !computeStatus.running &&
       !isStartingComputeNode &&
       !isStoppingComputeNode,
-    [config.model_path, configuredRelayUrls, computeStatus.running, isStartingComputeNode, isStoppingComputeNode]
+    [config.model_path, hasConfiguredRelayUrl, computeStatus.running, isStartingComputeNode, isStoppingComputeNode]
   );
   const operatorControlsDisabled = useMemo(
     () => (isStartingComputeNode && !computeStatus.running) || isStoppingComputeNode,

--- a/desktop-tauri/src/App.tsx
+++ b/desktop-tauri/src/App.tsx
@@ -980,14 +980,19 @@ export function App() {
     [pythonBridgeUnavailable, config.model_path, prompt, status]
   );
 
+  const configuredRelayUrls = useMemo(
+    () => config.relay_base_urls.filter((relayUrl) => relayUrl.trim().length > 0),
+    [config.relay_base_urls]
+  );
+
   const canStartComputeNode = useMemo(
     () =>
       Boolean(config.model_path.trim()) &&
-      normalizeRelayUrls(config.relay_base_urls, config.relay_base_url).length > 0 &&
+      configuredRelayUrls.length > 0 &&
       !computeStatus.running &&
       !isStartingComputeNode &&
       !isStoppingComputeNode,
-    [config.model_path, config.relay_base_url, config.relay_base_urls, computeStatus.running, isStartingComputeNode, isStoppingComputeNode]
+    [config.model_path, configuredRelayUrls, computeStatus.running, isStartingComputeNode, isStoppingComputeNode]
   );
   const operatorControlsDisabled = useMemo(
     () => (isStartingComputeNode && !computeStatus.running) || isStoppingComputeNode,

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -4234,6 +4234,9 @@ def test_windows_installer_identity_operator_record_requires_exact_context_tier_
         'n_ctx': 65536,
         'api_v1_readiness_yarn_requested_context_tokens': 65536,
         'api_v1_readiness_yarn_rope_supported': True,
+        'startup_phase': 'ready',
+        'startup_result': 'ready',
+        'startup_deadline_ms': 300000,
     }), expected_tier='64k-full')
     with pytest.raises(guard.InstallerIdentityError, match='mismatched context tier'):
         guard.assert_operator_record(json.dumps({**base, 'context_tier': '8k-fast', 'effective_n_ctx': 65536, 'n_ctx': 65536}), expected_tier='8k-fast')
@@ -5084,13 +5087,29 @@ def test_windows_installer_identity_operator_record_rejects_readiness_and_runtim
         'context_fallback': False,
         'api_v1_readiness_yarn_requested_context_tokens': 65536,
         'api_v1_readiness_yarn_rope_supported': True,
+        'startup_phase': 'ready',
+        'startup_result': 'ready',
+        'startup_deadline_ms': 300000,
     }
     with pytest.raises(guard.InstallerIdentityError, match='bridge-command preflight'):
         guard.assert_operator_record(json.dumps({**base, 'bridge_preflight': 'missing'}), expected_tier='64k-full')
     with pytest.raises(guard.InstallerIdentityError, match='model artifact inspection'):
         guard.assert_operator_record(json.dumps({**base, 'model_artifact_inspect': 'missing'}), expected_tier='64k-full')
-    with pytest.raises(guard.InstallerIdentityError, match='safe model artifact filename'):
-        guard.assert_operator_record(json.dumps({**base, 'model_artifact_filename': 'C:/Users/operator/model.gguf'}), expected_tier='64k-full')
+    for unsafe_filename in [
+        'C:/Users/operator/model.gguf',
+        r'C:\Users\operator\model.gguf',
+        '/home/operator/model.gguf',
+        'qwen3.bin',
+    ]:
+        with pytest.raises(guard.InstallerIdentityError, match='safe model artifact filename'):
+            guard.assert_operator_record(
+                json.dumps({**base, 'model_artifact_filename': unsafe_filename}),
+                expected_tier='64k-full',
+            )
+    accepted = guard.assert_operator_record(json.dumps(base), expected_tier='64k-full')
+    assert accepted['model_artifact_filename'] == 'qwen3.gguf'
+    assert 'C:' not in json.dumps(accepted)
+    assert '/home/' not in json.dumps(accepted)
     with pytest.raises(guard.InstallerIdentityError, match='Qwen3'):
         guard.assert_operator_record(json.dumps({**base, 'selected_model_profile': 'other'}), expected_tier='64k-full')
     with pytest.raises(guard.InstallerIdentityError, match='bounded ready'):

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -3726,7 +3726,7 @@ def test_windows_installer_identity_probes_scenario_current_version(monkeypatch,
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
         'model_artifact_inspect': 'ok',
-        'model_artifact_filename': 'qwen3.gguf',
+        'model_artifact_filename': 'Qwen3-8B-Q4_K_M.gguf',
         'context_tier': guard.seeded_config_values()['context_tier'],
         'preferred_mode': guard.seeded_config_values()['preferred_mode'],
     }))
@@ -4081,7 +4081,7 @@ def test_windows_installer_identity_operator_record_rejects_fabricated_or_incomp
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
         'model_artifact_inspect': 'ok',
-        'model_artifact_filename': 'qwen3.gguf',
+        'model_artifact_filename': 'Qwen3-8B-Q4_K_M.gguf',
     }))
     with pytest.raises(guard.InstallerIdentityError, match='did not emit JSON'):
         guard.assert_operator_record('launcher_source=bundled interpreter_basename=python.exe')
@@ -4215,7 +4215,7 @@ def test_windows_installer_identity_operator_record_requires_exact_context_tier_
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
         'model_artifact_inspect': 'ok',
-        'model_artifact_filename': 'qwen3.gguf',
+        'model_artifact_filename': 'Qwen3-8B-Q4_K_M.gguf',
         'selected_model_profile': 'qwen3-8b-q4',
         'startup_phase': 'ready',
         'startup_result': 'ready',
@@ -4254,7 +4254,7 @@ def test_windows_installer_identity_second_launch_rejects_repair_or_provisioning
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
         'model_artifact_inspect': 'ok',
-        'model_artifact_filename': 'qwen3.gguf',
+        'model_artifact_filename': 'Qwen3-8B-Q4_K_M.gguf',
         'selected_model_profile': 'qwen3-8b-q4',
         'context_tier': '8k-fast',
         'effective_n_ctx': 8192,
@@ -4292,7 +4292,7 @@ def test_windows_installer_identity_context_tier_probe_executes_twice_per_tier(m
             'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
             'bridge_preflight': 'ok',
             'model_artifact_inspect': 'ok',
-            'model_artifact_filename': 'qwen3.gguf',
+            'model_artifact_filename': 'Qwen3-8B-Q4_K_M.gguf',
             'selected_model_profile': 'qwen3-8b-q4',
             'context_tier': tier,
             'effective_n_ctx': n_ctx,
@@ -4433,7 +4433,7 @@ def test_windows_installer_identity_second_launch_requires_observed_zero_counter
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
         'model_artifact_inspect': 'ok',
-        'model_artifact_filename': 'qwen3.gguf',
+        'model_artifact_filename': 'Qwen3-8B-Q4_K_M.gguf',
         'selected_model_profile': 'qwen3-8b-q4',
         'model_profile_identifier': 'qwen3-8b-q4-k-m',
         'context_tier': '8k-fast',
@@ -4599,7 +4599,7 @@ def test_windows_installer_identity_run_scenario_rejects_sentinel_after_success(
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
         'model_artifact_inspect': 'ok',
-        'model_artifact_filename': 'qwen3.gguf',
+        'model_artifact_filename': 'Qwen3-8B-Q4_K_M.gguf',
     }))
     real_sentinel_dir = guard._sentinel_dir
 
@@ -4686,7 +4686,7 @@ def test_windows_installer_identity_operator_record_accepts_64k_ready_contract()
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
         'model_artifact_inspect': 'ok',
-        'model_artifact_filename': 'qwen3.gguf',
+        'model_artifact_filename': 'Qwen3-8B-Q4_K_M.gguf',
         'context_tier': '64k-full',
         'effective_n_ctx': 65536,
         'n_ctx': 65536,
@@ -4724,7 +4724,7 @@ def test_windows_installer_identity_operator_record_rejects_multiline_or_fallbac
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
         'model_artifact_inspect': 'ok',
-        'model_artifact_filename': 'qwen3.gguf',
+        'model_artifact_filename': 'Qwen3-8B-Q4_K_M.gguf',
     }
 
     with pytest.raises(guard.InstallerIdentityError, match='exactly one'):
@@ -5076,7 +5076,7 @@ def test_windows_installer_identity_operator_record_rejects_readiness_and_runtim
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
         'model_artifact_inspect': 'ok',
-        'model_artifact_filename': 'qwen3.gguf',
+        'model_artifact_filename': 'Qwen3-8B-Q4_K_M.gguf',
         'selected_model_profile': 'qwen3-8b-q4',
         'context_tier': '64k-full',
         'effective_n_ctx': 65536,
@@ -5100,6 +5100,7 @@ def test_windows_installer_identity_operator_record_rejects_readiness_and_runtim
         r'C:\Users\operator\model.gguf',
         '/home/operator/model.gguf',
         'qwen3.bin',
+        'other-safe-model.gguf',
     ]:
         with pytest.raises(guard.InstallerIdentityError, match='safe model artifact filename'):
             guard.assert_operator_record(
@@ -5107,7 +5108,7 @@ def test_windows_installer_identity_operator_record_rejects_readiness_and_runtim
                 expected_tier='64k-full',
             )
     accepted = guard.assert_operator_record(json.dumps(base), expected_tier='64k-full')
-    assert accepted['model_artifact_filename'] == 'qwen3.gguf'
+    assert accepted['model_artifact_filename'] == 'Qwen3-8B-Q4_K_M.gguf'
     assert 'C:' not in json.dumps(accepted)
     assert '/home/' not in json.dumps(accepted)
     with pytest.raises(guard.InstallerIdentityError, match='Qwen3'):
@@ -5147,7 +5148,7 @@ def test_windows_installer_identity_validate_tiers_detects_runtime_and_profile_d
             'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
             'bridge_preflight': 'ok',
             'model_artifact_inspect': 'ok',
-            'model_artifact_filename': 'qwen3.gguf',
+            'model_artifact_filename': 'Qwen3-8B-Q4_K_M.gguf',
             'selected_model_profile': 'qwen3-8b-q4',
             'model_profile_identifier': 'qwen3-8b-q4-k-m',
             'context_tier': tier,
@@ -5182,7 +5183,7 @@ def test_windows_installer_identity_validate_tiers_detects_runtime_and_profile_d
             'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
             'bridge_preflight': 'ok',
             'model_artifact_inspect': 'ok',
-            'model_artifact_filename': 'qwen3.gguf',
+            'model_artifact_filename': 'Qwen3-8B-Q4_K_M.gguf',
             'selected_model_profile': 'qwen3-8b-q4',
             'model_profile_identifier': 'changed-profile' if launches == 2 else 'qwen3-8b-q4-k-m',
             'context_tier': tier,

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -2539,7 +2539,7 @@ def _load_windows_release_validator():
     return module
 
 
-def _write_windows_runtime_fixture(root: Path, *, version: str = '0.1.3') -> tuple[Path, Path]:
+def _write_windows_runtime_fixture(root: Path, *, version: str = '0.1.4') -> tuple[Path, Path]:
     validator = _load_windows_release_validator()
     manifest = json.loads(Path('desktop-tauri/src-tauri/python/embedded_python_runtime_windows_x86_64_manifest.json').read_text(encoding='utf-8'))
     runtime = root / 'resources' / 'python-runtime'
@@ -2599,7 +2599,7 @@ def test_windows_validator_without_version_args_derives_package_json_version(tmp
 def test_windows_release_validator_accepts_extracted_msi_and_nsis(tmp_path):
     validator = _load_windows_release_validator()
     nsis, msi = _write_windows_runtime_fixture(tmp_path)
-    assert validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.3']) == 0
+    assert validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.4']) == 0
 
 
 def test_windows_release_validator_rejects_version_and_provenance_mismatch(tmp_path):
@@ -2614,7 +2614,7 @@ def test_windows_release_validator_rejects_version_and_provenance_mismatch(tmp_p
     data['llama_cpp_cuda_wheel']['flavor'] = 'cpu'
     provenance.write_text(json.dumps(data), encoding='utf-8')
     with pytest.raises(validator.ValidationError, match='incomplete Windows runtime provenance'):
-        validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.3'])
+        validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.4'])
 
 
 def _extract_workflow_job_block(text: str, job_key: str) -> str:
@@ -2653,18 +2653,18 @@ def test_release_workflow_runs_windows_validator_and_preserves_skipped_nvidia_ga
 
 def test_windows_validator_version_tag_config_and_extract_edges(tmp_path, monkeypatch):
     validator = _load_windows_release_validator()
-    assert validator.expected_version_from_tag(None, '0.1.3') == '0.1.3'
-    assert validator.expected_version_from_tag('desktop-v1.2.3', '0.1.3') == '1.2.3'
+    assert validator.expected_version_from_tag(None, '0.1.4') == '0.1.4'
+    assert validator.expected_version_from_tag('desktop-v1.2.3', '0.1.4') == '1.2.3'
     with pytest.raises(validator.ValidationError, match='desktop-vX.Y.Z'):
-        validator.expected_version_from_tag('1495/merge', '0.1.3')
+        validator.expected_version_from_tag('1495/merge', '0.1.4')
 
     package = tmp_path / 'package.json'
     lock = tmp_path / 'package-lock.json'
     tauri = tmp_path / 'tauri.conf.json'
     cargo = tmp_path / 'Cargo.toml'
     cargo_lock = tmp_path / 'Cargo.lock'
-    package.write_text(json.dumps({'version': '0.1.3'}), encoding='utf-8')
-    lock.write_text(json.dumps({'version': '0.1.3'}), encoding='utf-8')
+    package.write_text(json.dumps({'version': '0.1.4'}), encoding='utf-8')
+    lock.write_text(json.dumps({'version': '0.1.4'}), encoding='utf-8')
     tauri.write_text(json.dumps({'version': '9.9.9'}), encoding='utf-8')
     cargo.write_text('[package]\nname = "token-place-desktop-tauri"\nversion = "0.1.3"\n', encoding='utf-8')
     cargo_lock.write_text('version = 4\n\n[[package]]\nname = "token-place-desktop-tauri"\nversion = "0.1.3"\n', encoding='utf-8')
@@ -2674,17 +2674,17 @@ def test_windows_validator_version_tag_config_and_extract_edges(tmp_path, monkey
     monkeypatch.setattr(validator, 'CARGO_MANIFEST', cargo)
     monkeypatch.setattr(validator, 'CARGO_LOCK', cargo_lock)
     with pytest.raises(validator.ValidationError, match='Windows release version mismatch'):
-        validator.validate_config_versions('0.1.3')
-    tauri.write_text(json.dumps({'version': '0.1.3'}), encoding='utf-8')
+        validator.validate_config_versions('0.1.4')
+    tauri.write_text(json.dumps({'version': '0.1.4'}), encoding='utf-8')
     cargo.write_text('[package]\nname = "token-place-desktop-tauri"\nversion = "0.1.0"\n', encoding='utf-8')
     with pytest.raises(validator.ValidationError, match='Cargo.toml'):
-        validator.validate_config_versions('0.1.3')
-    cargo.write_text('[package]\nname = "token-place-desktop-tauri"\nversion = "0.1.3"\n', encoding='utf-8')
+        validator.validate_config_versions('0.1.4')
+    cargo.write_text('[package]\nname = "token-place-desktop-tauri"\nversion = "0.1.4"\n', encoding='utf-8')
     cargo_lock.write_text('version = 4\n\n[[package]]\nname = "token-place-desktop-tauri"\nversion = "0.1.0"\n', encoding='utf-8')
     with pytest.raises(validator.ValidationError, match='Cargo.lock'):
-        validator.validate_config_versions('0.1.3')
-    cargo_lock.write_text('version = 4\n\n[[package]]\nname = "token-place-desktop-tauri"\nversion = "0.1.3"\n', encoding='utf-8')
-    validator.validate_config_versions('0.1.3')
+        validator.validate_config_versions('0.1.4')
+    cargo_lock.write_text('version = 4\n\n[[package]]\nname = "token-place-desktop-tauri"\nversion = "0.1.4"\n', encoding='utf-8')
+    validator.validate_config_versions('0.1.4')
 
     source_dir = tmp_path / 'already-extracted'
     source_dir.mkdir()
@@ -3543,18 +3543,18 @@ def _load_windows_installer_identity():
 
 def test_windows_installer_identity_requires_previous_artifacts(tmp_path) -> None:
     guard = _load_windows_installer_identity()
-    current_nsis = tmp_path / 'token.place-desktop-0.1.3-x64-setup.exe'
-    current_msi = tmp_path / 'token.place-desktop-0.1.3-x64.msi'
-    previous_nsis = tmp_path / 'token.place-desktop-0.1.2-x64-setup.exe'
-    previous_msi = tmp_path / 'token.place-desktop-0.1.2-x64.msi'
+    current_nsis = tmp_path / 'token.place-desktop-0.1.4-x64-setup.exe'
+    current_msi = tmp_path / 'token.place-desktop-0.1.4-x64.msi'
+    previous_nsis = tmp_path / 'token.place-desktop-0.1.3-x64-setup.exe'
+    previous_msi = tmp_path / 'token.place-desktop-0.1.3-x64.msi'
     for path in (current_nsis, current_msi, previous_nsis, previous_msi):
         path.write_text('artifact', encoding='utf-8')
 
-    scenarios = guard.build_scenarios(current_nsis, current_msi, previous_nsis, previous_msi, '0.1.3', '0.1.2')
+    scenarios = guard.build_scenarios(current_nsis, current_msi, previous_nsis, previous_msi, '0.1.4', '0.1.3')
 
     assert [scenario.name for scenario in scenarios] == [
-        'clean-nsis-0.1.3',
-        'clean-msi-0.1.3',
+        'clean-nsis-0.1.4',
+        'clean-msi-0.1.4',
         'upgrade-nsis-to-nsis',
         'upgrade-msi-to-msi',
         'cross-nsis-to-msi',
@@ -3568,11 +3568,11 @@ def test_windows_installer_identity_requires_previous_artifacts(tmp_path) -> Non
 
 def test_windows_installer_identity_rejects_duplicate_previous_artifact(tmp_path) -> None:
     guard = _load_windows_installer_identity()
-    previous_nsis = tmp_path / 'token.place-desktop-0.1.2-x64-setup.exe'
+    previous_nsis = tmp_path / 'token.place-desktop-0.1.3-x64-setup.exe'
     previous_nsis.write_text('artifact', encoding='utf-8')
 
     with pytest.raises(guard.InstallerIdentityError, match='exactly one previous NSIS and one distinct previous MSI'):
-        guard.validate_previous_artifacts(previous_nsis, previous_nsis, '0.1.2')
+        guard.validate_previous_artifacts(previous_nsis, previous_nsis, '0.1.3')
 
 
 def test_immediate_prior_version_is_semver_aware() -> None:
@@ -3725,6 +3725,8 @@ def test_windows_installer_identity_probes_scenario_current_version(monkeypatch,
         'runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
+        'model_artifact_inspect': 'ok',
+        'model_artifact_filename': 'qwen3.gguf',
         'context_tier': guard.seeded_config_values()['context_tier'],
         'preferred_mode': guard.seeded_config_values()['preferred_mode'],
     }))
@@ -4078,6 +4080,8 @@ def test_windows_installer_identity_operator_record_rejects_fabricated_or_incomp
         'runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
+        'model_artifact_inspect': 'ok',
+        'model_artifact_filename': 'qwen3.gguf',
     }))
     with pytest.raises(guard.InstallerIdentityError, match='did not emit JSON'):
         guard.assert_operator_record('launcher_source=bundled interpreter_basename=python.exe')
@@ -4210,6 +4214,8 @@ def test_windows_installer_identity_operator_record_requires_exact_context_tier_
         'runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
+        'model_artifact_inspect': 'ok',
+        'model_artifact_filename': 'qwen3.gguf',
         'selected_model_profile': 'qwen3-8b-q4',
         'startup_phase': 'ready',
         'startup_result': 'ready',
@@ -4244,6 +4250,8 @@ def test_windows_installer_identity_second_launch_rejects_repair_or_provisioning
         'runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
+        'model_artifact_inspect': 'ok',
+        'model_artifact_filename': 'qwen3.gguf',
         'selected_model_profile': 'qwen3-8b-q4',
         'context_tier': '8k-fast',
         'effective_n_ctx': 8192,
@@ -4280,6 +4288,8 @@ def test_windows_installer_identity_context_tier_probe_executes_twice_per_tier(m
             'runtime_id': guard.EXPECTED_RUNTIME_ID,
             'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
             'bridge_preflight': 'ok',
+            'model_artifact_inspect': 'ok',
+            'model_artifact_filename': 'qwen3.gguf',
             'selected_model_profile': 'qwen3-8b-q4',
             'context_tier': tier,
             'effective_n_ctx': n_ctx,
@@ -4419,6 +4429,8 @@ def test_windows_installer_identity_second_launch_requires_observed_zero_counter
         'runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
+        'model_artifact_inspect': 'ok',
+        'model_artifact_filename': 'qwen3.gguf',
         'selected_model_profile': 'qwen3-8b-q4',
         'model_profile_identifier': 'qwen3-8b-q4-k-m',
         'context_tier': '8k-fast',
@@ -4508,10 +4520,10 @@ def test_installed_context_smoke_uses_get_llm_instance_boundary() -> None:
 
 def test_windows_installer_identity_main_non_windows_contract_success(monkeypatch, tmp_path, capsys) -> None:
     guard = _load_windows_installer_identity()
-    current_nsis = tmp_path / 'token.place-desktop-0.1.3-x64-setup.exe'
-    current_msi = tmp_path / 'token.place-desktop-0.1.3-x64.msi'
-    previous_nsis = tmp_path / 'token.place-desktop-0.1.2-x64-setup.exe'
-    previous_msi = tmp_path / 'token.place-desktop-0.1.2-x64.msi'
+    current_nsis = tmp_path / 'token.place-desktop-0.1.4-x64-setup.exe'
+    current_msi = tmp_path / 'token.place-desktop-0.1.4-x64.msi'
+    previous_nsis = tmp_path / 'token.place-desktop-0.1.3-x64-setup.exe'
+    previous_msi = tmp_path / 'token.place-desktop-0.1.3-x64.msi'
     for path in (current_nsis, current_msi, previous_nsis, previous_msi):
         path.write_text('artifact', encoding='utf-8')
     monkeypatch.setattr(guard.sys, 'platform', 'linux')
@@ -4583,6 +4595,8 @@ def test_windows_installer_identity_run_scenario_rejects_sentinel_after_success(
         'runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
+        'model_artifact_inspect': 'ok',
+        'model_artifact_filename': 'qwen3.gguf',
     }))
     real_sentinel_dir = guard._sentinel_dir
 
@@ -4594,7 +4608,7 @@ def test_windows_installer_identity_run_scenario_rejects_sentinel_after_success(
     monkeypatch.setattr(guard, '_sentinel_dir', sentinel_dir_with_activity)
 
     with pytest.raises(guard.InstallerIdentityError, match='sentinel was invoked'):
-        guard.run_scenario(guard.Scenario('clean-nsis-0.1.3', current), 'abcdef123456')
+        guard.run_scenario(guard.Scenario('clean-nsis-0.1.4', current), 'abcdef123456')
 
 
 
@@ -4668,6 +4682,8 @@ def test_windows_installer_identity_operator_record_accepts_64k_ready_contract()
         'runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
+        'model_artifact_inspect': 'ok',
+        'model_artifact_filename': 'qwen3.gguf',
         'context_tier': '64k-full',
         'effective_n_ctx': 65536,
         'n_ctx': 65536,
@@ -4704,6 +4720,8 @@ def test_windows_installer_identity_operator_record_rejects_multiline_or_fallbac
         'runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
+        'model_artifact_inspect': 'ok',
+        'model_artifact_filename': 'qwen3.gguf',
     }
 
     with pytest.raises(guard.InstallerIdentityError, match='exactly one'):
@@ -5054,6 +5072,8 @@ def test_windows_installer_identity_operator_record_rejects_readiness_and_runtim
         'runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
         'bridge_preflight': 'ok',
+        'model_artifact_inspect': 'ok',
+        'model_artifact_filename': 'qwen3.gguf',
         'selected_model_profile': 'qwen3-8b-q4',
         'context_tier': '64k-full',
         'effective_n_ctx': 65536,
@@ -5067,6 +5087,10 @@ def test_windows_installer_identity_operator_record_rejects_readiness_and_runtim
     }
     with pytest.raises(guard.InstallerIdentityError, match='bridge-command preflight'):
         guard.assert_operator_record(json.dumps({**base, 'bridge_preflight': 'missing'}), expected_tier='64k-full')
+    with pytest.raises(guard.InstallerIdentityError, match='model artifact inspection'):
+        guard.assert_operator_record(json.dumps({**base, 'model_artifact_inspect': 'missing'}), expected_tier='64k-full')
+    with pytest.raises(guard.InstallerIdentityError, match='safe model artifact filename'):
+        guard.assert_operator_record(json.dumps({**base, 'model_artifact_filename': 'C:/Users/operator/model.gguf'}), expected_tier='64k-full')
     with pytest.raises(guard.InstallerIdentityError, match='Qwen3'):
         guard.assert_operator_record(json.dumps({**base, 'selected_model_profile': 'other'}), expected_tier='64k-full')
     with pytest.raises(guard.InstallerIdentityError, match='bounded ready'):
@@ -5103,6 +5127,8 @@ def test_windows_installer_identity_validate_tiers_detects_runtime_and_profile_d
             'runtime_id': 'different-runtime' if launches == 2 else guard.EXPECTED_RUNTIME_ID,
             'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
             'bridge_preflight': 'ok',
+            'model_artifact_inspect': 'ok',
+            'model_artifact_filename': 'qwen3.gguf',
             'selected_model_profile': 'qwen3-8b-q4',
             'model_profile_identifier': 'qwen3-8b-q4-k-m',
             'context_tier': tier,
@@ -5136,6 +5162,8 @@ def test_windows_installer_identity_validate_tiers_detects_runtime_and_profile_d
             'runtime_id': guard.EXPECTED_RUNTIME_ID,
             'bundled_runtime_id': guard.EXPECTED_RUNTIME_ID,
             'bridge_preflight': 'ok',
+            'model_artifact_inspect': 'ok',
+            'model_artifact_filename': 'qwen3.gguf',
             'selected_model_profile': 'qwen3-8b-q4',
             'model_profile_identifier': 'changed-profile' if launches == 2 else 'qwen3-8b-q4-k-m',
             'context_tier': tier,
@@ -5159,20 +5187,20 @@ def test_windows_installer_identity_validate_tiers_detects_runtime_and_profile_d
 
 def test_windows_installer_identity_run_all_and_main_windows_paths(monkeypatch, tmp_path, capsys) -> None:
     guard = _load_windows_installer_identity()
-    current_nsis = tmp_path / 'token.place-desktop-0.1.3-x64-setup.exe'
-    current_msi = tmp_path / 'token.place-desktop-0.1.3-x64.msi'
-    previous_nsis = tmp_path / 'token.place-desktop-0.1.2-x64-setup.exe'
-    previous_msi = tmp_path / 'token.place-desktop-0.1.2-x64.msi'
+    current_nsis = tmp_path / 'token.place-desktop-0.1.4-x64-setup.exe'
+    current_msi = tmp_path / 'token.place-desktop-0.1.4-x64.msi'
+    previous_nsis = tmp_path / 'token.place-desktop-0.1.3-x64-setup.exe'
+    previous_msi = tmp_path / 'token.place-desktop-0.1.3-x64.msi'
     for path in (current_nsis, current_msi, previous_nsis, previous_msi):
         path.write_text('artifact', encoding='utf-8')
 
-    scenarios = [guard.Scenario('clean-nsis-0.1.3', guard.Installer(current_nsis, 'nsis', '0.1.3'))]
+    scenarios = [guard.Scenario('clean-nsis-0.1.4', guard.Installer(current_nsis, 'nsis', '0.1.4'))]
     artifacts_seen = []
     def fake_runner(scenario, build_id):
         artifacts_seen.append((scenario.name, build_id))
 
     guard.run_all_scenarios(scenarios, 'abcdef123456', runner=fake_runner, artifact_root=tmp_path / 'logs')
-    assert artifacts_seen == [('clean-nsis-0.1.3', 'abcdef123456')]
+    assert artifacts_seen == [('clean-nsis-0.1.4', 'abcdef123456')]
 
     old_argv = sys.argv
     monkeypatch.setattr(guard.sys, 'platform', 'win32')


### PR DESCRIPTION
### Motivation

Fix the Windows desktop-v0.1.3 regression where an auxiliary mount-time `inspect_model_artifact` failure disabled **Start operator** before the authoritative startup preflight could run.

Also make packaged Python-runtime discovery consistent between GUI and CLI/smoke contexts in preparation for desktop-v0.1.4.

### Implementation

- Decoupled `canStartComputeNode` from `pythonBridgeUnavailable`.
  - Start now requires a populated model path, at least one nonblank editable relay URL, and an operator that is not running, starting, or stopping.
  - Mount-time `desktop_python_runtime_missing` and `desktop_python_runtime_invalid` errors remain visible but do not disable Start.
  - Local inference and Download remain bridge-gated.
  - Operator startup retains fail-closed runtime, model, CUDA, context-tier, relay-readiness, and pre-registration validation.
- Updated bundled-runtime discovery to evaluate Tauri resource hints, executable-relative packaged roots, and permitted development roots together.
  - Candidate layouts are validated, canonicalized, and deduplicated.
  - Multiple distinct valid runtimes remain an error.
  - Packaged Windows never falls back to host Python.
  - Existing macOS behavior is preserved.
- Introduced a consistent bridge resource context so GUI inspection, operator startup, script lookup, runtime lookup, environment construction, and subprocess execution use the same executable/resource/manifest inputs.
- Extended installed-Windows smoke validation:
  - Executes packaged `model_bridge.py inspect`.
  - Requires `model_artifact_inspect: "ok"`.
  - Requires the exact basename-only `Qwen3-8B-Q4_K_M.gguf`.
  - Preserves the 8K and 64K operator-preflight checks.
  - Sanitizes Python subprocess environments and emitted diagnostics.
- Updated all canonical desktop version surfaces from `0.1.3` to `0.1.4`.
- Made the full Rust regressions deterministic and added the complete Rust suite to both Linux and Windows desktop-operator CI.

### Regression coverage

- React tests cover:
  - mount-time missing/invalid bundled-runtime errors;
  - Start remaining enabled and invoking `start_compute_node`;
  - local inference and Download remaining disabled;
  - running, starting, missing-model, and whitespace-cleared-relay gates;
  - legacy configuration hydration to the default relay.
- Rust tests cover:
  - stale Tauri resource hints;
  - executable-relative Windows runtime discovery;
  - canonical candidate deduplication;
  - ambiguity and missing/corrupt-runtime failures;
  - shared GUI/operator bridge context;
  - exact safe model-inspection evidence;
  - deterministic process-tree and sidecar behavior.
- Python artifact tests reject missing, unsuccessful, path-bearing, non-GGUF, or incorrect model-inspection evidence.

### Validation

Latest head: `6195fed6c9c943dcdcaaf582560612e465c81abc`

All latest-head PR workflows completed successfully:

- [Desktop operator app e2e](https://github.com/futuroptimist/token.place/actions/runs/30070696562)
  - Linux frontend build, UI e2e, packaged bridge, parity, cancellation, and integration checks.
  - Full Linux Rust suite: 183 passed, 0 failed.
  - Windows parity, CUDA-handoff regressions, and full Rust suite: 162 passed, 0 failed.
  - Python 3.9 packaged-inspection smoke.
- [CI](https://github.com/futuroptimist/token.place/actions/runs/30070696564)
- [run_all_tests.sh PR](https://github.com/futuroptimist/token.place/actions/runs/30070696636)
- [GHCR relay image](https://github.com/futuroptimist/token.place/actions/runs/30070696602)
- [Helm chart](https://github.com/futuroptimist/token.place/actions/runs/30070696563)

Focused frontend, Rust, Python artifact, Python compile, frontend-build, pre-commit, and diff checks passed.

Greptile and Copilot concerns about subprocess environment parity, non-UTF8 path handling, and exact basename-only GGUF validation are addressed in the current code. The remaining unresolved GitHub thread markers refer to outdated code.

### Post-merge release validation

Per maintainer direction, the complete `Desktop Tauri Release` MSI/NSIS validation will run after merge and before publishing desktop-v0.1.4. It must verify:

- clean-install and upgrade scenarios;
- GUI-equivalent packaged model inspection;
- the exact safe model filename;
- 8K and 64K operator preflights;
- absence of absolute installation or user paths in smoke records.

Real CUDA operation remains to be validated separately on a Windows x64 NVIDIA machine; mocked CUDA probes are not treated as hardware proof.

No tag was created, moved, replaced, or published by this PR. `desktop-v0.1.3` remains immutable. Tag `desktop-v0.1.4` only after the post-merge release checks are green.

### Files changed

- `.github/workflows/desktop-operator-e2e.yml`
- `desktop-tauri/package-lock.json`
- `desktop-tauri/package.json`
- `desktop-tauri/scripts/test_windows_installer_identity.py`
- `desktop-tauri/src-tauri/Cargo.lock`
- `desktop-tauri/src-tauri/Cargo.toml`
- `desktop-tauri/src-tauri/src/compute_node.rs`
- `desktop-tauri/src-tauri/src/main.rs`
- `desktop-tauri/src-tauri/src/python_runtime.rs`
- `desktop-tauri/src-tauri/src/sidecar.rs`
- `desktop-tauri/src-tauri/tauri.conf.json`
- `desktop-tauri/src/App.test.tsx`
- `desktop-tauri/src/App.tsx`
- `tests/unit/test_desktop_release_artifacts.py`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a628b026e10832f89b01db7038212b9)