### PR TITLE
Gate macOS Metal bootstrap before runner allocation

### DIFF
--- a/.github/workflows/run-all-tests-pr.yml
+++ b/.github/workflows/run-all-tests-pr.yml
@@ -98,37 +98,49 @@ jobs:
           if-no-files-found: error
 
 
-  macos-metal-runtime-bootstrap:
-    name: macOS Metal desktop runtime bootstrap
-    runs-on: macos-26
-    timeout-minutes: 45
+  detect-macos-metal-runtime-changes:
+    name: Detect macOS Metal desktop runtime changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
+    outputs:
+      run_macos_metal: ${{ steps.detect.outputs.run_macos_metal }}
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Detect desktop runtime or packaging changes
-        id: changes
+        id: detect
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
-            changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD)"
-          else
-            changed_files="desktop-tauri/src-tauri/python/manual-dispatch"
-          fi
-          printf '%s\n' "$changed_files"
-          if printf '%s\n' "$changed_files" | grep -Eq '^(desktop-tauri/src-tauri/python/|desktop-tauri/scripts/prepare_.*python_runtime|requirements\.txt$)'; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run_macos_metal=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
+          changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}"..."${{ github.event.pull_request.head.sha }}")"
+          printf '%s\n' "$changed_files"
+          if printf '%s\n' "$changed_files" | grep -Eq '^(desktop-tauri/src-tauri/python/|desktop-tauri/scripts/prepare_.*python_runtime|requirements\.txt$|\.github/workflows/run-all-tests-pr\.yml$)'; then
+            echo "run_macos_metal=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_macos_metal=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  macos-metal-runtime-bootstrap:
+    name: macOS Metal desktop runtime bootstrap
+    needs: detect-macos-metal-runtime-changes
+    if: needs.detect-macos-metal-runtime-changes.outputs.run_macos_metal == 'true'
+    runs-on: macos-26
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
       - name: Set up Python 3.11
-        if: steps.changes.outputs.run == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -136,7 +148,6 @@ jobs:
           cache-dependency-path: requirements.txt
 
       - name: Prepare and verify Metal-capable embedded Python runtime
-        if: steps.changes.outputs.run == 'true'
         working-directory: desktop-tauri
         env:
           CMAKE_ARGS: -DGGML_METAL=on
@@ -148,7 +159,3 @@ jobs:
           python scripts/prepare_embedded_python_runtime.py
           test -x src-tauri/python-runtime/bin/python3
           src-tauri/python-runtime/bin/python3 -m pip check
-
-      - name: Summarize skipped Metal bootstrap
-        if: steps.changes.outputs.run != 'true'
-        run: echo "No desktop Python runtime, packaging bootstrap, or requirements.txt changes detected; skipping focused macOS Metal bootstrap." >> "$GITHUB_STEP_SUMMARY"

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -54,6 +54,46 @@ def _run_all_tests_jobs() -> dict[str, dict]:
     }
 
 
+def _run_all_tests_workflow_jobs() -> dict:
+    jobs = _run_all_tests_workflow().get("jobs", {})
+    assert isinstance(jobs, dict), "run-all-tests-pr.yml must define jobs"
+    return jobs
+
+
+def _run_all_tests_macos_detector_job() -> dict:
+    jobs = _run_all_tests_workflow_jobs()
+    job = jobs.get("detect-macos-metal-runtime-changes")
+    assert isinstance(job, dict), (
+        "run-all-tests-pr.yml must define a Linux macOS Metal detector job"
+    )
+    return job
+
+
+def _run_all_tests_macos_job() -> dict:
+    jobs = _run_all_tests_workflow_jobs()
+    job = jobs.get("macos-metal-runtime-bootstrap")
+    assert isinstance(job, dict), (
+        "run-all-tests-pr.yml must define the focused macOS Metal job"
+    )
+    return job
+
+
+def _macos_detector_requests_metal(event_name: str, changed_files: list[str]) -> bool:
+    if event_name == "workflow_dispatch":
+        return True
+    relevant_prefixes = ("desktop-tauri/src-tauri/python/",)
+    relevant_exact = {"requirements.txt", ".github/workflows/run-all-tests-pr.yml"}
+    return any(
+        path.startswith(relevant_prefixes)
+        or path in relevant_exact
+        or (
+            path.startswith("desktop-tauri/scripts/prepare_")
+            and "python_runtime" in path.removeprefix("desktop-tauri/scripts/prepare_")
+        )
+        for path in changed_files
+    )
+
+
 def _job_steps(job: dict) -> list[dict]:
     steps = job.get("steps", [])
     assert isinstance(steps, list), "workflow job steps must be a list"
