### PR TITLE
Gate macOS Metal bootstrap with cheap Ubuntu detector to avoid macOS runner allocation

### DIFF
--- a/.github/workflows/run-all-tests-pr.yml
+++ b/.github/workflows/run-all-tests-pr.yml
@@ -98,8 +98,42 @@ jobs:
           if-no-files-found: error
 
 
+  detect-macos-metal-runtime-changes:
+    name: Detect macOS Metal desktop runtime changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      run_macos_metal: ${{ steps.detect.outputs.run_macos_metal }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect desktop runtime or packaging changes
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run_macos_metal=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD)"
+          printf '%s\n' "$changed_files"
+          if printf '%s\n' "$changed_files" | grep -Eq '^(desktop-tauri/src-tauri/python/|desktop-tauri/scripts/prepare_.*python_runtime|requirements\.txt$|\.github/workflows/run-all-tests-pr\.yml$)'; then
+            echo "run_macos_metal=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_macos_metal=false" >> "$GITHUB_OUTPUT"
+          fi
+
   macos-metal-runtime-bootstrap:
     name: macOS Metal desktop runtime bootstrap
+    needs: detect-macos-metal-runtime-changes
+    if: ${{ needs.detect-macos-metal-runtime-changes.outputs.run_macos_metal == 'true' }}
     runs-on: macos-26
     timeout-minutes: 45
     permissions:
@@ -109,26 +143,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect desktop runtime or packaging changes
-        id: changes
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
-            changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD)"
-          else
-            changed_files="desktop-tauri/src-tauri/python/manual-dispatch"
-          fi
-          printf '%s\n' "$changed_files"
-          if printf '%s\n' "$changed_files" | grep -Eq '^(desktop-tauri/src-tauri/python/|desktop-tauri/scripts/prepare_.*python_runtime|requirements\.txt$)'; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Set up Python 3.11
-        if: steps.changes.outputs.run == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -136,7 +151,6 @@ jobs:
           cache-dependency-path: requirements.txt
 
       - name: Prepare and verify Metal-capable embedded Python runtime
-        if: steps.changes.outputs.run == 'true'
         working-directory: desktop-tauri
         env:
           CMAKE_ARGS: -DGGML_METAL=on
@@ -148,7 +162,3 @@ jobs:
           python scripts/prepare_embedded_python_runtime.py
           test -x src-tauri/python-runtime/bin/python3
           src-tauri/python-runtime/bin/python3 -m pip check
-
-      - name: Summarize skipped Metal bootstrap
-        if: steps.changes.outputs.run != 'true'
-        run: echo "No desktop Python runtime, packaging bootstrap, or requirements.txt changes detected; skipping focused macOS Metal bootstrap." >> "$GITHUB_STEP_SUMMARY"

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -54,6 +54,41 @@ def _run_all_tests_jobs() -> dict[str, dict]:
     }
 
 
+def _run_macos_metal_detector_job() -> dict:
+    workflow_data = _run_all_tests_workflow()
+    job = workflow_data["jobs"].get("detect-macos-metal-runtime-changes")
+    assert job, "run-all-tests-pr.yml must define a cheap Linux detector job"
+    return job
+
+
+def _macos_metal_bootstrap_job() -> dict:
+    workflow_data = _run_all_tests_workflow()
+    job = workflow_data["jobs"].get("macos-metal-runtime-bootstrap")
+    assert job, (
+        "Desktop Python runtime or packaging changes need a focused macOS Metal "
+        "bootstrap guardrail now that the duplicate macOS full-suite job is removed."
+    )
+    return job
+
+
+def _macos_metal_detector_would_run(
+    changed_files: list[str], event_name: str = "pull_request"
+) -> bool:
+    if event_name == "workflow_dispatch":
+        return True
+    relevant_prefixes = ("desktop-tauri/src-tauri/python/",)
+    return any(
+        path.startswith(relevant_prefixes)
+        or (
+            path.startswith("desktop-tauri/scripts/prepare_")
+            and "python_runtime" in path
+        )
+        or path == "requirements.txt"
+        or path == ".github/workflows/run-all-tests-pr.yml"
+        for path in changed_files
+    )
+
+
 def _job_steps(job: dict) -> list[dict]:
     steps = job.get("steps", [])
     assert isinstance(steps, list), "workflow job steps must be a list"
