### PR TITLE
Gate macOS Metal PR bootstrap before runner allocation

### DIFF
--- a/.github/workflows/run-all-tests-pr.yml
+++ b/.github/workflows/run-all-tests-pr.yml
@@ -98,12 +98,14 @@ jobs:
           if-no-files-found: error
 
 
-  macos-metal-runtime-bootstrap:
-    name: macOS Metal desktop runtime bootstrap
-    runs-on: macos-26
-    timeout-minutes: 45
+  macos-metal-change-detector:
+    name: Detect macOS Metal bootstrap changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
+    outputs:
+      run_macos_metal: ${{ steps.changes.outputs.run_macos_metal }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -114,21 +116,32 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
-            changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD)"
-          else
-            changed_files="desktop-tauri/src-tauri/python/manual-dispatch"
-          fi
-          printf '%s\n' "$changed_files"
-          if printf '%s\n' "$changed_files" | grep -Eq '^(desktop-tauri/src-tauri/python/|desktop-tauri/scripts/prepare_.*python_runtime|requirements\.txt$)'; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run_macos_metal=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD)"
+          printf '%s\n' "$changed_files"
+          if printf '%s\n' "$changed_files" | grep -Eq '^(desktop-tauri/src-tauri/python/|desktop-tauri/scripts/prepare_.*python_runtime|requirements\.txt$|\.github/workflows/run-all-tests-pr\.yml$)'; then
+            echo "run_macos_metal=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_macos_metal=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  macos-metal-runtime-bootstrap:
+    name: macOS Metal desktop runtime bootstrap
+    needs: macos-metal-change-detector
+    if: needs.macos-metal-change-detector.outputs.run_macos_metal == 'true'
+    runs-on: macos-26
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
       - name: Set up Python 3.11
-        if: steps.changes.outputs.run == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -136,7 +149,6 @@ jobs:
           cache-dependency-path: requirements.txt
 
       - name: Prepare and verify Metal-capable embedded Python runtime
-        if: steps.changes.outputs.run == 'true'
         working-directory: desktop-tauri
         env:
           CMAKE_ARGS: -DGGML_METAL=on
@@ -148,7 +160,3 @@ jobs:
           python scripts/prepare_embedded_python_runtime.py
           test -x src-tauri/python-runtime/bin/python3
           src-tauri/python-runtime/bin/python3 -m pip check
-
-      - name: Summarize skipped Metal bootstrap
-        if: steps.changes.outputs.run != 'true'
-        run: echo "No desktop Python runtime, packaging bootstrap, or requirements.txt changes detected; skipping focused macOS Metal bootstrap." >> "$GITHUB_STEP_SUMMARY"

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 import stat
 import subprocess
 from pathlib import Path
@@ -52,6 +53,31 @@ def _run_all_tests_jobs() -> dict[str, dict]:
         for job_id, job in jobs.items()
         if isinstance(job, dict) and "run_all_tests.sh" in str(job.get("name", ""))
     }
+
+
+def _workflow_step_by_name(job: dict, name: str) -> dict:
+    matches = [step for step in _job_steps(job) if step.get("name") == name]
+    assert len(matches) == 1, f"expected exactly one step named {name!r}"
+    return matches[0]
+
+
+def _macos_metal_detector_regex() -> re.Pattern[str]:
+    workflow_data = _run_all_tests_workflow()
+    detector = workflow_data["jobs"].get("macos-metal-change-detector")
+    assert isinstance(detector, dict), "run-all-tests-pr.yml must define a detector job"
+    run_script = str(
+        _workflow_step_by_name(
+            detector, "Detect desktop runtime or packaging changes"
+        ).get("run", "")
+    )
+    match = re.search(r"grep -Eq '([^']+)'", run_script)
+    assert match, "detector must keep an explicit grep -E path-selection contract"
+    return re.compile(match.group(1))
+
+
+def _macos_metal_requested_for(paths: list[str]) -> bool:
+    pattern = _macos_metal_detector_regex()
+    return any(pattern.search(path) for path in paths)
 
 
 def _job_steps(job: dict) -> list[dict]:
@@ -479,21 +505,46 @@ def test_linux_run_all_tests_pr_job_invokes_the_full_suite() -> None:
 
 def test_run_all_tests_pr_has_path_gated_macos_metal_bootstrap() -> None:
     workflow_data = _run_all_tests_workflow()
