### PR TITLE
Gate macOS Metal PR bootstrap before runner allocation

### DIFF
--- a/.github/workflows/run-all-tests-pr.yml
+++ b/.github/workflows/run-all-tests-pr.yml
@@ -98,12 +98,14 @@ jobs:
           if-no-files-found: error
 
 
-  macos-metal-runtime-bootstrap:
-    name: macOS Metal desktop runtime bootstrap
-    runs-on: macos-26
-    timeout-minutes: 45
+  detect-macos-metal-runtime-changes:
+    name: Detect macOS Metal desktop runtime changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
+    outputs:
+      run_macos_metal: ${{ steps.changes.outputs.run_macos_metal }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -114,21 +116,35 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
-            changed_files="$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD)"
-          else
-            changed_files="desktop-tauri/src-tauri/python/manual-dispatch"
-          fi
-          printf '%s\n' "$changed_files"
-          if printf '%s\n' "$changed_files" | grep -Eq '^(desktop-tauri/src-tauri/python/|desktop-tauri/scripts/prepare_.*python_runtime|requirements\.txt$)'; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run_macos_metal=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
+          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+          changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}"...HEAD)"
+          printf '%s\n' "$changed_files"
+          if printf '%s\n' "$changed_files" | grep -Eq '^(desktop-tauri/src-tauri/python/|desktop-tauri/scripts/prepare_.*python_runtime|requirements\.txt$|\.github/workflows/run-all-tests-pr\.yml$)'; then
+            echo "run_macos_metal=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_macos_metal=false" >> "$GITHUB_OUTPUT"
+          fi
+
+
+  macos-metal-runtime-bootstrap:
+    name: macOS Metal desktop runtime bootstrap
+    needs: detect-macos-metal-runtime-changes
+    if: needs.detect-macos-metal-runtime-changes.outputs.run_macos_metal == 'true'
+    runs-on: macos-26
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
       - name: Set up Python 3.11
-        if: steps.changes.outputs.run == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -136,7 +152,6 @@ jobs:
           cache-dependency-path: requirements.txt
 
       - name: Prepare and verify Metal-capable embedded Python runtime
-        if: steps.changes.outputs.run == 'true'
         working-directory: desktop-tauri
         env:
           CMAKE_ARGS: -DGGML_METAL=on
@@ -148,7 +163,3 @@ jobs:
           python scripts/prepare_embedded_python_runtime.py
           test -x src-tauri/python-runtime/bin/python3
           src-tauri/python-runtime/bin/python3 -m pip check
-
-      - name: Summarize skipped Metal bootstrap
-        if: steps.changes.outputs.run != 'true'
-        run: echo "No desktop Python runtime, packaging bootstrap, or requirements.txt changes detected; skipping focused macOS Metal bootstrap." >> "$GITHUB_STEP_SUMMARY"

--- a/tests/unit/test_workflow_ci_sentinel.py
+++ b/tests/unit/test_workflow_ci_sentinel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 import stat
 import subprocess
 from pathlib import Path
@@ -53,6 +54,33 @@ def _run_all_tests_jobs() -> dict[str, dict]:
         if isinstance(job, dict) and "run_all_tests.sh" in str(job.get("name", ""))
     }
 
+
+def _macos_metal_detector_job(workflow_data: dict) -> dict:
+    job = workflow_data["jobs"].get("detect-macos-metal-runtime-changes")
+    assert job, "run-all-tests-pr.yml must define a cheap Linux detector before macOS"
+    return job
+
+
+def _macos_metal_bootstrap_job(workflow_data: dict) -> dict:
+    job = workflow_data["jobs"].get("macos-metal-runtime-bootstrap")
+    assert job, (
+        "Desktop Python runtime or packaging changes need a focused macOS Metal "
+        "bootstrap guardrail now that the duplicate macOS full-suite job is removed."
+    )
+    return job
+
+
+def _macos_metal_detector_regex() -> re.Pattern[str]:
+    workflow_data = _run_all_tests_workflow()
+    detector_runs = _step_runs(_macos_metal_detector_job(workflow_data))
+    match = re.search(r"grep -Eq '([^']+)'", detector_runs)
+    assert match, "macOS Metal detector must use one grep -Eq path-selection regex"
+    return re.compile(match.group(1))
+
+
+def _macos_metal_requested_for_paths(paths: list[str]) -> bool:
+    detector_regex = _macos_metal_detector_regex()
+    return any(detector_regex.search(path) for path in paths)
 
 def _job_steps(job: dict) -> list[dict]:
     steps = job.get("steps", [])