@@ -477,32 +517,75 @@ def test_linux_run_all_tests_pr_job_invokes_the_full_suite() -> None:
     )
 
 
-def test_run_all_tests_pr_has_path_gated_macos_metal_bootstrap() -> None:
-    workflow_data = _run_all_tests_workflow()
-    job = workflow_data["jobs"].get("macos-metal-runtime-bootstrap")
+def test_run_all_tests_pr_has_linux_macos_metal_detector_output() -> None:
+    detector = _run_all_tests_macos_detector_job()
 
-    assert job, (
-        "Desktop Python runtime or packaging changes need a focused macOS Metal "
-        "bootstrap guardrail now that the duplicate macOS full-suite job is removed."
-    )
+    assert detector["runs-on"] == "ubuntu-latest"
+    assert detector["timeout-minutes"] == "5"
+    assert detector["permissions"] == {"contents": "read"}
+    assert detector["outputs"]["run_macos_metal"] == "${{ steps.detect.outputs.run_macos_metal }}"
+    detector_text = yaml.dump(detector, sort_keys=True)
+    assert "fetch-depth: '0'" in detector_text
+    assert "github.event.pull_request.base.sha" in detector_text
+    assert "github.event.pull_request.head.sha" in detector_text
+    assert "run_macos_metal=true" in detector_text
+    assert "workflow_dispatch" in detector_text
+
+
+def test_run_all_tests_pr_has_job_gated_macos_metal_bootstrap() -> None:
+    job = _run_all_tests_macos_job()
+
+    assert job["name"] == "macOS Metal desktop runtime bootstrap"
     assert job["runs-on"] == "macos-26"
+    assert job["needs"] == "detect-macos-metal-runtime-changes"
+    assert job["if"] == "needs.detect-macos-metal-runtime-changes.outputs.run_macos_metal == 'true'"
     job_text = yaml.dump(job, sort_keys=True)
-    assert "desktop-tauri/src-tauri/python/" in job_text
-    assert "requirements.txt" in job_text
     assert "CMAKE_ARGS" in job_text
     assert "-DGGML_METAL=on" in job_text
     assert "FORCE_CMAKE" in job_text
+    assert "test \"$(uname -m)\" = \"arm64\"" in job_text
     assert "scripts/prepare_embedded_python_runtime.py" in job_text
-    assert "steps.changes.outputs.run == 'true'" in job_text
+    assert "test -x src-tauri/python-runtime/bin/python3" in job_text
+    assert "src-tauri/python-runtime/bin/python3 -m pip check" in job_text
+    assert "steps.changes.outputs.run" not in job_text
 