@@ -477,23 +512,54 @@ def test_linux_run_all_tests_pr_job_invokes_the_full_suite() -> None:
     )
 
 
-def test_run_all_tests_pr_has_path_gated_macos_metal_bootstrap() -> None:
-    workflow_data = _run_all_tests_workflow()
-    job = workflow_data["jobs"].get("macos-metal-runtime-bootstrap")
+def test_run_all_tests_pr_has_linux_macos_metal_change_detector() -> None:
+    job = _run_macos_metal_detector_job()
+    job_text = yaml.dump(job, sort_keys=True)
+    job_runs = _step_runs(job)
 
-    assert job, (
-        "Desktop Python runtime or packaging changes need a focused macOS Metal "
-        "bootstrap guardrail now that the duplicate macOS full-suite job is removed."
+    assert job["runs-on"] == "ubuntu-latest"
+    assert job["timeout-minutes"] == "5"
+    assert job["permissions"] == {"contents": "read"}
+    assert job["outputs"]["run_macos_metal"] == (
+        "${{ steps.detect.outputs.run_macos_metal }}"
+    )
+    assert "run_macos_metal=true" in job_runs
+    assert "run_macos_metal=false" in job_runs
+    assert "github.event_name" in job_runs
+    assert "workflow_dispatch" in job_runs
+    assert "desktop-tauri/src-tauri/python/" in job_runs
+    assert "desktop-tauri/scripts/prepare_.*python_runtime" in job_runs
+    assert r"requirements\.txt$" in job_runs
+    assert r"\.github/workflows/run-all-tests-pr\.yml$" in job_runs
+
+    checkout_steps = [
+        step
+        for step in _job_steps(job)
+        if str(step.get("uses", "")).startswith("actions/checkout@")
+    ]
+    assert len(checkout_steps) == 1
+    assert checkout_steps[0].get("with", {}).get("fetch-depth") == "0"
+
+
+def test_run_all_tests_pr_macos_metal_bootstrap_is_job_gated() -> None:
+    job = _macos_metal_bootstrap_job()
+    job_text = yaml.dump(job, sort_keys=True)
+
+    assert job["name"] == "macOS Metal desktop runtime bootstrap"
+    assert job["needs"] == "detect-macos-metal-runtime-changes"
+    assert (
+        job["if"]
+        == "${{ needs.detect-macos-metal-runtime-changes.outputs.run_macos_metal == 'true' }}"
     )
     assert job["runs-on"] == "macos-26"
-    job_text = yaml.dump(job, sort_keys=True)
-    assert "desktop-tauri/src-tauri/python/" in job_text
-    assert "requirements.txt" in job_text
     assert "CMAKE_ARGS" in job_text
     assert "-DGGML_METAL=on" in job_text
     assert "FORCE_CMAKE" in job_text
+    assert 'test "$(uname -m)" = "arm64"' in job_text
     assert "scripts/prepare_embedded_python_runtime.py" in job_text
-    assert "steps.changes.outputs.run == 'true'" in job_text
+    assert "test -x src-tauri/python-runtime/bin/python3" in job_text
+    assert "src-tauri/python-runtime/bin/python3 -m pip check" in job_text
+    assert "steps.changes.outputs.run" not in job_text
 
     checkout_steps = [
         step
@@ -503,6 +569,33 @@ def test_run_all_tests_pr_has_path_gated_macos_metal_bootstrap() -> None:
     assert len(checkout_steps) == 1
     assert checkout_steps[0]["uses"] == "actions/checkout@v5"
     assert checkout_steps[0].get("with", {}).get("fetch-depth") == "0"
+
+
+def test_run_all_tests_pr_macos_metal_detector_path_contract() -> None:
+    relevant_examples = {
+        "embedded runtime": ["desktop-tauri/src-tauri/python/server.py"],
+        "prepare runtime script": [
+            "desktop-tauri/scripts/prepare_embedded_python_runtime.py"
+        ],
+        "root requirements": ["requirements.txt"],
+        "workflow self-validation": [".github/workflows/run-all-tests-pr.yml"],
+    }
+
+    assert not _macos_metal_detector_would_run(["README.md"])
+    assert not _macos_metal_detector_would_run(["desktop-tauri/package.json"])
+    assert _macos_metal_detector_would_run([], event_name="workflow_dispatch")
+    for label, paths in relevant_examples.items():
+        assert _macos_metal_detector_would_run(paths), label
+
+
+def test_run_all_tests_pr_macos_side_detection_steps_are_removed() -> None:
+    job = _macos_metal_bootstrap_job()
+    step_names = {str(step.get("name", "")) for step in _job_steps(job)}
+    job_text = yaml.dump(job, sort_keys=True)
+
+    assert "Detect desktop runtime or packaging changes" not in step_names
+    assert "Summarize skipped Metal bootstrap" not in step_names
+    assert "No desktop Python runtime" not in job_text
 
 
 def test_run_all_tests_pr_jobs_do_not_continue_on_error() -> None:


### PR DESCRIPTION
### Motivation
- Prevent macOS `macos-26` runners from being allocated for PRs that do not touch the native Metal-capable embedded Python runtime by moving change detection off the macOS job. 
- Preserve the focused macOS Metal bootstrap for true runtime/bootstrap changes and manual `workflow_dispatch` runs while keeping the overall PR workflow visible and minimal.

### Description
- Add a new cheap detector job `detect-macos-metal-runtime-changes` that runs on `ubuntu-latest`, has `permissions: contents: read`, a 5-minute timeout, a full-history checkout (`fetch-depth: 0`), and exposes `outputs.run_macos_metal` from the detector step. 
- Move the changed-file detection logic to that detector and make `workflow_dispatch` always set `run_macos_metal=true`, while PRs only set it if the change matches the preserved path contract. 
- Gate the existing `macos-metal-runtime-bootstrap` job at the job level with `needs: detect-macos-metal-runtime-changes` and `if: ${{ needs.detect-macos-metal-runtime-changes.outputs.run_macos_metal == 'true' }}`, preserving the visible job name and `runs-on: macos-26`. 
- Remove the redundant macOS-side detection step, conditional `if` on setup/build steps, and the skipped-bootstrap summary step while leaving all Metal bootstrap commands and invariants unchanged, including `CMAKE_ARGS=-DGGML_METAL=on`, `FORCE_CMAKE=1`, the `arm64` assertion, runtime preparation, executable assertion, and `pip check`. 
- Add focused sentinel tests in `tests/unit/test_workflow_ci_sentinel.py` covering the new detector job, detector output consumption, job-level gating, the path contract, manual dispatch behavior, and removal of the macOS-side detection/skip steps.

Relevant path contract (detector will trigger macOS bootstrap when any of these change):
- `desktop-tauri/src-tauri/python/**`
- `desktop-tauri/scripts/prepare_*python_runtime*` (matching the existing prepare script regex)
- root `requirements.txt`
- `.github/workflows/run-all-tests-pr.yml` (workflow self-validation)
- Manual `workflow_dispatch` always requests macOS (`run_macos_metal=true`).

### Testing
- Ran unit sentinel tests with `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` and observed `32 passed` (all tests passed). 
- Parsed the modified workflow with the repo YAML loader using `python -c "import yaml; yaml.load(..., Loader=yaml.BaseLoader)"` and confirmed the file parses and `jobs` exist (parsing passed). 
- Ran `git diff --check` and confirmed no trailing/whitespace issues (passed). 
- Ran repository checks via `pre-commit run --all-files` and observed the hooks passed (passed). 

Verification notes and limits:
- Verified locally that the detector job runs on Linux and exposes `outputs.run_macos_metal`, that the macOS job has job-level gating and retains `runs-on: macos-26`, and that the old macOS-side detection/skip steps are removed. 
- Environment note: this execution environment had no configured `origin` remote, so remote fetch/fast-forward against `origin/main` could not be performed here; all checks above were run against the local working tree.

Conclusion: irrelevant PRs that do not touch any of the listed path categories or that are not manual dispatches will now skip the `macOS Metal desktop runtime bootstrap` job before a `macos-26` runner is allocated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6297112004832fa37597c33d6f1667)