@@ -477,23 +505,50 @@ def test_linux_run_all_tests_pr_job_invokes_the_full_suite() -> None:
     )
 
 
-def test_run_all_tests_pr_has_path_gated_macos_metal_bootstrap() -> None:
+def test_run_all_tests_pr_has_linux_macos_metal_change_detector() -> None:
     workflow_data = _run_all_tests_workflow()
-    job = workflow_data["jobs"].get("macos-metal-runtime-bootstrap")
+    detector = _macos_metal_detector_job(workflow_data)
 
-    assert job, (
-        "Desktop Python runtime or packaging changes need a focused macOS Metal "
-        "bootstrap guardrail now that the duplicate macOS full-suite job is removed."
+    assert detector["runs-on"] == "ubuntu-latest"
+    assert detector["timeout-minutes"] == "5"
+    assert detector.get("permissions", {}).get("contents") == "read"
+    assert detector.get("outputs", {}).get("run_macos_metal") == (
+        "${{ steps.changes.outputs.run_macos_metal }}"
+    )
+    detector_runs = _step_runs(detector)
+    assert "github.event.pull_request.base.sha" in detector_runs
+    assert "run_macos_metal=true" in detector_runs
+    assert "run_macos_metal=false" in detector_runs
+
+    checkout_steps = [
+        step
+        for step in _job_steps(detector)
+        if str(step.get("uses", "")).startswith("actions/checkout@")
+    ]
+    assert len(checkout_steps) == 1
+    assert checkout_steps[0]["uses"] == "actions/checkout@v5"
+    assert checkout_steps[0].get("with", {}).get("fetch-depth") == "0"
+
+
+def test_run_all_tests_pr_has_job_gated_macos_metal_bootstrap() -> None:
+    workflow_data = _run_all_tests_workflow()
+    job = _macos_metal_bootstrap_job(workflow_data)
+
+    assert job["name"] == "macOS Metal desktop runtime bootstrap"
+    assert job["needs"] == "detect-macos-metal-runtime-changes"
+    assert job["if"] == (
+        "needs.detect-macos-metal-runtime-changes.outputs.run_macos_metal == 'true'"
     )
     assert job["runs-on"] == "macos-26"
     job_text = yaml.dump(job, sort_keys=True)
-    assert "desktop-tauri/src-tauri/python/" in job_text
-    assert "requirements.txt" in job_text
     assert "CMAKE_ARGS" in job_text
     assert "-DGGML_METAL=on" in job_text
     assert "FORCE_CMAKE" in job_text
+    assert 'test "$(uname -m)" = "arm64"' in job_text
     assert "scripts/prepare_embedded_python_runtime.py" in job_text
-    assert "steps.changes.outputs.run == 'true'" in job_text
+    assert "test -x src-tauri/python-runtime/bin/python3" in job_text
+    assert "src-tauri/python-runtime/bin/python3 -m pip check" in job_text
+    assert "steps.changes.outputs.run" not in job_text
 
     checkout_steps = [
         step
@@ -503,6 +558,53 @@ def test_run_all_tests_pr_has_path_gated_macos_metal_bootstrap() -> None:
     assert len(checkout_steps) == 1
     assert checkout_steps[0]["uses"] == "actions/checkout@v5"
     assert checkout_steps[0].get("with", {}).get("fetch-depth") == "0"
+
+
+def test_run_all_tests_pr_macos_metal_detector_path_contract() -> None:
+    relevant_paths = [
+        "desktop-tauri/src-tauri/python/requirements.txt",
+        "desktop-tauri/src-tauri/python/tokenplace_runtime/server.py",
+        "desktop-tauri/scripts/prepare_embedded_python_runtime.py",
+        "desktop-tauri/scripts/prepare_macos_python_runtime.sh",
+        "requirements.txt",
+        ".github/workflows/run-all-tests-pr.yml",
+    ]
+    irrelevant_paths = [
+        "README.md",
+        "docs/architecture/api_v1_e2ee_relay.md",
+        "desktop-tauri/src/App.tsx",
+        "desktop-tauri/scripts/check_desktop_python.py",
+        ".github/workflows/desktop-release.yml",
+        "requirements-dev.txt",
+    ]
+
+    for path in relevant_paths:
+        assert _macos_metal_requested_for_paths([path]), (
+            f"{path} must request the focused macOS Metal bootstrap"
+        )
+    for path in irrelevant_paths:
+        assert not _macos_metal_requested_for_paths([path]), (
+            f"{path} must not request macOS runner allocation"
+        )
+
+
+def test_run_all_tests_pr_macos_metal_detector_manual_dispatch_runs() -> None:
+    detector_runs = _step_runs(_macos_metal_detector_job(_run_all_tests_workflow()))
+
+    manual_dispatch_branch = detector_runs.split(
+        'if [ "${{ github.event_name }}" != "pull_request" ]; then', 1
+    )[1].split("fi", 1)[0]
+    assert "run_macos_metal=true" in manual_dispatch_branch
+    assert "exit 0" in manual_dispatch_branch
+
+
+def test_run_all_tests_pr_removed_macos_side_change_detection_steps() -> None:
+    workflow_data = _run_all_tests_workflow()
+    job = _macos_metal_bootstrap_job(workflow_data)
+    step_names = {str(step.get("name", "")) for step in _job_steps(job)}
+
+    assert "Detect desktop runtime or packaging changes" not in step_names
+    assert "Summarize skipped Metal bootstrap" not in step_names
 
 
 def test_run_all_tests_pr_jobs_do_not_continue_on_error() -> None:


### PR DESCRIPTION
### Motivation
- Avoid allocating a costly `macos-26` runner on PRs that do not touch the native Metal-capable embedded Python runtime while preserving focused macOS validation for relevant changes and manual dispatches.
- Maintain the existing path-selection contract so edits to the native bootstrap paths or the PR workflow still validate the native path.

### Description
- Add a cheap Ubuntu detector job `detect-macos-metal-runtime-changes` that runs on `ubuntu-latest`, has a 5-minute timeout, `permissions: contents: read`, checks out with history, and exposes a stable output `run_macos_metal`.
- Gate the existing `macos-metal-runtime-bootstrap` job at the job level with `needs: detect-macos-metal-runtime-changes` and `if: needs.detect-macos-metal-runtime-changes.outputs.run_macos_metal == 'true'`, preserving the visible job name and `runs-on: macos-26`.
- For `workflow_dispatch`, the detector unconditionally emits `run_macos_metal=true` so manual dispatches still run the macOS bootstrap.
- Remove the redundant macOS-side detection step, step-level `if` checks, and the skipped-bootstrap summary; preserve the Metal bootstrap commands and invariants (`CMAKE_ARGS=-DGGML_METAL=on`, `FORCE_CMAKE=1`, arm64 assertion, runtime preparation, executable assertion, and `pip check`).
- Keep `linux-run-all-tests` independent (no dependency on the detector or macOS job) and add sentinel test helpers that inspect the detector, job-level gating, path contract, and removed macOS-side steps.

### Testing
- Installed verification deps with `python -m pip install -r config/requirements_codex_verification.txt` (succeeded).
- Ran workflow sentinel unit tests with `python -m pytest tests/unit/test_workflow_ci_sentinel.py -q` which passed: `33 passed` (1.38s).
- Verified workflow YAML parses with `yaml.BaseLoader` via a small check script (succeeded).
- Ran `git diff --check` and `pre-commit run --all-files` as CI-style checks (both succeeded in this environment).

Path contract enforced by the detector (kept): `desktop-tauri/src-tauri/python/**`, `desktop-tauri/scripts/prepare_*python_runtime*`, root `requirements.txt`, and `.github/workflows/run-all-tests-pr.yml`; `workflow_dispatch` always requests the macOS bootstrap.

Verification summary: the detector runs on Ubuntu and exposes `run_macos_metal`, the macOS job now has job-level gating and retains `runs-on: macos-26`, irrelevant changes do not request macOS execution, relevant paths and manual dispatches still request macOS execution, and the old macOS-side detection and skip-summary steps were removed.

I confirm that irrelevant PRs now skip the `macos-metal-runtime-bootstrap` job before GitHub allocates a `macos-26` runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a629707e954832fa1cf361694f29679)