-    job = workflow_data["jobs"].get("macos-metal-runtime-bootstrap")
+    jobs = workflow_data["jobs"]
+    detector = jobs.get("macos-metal-change-detector")
+    job = jobs.get("macos-metal-runtime-bootstrap")
+
+    assert detector, "A cheap Linux detector must decide whether macOS Metal is needed."
+    assert detector["runs-on"] == "ubuntu-latest"
+    assert detector["timeout-minutes"] == "5"
+    assert detector["permissions"] == {"contents": "read"}
+    assert detector["outputs"]["run_macos_metal"] == (
+        "${{ steps.changes.outputs.run_macos_metal }}"
+    )
+
+    detector_text = yaml.dump(detector, sort_keys=True)
+    assert "desktop-tauri/src-tauri/python/" in detector_text
+    assert "desktop-tauri/scripts/prepare_.*python_runtime" in detector_text
+    assert _macos_metal_requested_for(["requirements.txt"])
+    assert _macos_metal_requested_for([".github/workflows/run-all-tests-pr.yml"])
+    assert "workflow_dispatch" in detector_text
+    assert "run_macos_metal=true" in detector_text
 
     assert job, (
         "Desktop Python runtime or packaging changes need a focused macOS Metal "
         "bootstrap guardrail now that the duplicate macOS full-suite job is removed."
     )
+    assert job["name"] == "macOS Metal desktop runtime bootstrap"
+    assert job["needs"] == "macos-metal-change-detector"
+    assert job["if"] == (
+        "needs.macos-metal-change-detector.outputs.run_macos_metal == 'true'"
+    )
     assert job["runs-on"] == "macos-26"
     job_text = yaml.dump(job, sort_keys=True)
-    assert "desktop-tauri/src-tauri/python/" in job_text
-    assert "requirements.txt" in job_text
     assert "CMAKE_ARGS" in job_text
     assert "-DGGML_METAL=on" in job_text
     assert "FORCE_CMAKE" in job_text
+    assert 'test "$(uname -m)" = "arm64"' in job_text
     assert "scripts/prepare_embedded_python_runtime.py" in job_text
-    assert "steps.changes.outputs.run == 'true'" in job_text
+    assert "test -x src-tauri/python-runtime/bin/python3" in job_text
+    assert "src-tauri/python-runtime/bin/python3 -m pip check" in job_text
+    assert "steps.changes.outputs.run" not in job_text
+    assert "Summarize skipped Metal bootstrap" not in job_text
 
     checkout_steps = [
         step
@@ -502,7 +553,56 @@ def test_run_all_tests_pr_has_path_gated_macos_metal_bootstrap() -> None:
     ]
     assert len(checkout_steps) == 1
     assert checkout_steps[0]["uses"] == "actions/checkout@v5"
-    assert checkout_steps[0].get("with", {}).get("fetch-depth") == "0"
+
+
+def test_run_all_tests_pr_linux_job_is_independent_of_macos_gate() -> None:
+    workflow_data = _run_all_tests_workflow()
+    linux_job = workflow_data["jobs"]["linux-run-all-tests"]
+
+    assert "needs" not in linux_job, (
+        "linux-run-all-tests should start independently and must not wait for the "
+        "macOS Metal detector or gated macOS job."
+    )
+
+
+def test_run_all_tests_pr_macos_metal_detector_path_contract() -> None:
+    assert not _macos_metal_requested_for(["docs/README.md", "relay.py"])
+
+    relevant_paths = [
+        "desktop-tauri/src-tauri/python/requirements.txt",
+        "desktop-tauri/src-tauri/python/runtime_bootstrap.py",
+        "desktop-tauri/scripts/prepare_embedded_python_runtime.py",
+        "desktop-tauri/scripts/prepare_macos_python_runtime.sh",
+        "requirements.txt",
+        ".github/workflows/run-all-tests-pr.yml",
+    ]
+    for path in relevant_paths:
+        assert _macos_metal_requested_for([path]), f"{path} must request macOS Metal"
+
+
+def test_run_all_tests_pr_macos_metal_manual_dispatch_requests_macos() -> None:
+    workflow_data = _run_all_tests_workflow()
+    detector = workflow_data["jobs"]["macos-metal-change-detector"]
+    run_script = str(
+        _workflow_step_by_name(
+            detector, "Detect desktop runtime or packaging changes"
+        ).get("run", "")
+    )
+
+    manual_branch = run_script.split(
+        'if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then', 1
+    )[1].split("fi", 1)[0]
+    assert "run_macos_metal=true" in manual_branch
+    assert "exit 0" in manual_branch
+
+
+def test_run_all_tests_pr_removed_macos_side_skip_detection() -> None:
+    workflow_data = _run_all_tests_workflow()
+    macos_job = workflow_data["jobs"]["macos-metal-runtime-bootstrap"]
+    macos_step_names = {str(step.get("name", "")) for step in _job_steps(macos_job)}
+
+    assert "Detect desktop runtime or packaging changes" not in macos_step_names
+    assert "Summarize skipped Metal bootstrap" not in macos_step_names
 
 
 def test_run_all_tests_pr_jobs_do_not_continue_on_error() -> None:


### PR DESCRIPTION
### Motivation
- Avoid allocating a billed macOS runner on pull requests that do not touch the Metal-capable embedded Python runtime or its bootstrap inputs.
- Preserve the focused native Metal bootstrap for relevant changes and manual dispatches while keeping the workflow concurrency/cancellation behavior and existing native bootstrap invariants.

### Description
- Added a cheap `ubuntu-latest` detector job `macos-metal-change-detector` that checks PR changed files, has a 5 minute timeout, `permissions: contents: read`, a full checkout (`fetch-depth: 0`), and exposes `outputs.run_macos_metal` for downstream gating.
- The detector keeps the existing path selection contract for triggering macOS work: `desktop-tauri/src-tauri/python/**`, matching `desktop-tauri/scripts/prepare_*python_runtime*`, root `requirements.txt`, and `.github/workflows/run-all-tests-pr.yml`, and it always emits `run_macos_metal=true` on `workflow_dispatch`.
- Gated the `macos-metal-runtime-bootstrap` job at the job level with `needs: macos-metal-change-detector` and `if: needs.macos-metal-change-detector.outputs.run_macos_metal == 'true'` while preserving `name: macOS Metal desktop runtime bootstrap` and `runs-on: macos-26`.
- Removed the old macOS-side change detection step, step-level `if` guards, and the skipped-bootstrap summary from the macOS job, while preserving the native Metal bootstrap commands and invariants including `CMAKE_ARGS=-DGGML_METAL=on`, `FORCE_CMAKE=1`, the `arm64` assertion, runtime preparation (`scripts/prepare_embedded_python_runtime.py`), executable assertion, and `pip check`.
- Tests: updated `tests/unit/test_workflow_ci_sentinel.py` with sentinel coverage asserting the detector runs on Linux, exposes the output, gates the macOS job at job-level, preserves `runs-on: macos-26`, keeps Linux job independence, enforces the path contract, and verifies the old macOS-side skip step is gone.

### Testing
- Ran unit sentinel suite: `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` and all tests passed (`33 passed`).
- Verified YAML parsing via the repo loader: `python - <<'PY'\nfrom pathlib import Path\nimport yaml\npath = Path('.github/workflows/run-all-tests-pr.yml')\ndata = yaml.load(path.read_text(encoding='utf-8'), Loader=yaml.BaseLoader)\nassert isinstance(data, dict)\nassert 'jobs' in data\nprint(f'{path} parsed with yaml.BaseLoader')\nPY` (succeeded).
- Ran `git diff --check` (no trailing whitespace or conflict markers found) and `pre-commit run --all-files` (hooks passed).

Relevant path contract (preserved)
- `desktop-tauri/src-tauri/python/**` triggers the macOS Metal bootstrap.
- `desktop-tauri/scripts/prepare_*python_runtime*` scripts trigger the macOS Metal bootstrap.
- Root `requirements.txt` triggers the macOS Metal bootstrap.
- Edits to `.github/workflows/run-all-tests-pr.yml` trigger the macOS Metal bootstrap.
- Manual `workflow_dispatch` always requests macOS execution.

Verification outcome
- The detector job runs on `ubuntu-latest` and emits `run_macos_metal` which is consumed by the macOS job at the job level; the `macos-metal-runtime-bootstrap` job retains `runs-on: macos-26` but is now skipped by GitHub before a macOS runner is allocated when `run_macos_metal=false`.
- Automated checks (`pytest`, YAML parse, `git diff --check`, and `pre-commit`) all succeeded.

Confirmation
- Irrelevant PRs that do not touch the preserved path contract now skip the `macos-metal-runtime-bootstrap` job before GitHub assigns a `macos-26` runner, reducing unnecessary billed macOS allocations.

Files changed: `.github/workflows/run-all-tests-pr.yml`, `tests/unit/test_workflow_ci_sentinel.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62970cb7cc832fb04a036ef9c54a34)