-    checkout_steps = [
-        step
-        for step in _job_steps(job)
-        if str(step.get("uses", "")).startswith("actions/checkout@")
-    ]
-    assert len(checkout_steps) == 1
-    assert checkout_steps[0]["uses"] == "actions/checkout@v5"
-    assert checkout_steps[0].get("with", {}).get("fetch-depth") == "0"
+
+def test_run_all_tests_pr_linux_full_suite_stays_independent() -> None:
+    linux_job = _run_all_tests_workflow_jobs()["linux-run-all-tests"]
+
+    assert "needs" not in linux_job
+
+
+def test_run_all_tests_pr_macos_detector_path_contract() -> None:
+    assert not _macos_detector_requests_metal(
+        "pull_request",
+        [
+            "README.md",
+            "desktop-tauri/src-tauri/src/main.rs",
+            "desktop-tauri/scripts/prepare_release_notes.py",
+        ],
+    )
+    for path in (
+        "desktop-tauri/src-tauri/python/requirements.txt",
+        "desktop-tauri/src-tauri/python/tokenplace_runtime/server.py",
+        "desktop-tauri/scripts/prepare_embedded_python_runtime.py",
+        "desktop-tauri/scripts/prepare_macos_python_runtime.sh",
+        "requirements.txt",
+        ".github/workflows/run-all-tests-pr.yml",
+    ):
+        assert _macos_detector_requests_metal("pull_request", [path]), path
+    assert _macos_detector_requests_metal("workflow_dispatch", [])
+
+
+def test_run_all_tests_pr_removed_macos_side_detection_and_skip_summary() -> None:
+    job = _run_all_tests_macos_job()
+    step_names = {str(step.get("name", "")) for step in _job_steps(job)}
+    job_text = yaml.dump(job, sort_keys=True)
+
+    assert "Detect desktop runtime or packaging changes" not in step_names
+    assert "Summarize skipped Metal bootstrap" not in step_names
+    assert "No desktop Python runtime" not in job_text
+    assert "steps.changes.outputs.run" not in job_text
 
 
 def test_run_all_tests_pr_jobs_do_not_continue_on_error() -> None:


### PR DESCRIPTION
### Motivation
- Avoid billing a `macos-26` runner on PRs that do not touch the Metal-capable embedded Python runtime surface while preserving focused macOS verification when needed.
- Keep the focused native Metal bootstrap for relevant changes and `workflow_dispatch` (manual) runs and make the decision cheaply on Ubuntu before any macOS runner is allocated.

### Description
- Added a cheap detector job `detect-macos-metal-runtime-changes` that runs on `ubuntu-latest` with a 5-minute timeout, `permissions: contents: read`, a full-history checkout, and a stable output `run_macos_metal` that is true for `workflow_dispatch` and when paths match the relevant contract in `run-all-tests-pr.yml`.
- Gated the existing `macos-metal-runtime-bootstrap` job at the job level using `needs: detect-macos-metal-runtime-changes` and `if: needs.detect-macos-metal-runtime-changes.outputs.run_macos_metal == 'true'` while keeping the visible job name and `runs-on: macos-26` so relevant runs still get the same macOS bootstrap.
- Removed the macOS-side change-detection step and skip-summary step from the macOS job but preserved all actual bootstrap commands and invariants including `CMAKE_ARGS=-DGGML_METAL=on`, `FORCE_CMAKE=1`, the `arm64` assertion, runtime preparation, executable assertion, and `pip check`.
- Updated `tests/unit/test_workflow_ci_sentinel.py` to assert the detector runs on Linux, exposes `run_macos_metal`, that the macOS job is job-gated and still `runs-on: macos-26`, that `workflow_dispatch` forces macOS, that irrelevant changes do not request macOS, and that the old macOS-side detection/skip-summary steps are removed.
- Path contract preserved: macOS Metal bootstrap runs when changes touch `desktop-tauri/src-tauri/python/**`, `desktop-tauri/scripts/prepare_*python_runtime*` (the existing prepare-* pattern), `requirements.txt` at repo root, or edits to ` .github/workflows/run-all-tests-pr.yml`.

### Testing
- Ran the focused sentinel suite: `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` and it passed: `33 passed`.
- Validated workflow YAML parsing with the repo loader: `python -c "import yaml; yaml.load(open('.github/workflows/run-all-tests-pr.yml').read(), Loader=yaml.BaseLoader)` succeeded and the workflow parsed with `3` jobs.
- Ran repository checks: `pre-commit run --all-files` completed successfully (project checks passed).
- Ran `git diff --check` and no whitespace/patch errors were reported.

Verification result and confirmation: the detector job now executes on `ubuntu-latest` and emits `run_macos_metal` which the macOS job consumes at the job level; therefore irrelevant pull requests no longer request or allocate a `macos-26` runner (the job is skipped by GitHub before runner allocation), while changes matching the preserved path contract and manual `workflow_dispatch` runs still cause the macOS Metal bootstrap to run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62970296f4832f8cdf970d09e1e035)