### PR TITLE
Fix packaged Windows runtime environment for desktop 0.1.6

### DIFF
--- a/desktop-tauri/package-lock.json
+++ b/desktop-tauri/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-place-desktop-tauri",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "token-place-desktop-tauri",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/desktop-tauri/package.json
+++ b/desktop-tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "token-place-desktop-tauri",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop-tauri/scripts/test_windows_installer_identity.py
+++ b/desktop-tauri/scripts/test_windows_installer_identity.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterable
 
-EXPECTED_VERSION = "0.1.5"
+EXPECTED_VERSION = "0.1.6"
 EXPECTED_MODEL_ARTIFACT_FILENAME = "Qwen3-8B-Q4_K_M.gguf"
 EXPECTED_RUNTIME_ID = "bundled-cpython-3.11-win-x86_64-cu124"
 RUNTIME_PROVENANCE_NAME = "embedded_python_runtime_provenance.json"

--- a/desktop-tauri/src-tauri/Cargo.lock
+++ b/desktop-tauri/src-tauri/Cargo.lock
@@ -4167,7 +4167,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-place-desktop-tauri"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "aes",
  "anyhow",

--- a/desktop-tauri/src-tauri/Cargo.toml
+++ b/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "token-place-desktop-tauri"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -1679,7 +1679,15 @@ def _desktop_platform() -> str:
 
 
 def _desktop_arch() -> str:
-    return platform_module.machine().lower().replace("amd64", "x86_64")
+    machine = platform_module.machine().lower().replace("amd64", "x86_64")
+    if _is_exact_packaged_runtime_layout() and _desktop_platform().startswith("win"):
+        attested = os.environ.get("TOKEN_PLACE_PACKAGED_TARGET_ARCH", "").strip().lower()
+        if attested != "x86_64" or machine not in {"", "x86_64"}:
+            return "architecture_mismatch"
+        if struct.calcsize("P") * 8 != 64 or not _bundled_runtime_provenance_valid():
+            return "architecture_mismatch"
+        return "x86_64"
+    return machine
 
 
 def _runtime_bootstrap_policy() -> RuntimeBootstrapPolicy:

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1770,10 +1770,18 @@ pub(crate) fn prepare_operator_bridge_launch(
         };
         let launcher = resolve_bundled_python_launcher_at_root(&resource_root, true)
             .map_err(OperatorBridgeLaunchPreparationError::from_launcher)?;
+        let import_root = resolve_packaged_import_root(&resource_root).ok_or_else(|| {
+            OperatorBridgeLaunchPreparationError::new(
+                "import_root_resolution",
+                "desktop_python_runtime_invalid",
+                "packaged_import_root_invalid",
+                "packaged import root is missing or ambiguous",
+            )
+        })?;
         return Ok(OperatorBridgeLaunchPreparation {
             bridge_script: bridge_script.to_string_lossy().into_owned(),
             launcher: Some(launcher),
-            import_root: resource_root.clone(),
+            import_root,
             resource_root,
             layout,
         });
@@ -1820,6 +1828,29 @@ pub(crate) fn prepare_operator_bridge_launch(
         import_root,
         layout,
     })
+}
+
+fn resolve_packaged_import_root(resource_root: &Path) -> Option<PathBuf> {
+    let canonical_resource = resource_root.canonicalize().ok()?;
+    let mut matches = Vec::new();
+    for relative in ["", "_up_", "_up_/_up_"] {
+        let candidate = canonical_resource.join(relative);
+        let Ok(candidate) = candidate.canonicalize() else {
+            continue;
+        };
+        if !candidate.starts_with(&canonical_resource) {
+            continue;
+        }
+        if candidate.join("utils").is_dir() && candidate.join("config.py").is_file() {
+            if !matches.contains(&candidate) {
+                matches.push(candidate);
+            }
+        }
+    }
+    match matches.as_slice() {
+        [root] => Some(root.clone()),
+        _ => None,
+    }
 }
 
 fn packaged_launcher_source_is_valid(

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -36,6 +36,12 @@ pub struct PythonLauncher {
 }
 
 impl PythonLauncher {
+    fn bundled_runtime_root(&self) -> Option<PathBuf> {
+        (self.source == PythonLauncherSource::BundledRuntime)
+            .then(|| Path::new(&self.program).parent().map(Path::to_path_buf))
+            .flatten()
+    }
+
     fn new(
         program: impl Into<String>,
         args: Vec<String>,
@@ -54,7 +60,10 @@ impl PythonLauncher {
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.args);
         if self.source == PythonLauncherSource::BundledRuntime {
-            sanitize_packaged_python_subprocess_env(&mut cmd);
+            sanitize_packaged_python_subprocess_env_at_root(
+                &mut cmd,
+                self.bundled_runtime_root().as_deref(),
+            );
         }
         cmd.arg("--version");
         cmd
@@ -64,7 +73,10 @@ impl PythonLauncher {
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.args);
         if self.source == PythonLauncherSource::BundledRuntime {
-            sanitize_packaged_python_subprocess_env(&mut cmd);
+            sanitize_packaged_python_subprocess_env_at_root(
+                &mut cmd,
+                self.bundled_runtime_root().as_deref(),
+            );
         }
         cmd.arg("-c");
         cmd.arg("import json,platform,struct,sys; print(json.dumps({'version': list(sys.version_info[:3]), 'machine': platform.machine(), 'pointer_bits': struct.calcsize('P') * 8, 'executable': sys.executable, 'prefix': sys.prefix}))");
@@ -78,7 +90,10 @@ impl PythonLauncher {
         let mut cmd = tokio::process::Command::new(&self.program);
         cmd.args(&self.args);
         if self.source == PythonLauncherSource::BundledRuntime {
-            sanitize_packaged_python_subprocess_env(&mut cmd);
+            sanitize_packaged_python_subprocess_env_at_root(
+                &mut cmd,
+                self.bundled_runtime_root().as_deref(),
+            );
         }
         cmd.arg(script_path);
         cmd
@@ -91,7 +106,10 @@ impl PythonLauncher {
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.args);
         if self.source == PythonLauncherSource::BundledRuntime {
-            sanitize_packaged_python_subprocess_env(&mut cmd);
+            sanitize_packaged_python_subprocess_env_at_root(
+                &mut cmd,
+                self.bundled_runtime_root().as_deref(),
+            );
         }
         cmd.arg(script_path);
         cmd
@@ -1197,6 +1215,23 @@ pub fn sanitize_packaged_python_subprocess_env<C>(command: &mut C)
 where
     C: PythonEnvCommand,
 {
+    sanitize_packaged_python_subprocess_env_at_root(command, None);
+}
+
+fn canonical_existing_directory(path: &Path) -> Option<PathBuf> {
+    path.canonicalize().ok().filter(|path| path.is_dir())
+}
+
+/// Build the immutable bundled-Python environment from verified paths.  In
+/// particular, PATH is never copied from the parent process: llama-cpp-python's
+/// Windows loader requires the variable to exist even though it prepends its
+/// own native-library directory.
+pub fn sanitize_packaged_python_subprocess_env_at_root<C>(
+    command: &mut C,
+    runtime_root: Option<&Path>,
+) where
+    C: PythonEnvCommand,
+{
     command.clear_env();
     for key in PACKAGED_ENV_FUNDAMENTALS {
         if let Some(value) = std::env::var_os(key) {
@@ -1219,6 +1254,45 @@ where
     }
     command.set_env("PYTHONNOUSERSITE", std::ffi::OsStr::new("1"));
     command.set_env("PYTHONDONTWRITEBYTECODE", std::ffi::OsStr::new("1"));
+
+    let mut trusted_path = Vec::new();
+    if let Some(runtime_root) = runtime_root.and_then(canonical_existing_directory) {
+        trusted_path.push(runtime_root.clone());
+        for native in [
+            runtime_root.join("Lib/site-packages/llama_cpp/lib"),
+            runtime_root.join("lib/site-packages/llama_cpp/lib"),
+        ] {
+            if let Some(native) = canonical_existing_directory(&native) {
+                if !trusted_path.contains(&native) {
+                    trusted_path.push(native);
+                }
+            }
+        }
+    }
+    if cfg!(target_os = "windows") {
+        if let Some(system_root) = std::env::var_os("SystemRoot")
+            .map(PathBuf::from)
+            .filter(|path| path.is_absolute())
+            .and_then(|path| canonical_existing_directory(&path))
+        {
+            if let Some(system32) = canonical_existing_directory(&system_root.join("System32")) {
+                if !trusted_path.contains(&system32) {
+                    trusted_path.push(system32);
+                }
+            }
+        }
+        // This value is an assertion made by the already-attested x64 bundle,
+        // not architecture evidence inherited from the host.
+        if runtime_root.is_some() && cfg!(target_arch = "x86_64") {
+            command.set_env("PROCESSOR_ARCHITECTURE", "AMD64");
+            command.set_env("TOKEN_PLACE_PACKAGED_TARGET_ARCH", "x86_64");
+        }
+    }
+    if !trusted_path.is_empty() {
+        if let Ok(path) = std::env::join_paths(&trusted_path) {
+            command.set_env("PATH", path);
+        }
+    }
 }
 
 fn import_root_is_confirmed_unbundled_development(import_root: &Path) -> bool {
@@ -1241,7 +1315,10 @@ pub fn configure_python_subprocess_env_for_layout<C>(
     C: PythonEnvCommand,
 {
     disable_python_user_site(command);
-    if packaged || layout != ResourceLayoutKind::DevSourceTree {
+    // Bundled launcher constructors have already cleared the environment with
+    // their verified runtime root.  Do not clear it a second time here and
+    // lose the deterministic native-loader PATH.
+    if !packaged && layout != ResourceLayoutKind::DevSourceTree {
         sanitize_packaged_python_subprocess_env(command);
     }
     command.set_env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", import_root.as_os_str());

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "token.place desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "place.token.desktop",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -2539,7 +2539,7 @@ def _load_windows_release_validator():
     return module
 
 
-def _write_windows_runtime_fixture(root: Path, *, version: str = '0.1.5') -> tuple[Path, Path]:
+def _write_windows_runtime_fixture(root: Path, *, version: str = '0.1.6') -> tuple[Path, Path]:
     validator = _load_windows_release_validator()
     manifest = json.loads(Path('desktop-tauri/src-tauri/python/embedded_python_runtime_windows_x86_64_manifest.json').read_text(encoding='utf-8'))
     runtime = root / 'resources' / 'python-runtime'
@@ -2599,7 +2599,7 @@ def test_windows_validator_without_version_args_derives_package_json_version(tmp
 def test_windows_release_validator_accepts_extracted_msi_and_nsis(tmp_path):
     validator = _load_windows_release_validator()
     nsis, msi = _write_windows_runtime_fixture(tmp_path)
-    assert validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.5']) == 0
+    assert validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.6']) == 0
 
 
 def test_windows_release_validator_rejects_version_and_provenance_mismatch(tmp_path):
@@ -2614,7 +2614,7 @@ def test_windows_release_validator_rejects_version_and_provenance_mismatch(tmp_p
     data['llama_cpp_cuda_wheel']['flavor'] = 'cpu'
     provenance.write_text(json.dumps(data), encoding='utf-8')
     with pytest.raises(validator.ValidationError, match='incomplete Windows runtime provenance'):
-        validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.5'])
+        validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.6'])
 
 
 def _extract_workflow_job_block(text: str, job_key: str) -> str:
@@ -2653,18 +2653,18 @@ def test_release_workflow_runs_windows_validator_and_preserves_skipped_nvidia_ga
 
 def test_windows_validator_version_tag_config_and_extract_edges(tmp_path, monkeypatch):
     validator = _load_windows_release_validator()
-    assert validator.expected_version_from_tag(None, '0.1.5') == '0.1.5'
-    assert validator.expected_version_from_tag('desktop-v1.2.3', '0.1.5') == '1.2.3'
+    assert validator.expected_version_from_tag(None, '0.1.6') == '0.1.6'
+    assert validator.expected_version_from_tag('desktop-v1.2.3', '0.1.6') == '1.2.3'
     with pytest.raises(validator.ValidationError, match='desktop-vX.Y.Z'):
-        validator.expected_version_from_tag('1495/merge', '0.1.5')
+        validator.expected_version_from_tag('1495/merge', '0.1.6')
 
     package = tmp_path / 'package.json'
     lock = tmp_path / 'package-lock.json'
     tauri = tmp_path / 'tauri.conf.json'
     cargo = tmp_path / 'Cargo.toml'
     cargo_lock = tmp_path / 'Cargo.lock'
-    package.write_text(json.dumps({'version': '0.1.5'}), encoding='utf-8')
-    lock.write_text(json.dumps({'version': '0.1.5'}), encoding='utf-8')
+    package.write_text(json.dumps({'version': '0.1.6'}), encoding='utf-8')
+    lock.write_text(json.dumps({'version': '0.1.6'}), encoding='utf-8')
     tauri.write_text(json.dumps({'version': '9.9.9'}), encoding='utf-8')
     cargo.write_text('[package]\nname = "token-place-desktop-tauri"\nversion = "0.1.3"\n', encoding='utf-8')
     cargo_lock.write_text('version = 4\n\n[[package]]\nname = "token-place-desktop-tauri"\nversion = "0.1.3"\n', encoding='utf-8')
@@ -2674,17 +2674,17 @@ def test_windows_validator_version_tag_config_and_extract_edges(tmp_path, monkey
     monkeypatch.setattr(validator, 'CARGO_MANIFEST', cargo)
     monkeypatch.setattr(validator, 'CARGO_LOCK', cargo_lock)
     with pytest.raises(validator.ValidationError, match='Windows release version mismatch'):
-        validator.validate_config_versions('0.1.5')
-    tauri.write_text(json.dumps({'version': '0.1.5'}), encoding='utf-8')
+        validator.validate_config_versions('0.1.6')
+    tauri.write_text(json.dumps({'version': '0.1.6'}), encoding='utf-8')
     cargo.write_text('[package]\nname = "token-place-desktop-tauri"\nversion = "0.1.0"\n', encoding='utf-8')
     with pytest.raises(validator.ValidationError, match='Cargo.toml'):
-        validator.validate_config_versions('0.1.5')
-    cargo.write_text('[package]\nname = "token-place-desktop-tauri"\nversion = "0.1.5"\n', encoding='utf-8')
+        validator.validate_config_versions('0.1.6')
+    cargo.write_text('[package]\nname = "token-place-desktop-tauri"\nversion = "0.1.6"\n', encoding='utf-8')
     cargo_lock.write_text('version = 4\n\n[[package]]\nname = "token-place-desktop-tauri"\nversion = "0.1.0"\n', encoding='utf-8')
     with pytest.raises(validator.ValidationError, match='Cargo.lock'):
-        validator.validate_config_versions('0.1.5')
-    cargo_lock.write_text('version = 4\n\n[[package]]\nname = "token-place-desktop-tauri"\nversion = "0.1.5"\n', encoding='utf-8')
-    validator.validate_config_versions('0.1.5')
+        validator.validate_config_versions('0.1.6')
+    cargo_lock.write_text('version = 4\n\n[[package]]\nname = "token-place-desktop-tauri"\nversion = "0.1.6"\n', encoding='utf-8')
+    validator.validate_config_versions('0.1.6')
 
     source_dir = tmp_path / 'already-extracted'
     source_dir.mkdir()
@@ -4627,10 +4627,10 @@ def test_installed_context_smoke_uses_get_llm_instance_boundary() -> None:
 
 def test_windows_installer_identity_main_non_windows_contract_success(monkeypatch, tmp_path, capsys) -> None:
     guard = _load_windows_installer_identity()
-    current_nsis = tmp_path / 'token.place-desktop-0.1.5-x64-setup.exe'
-    current_msi = tmp_path / 'token.place-desktop-0.1.5-x64.msi'
-    previous_nsis = tmp_path / 'token.place-desktop-0.1.4-x64-setup.exe'
-    previous_msi = tmp_path / 'token.place-desktop-0.1.4-x64.msi'
+    current_nsis = tmp_path / 'token.place-desktop-0.1.6-x64-setup.exe'
+    current_msi = tmp_path / 'token.place-desktop-0.1.6-x64.msi'
+    previous_nsis = tmp_path / 'token.place-desktop-0.1.5-x64-setup.exe'
+    previous_msi = tmp_path / 'token.place-desktop-0.1.5-x64.msi'
     for path in (current_nsis, current_msi, previous_nsis, previous_msi):
         path.write_text('artifact', encoding='utf-8')
     monkeypatch.setattr(guard.sys, 'platform', 'linux')
@@ -5413,20 +5413,20 @@ def test_windows_installer_identity_validate_tiers_detects_runtime_and_profile_d
 
 def test_windows_installer_identity_run_all_and_main_windows_paths(monkeypatch, tmp_path, capsys) -> None:
     guard = _load_windows_installer_identity()
-    current_nsis = tmp_path / 'token.place-desktop-0.1.5-x64-setup.exe'
-    current_msi = tmp_path / 'token.place-desktop-0.1.5-x64.msi'
-    previous_nsis = tmp_path / 'token.place-desktop-0.1.4-x64-setup.exe'
-    previous_msi = tmp_path / 'token.place-desktop-0.1.4-x64.msi'
+    current_nsis = tmp_path / 'token.place-desktop-0.1.6-x64-setup.exe'
+    current_msi = tmp_path / 'token.place-desktop-0.1.6-x64.msi'
+    previous_nsis = tmp_path / 'token.place-desktop-0.1.5-x64-setup.exe'
+    previous_msi = tmp_path / 'token.place-desktop-0.1.5-x64.msi'
     for path in (current_nsis, current_msi, previous_nsis, previous_msi):
         path.write_text('artifact', encoding='utf-8')
 
-    scenarios = [guard.Scenario('clean-nsis-0.1.5', guard.Installer(current_nsis, 'nsis', '0.1.5'))]
+    scenarios = [guard.Scenario('clean-nsis-0.1.6', guard.Installer(current_nsis, 'nsis', '0.1.6'))]
     artifacts_seen = []
     def fake_runner(scenario, build_id):
         artifacts_seen.append((scenario.name, build_id))
 
     guard.run_all_scenarios(scenarios, 'abcdef123456', runner=fake_runner, artifact_root=tmp_path / 'logs')
-    assert artifacts_seen == [('clean-nsis-0.1.5', 'abcdef123456')]
+    assert artifacts_seen == [('clean-nsis-0.1.6', 'abcdef123456')]
 
     old_argv = sys.argv
     monkeypatch.setattr(guard.sys, 'platform', 'win32')


### PR DESCRIPTION
### Motivation

- Packaged Windows launches cleared the environment but did not define `PATH`, causing `llama-cpp-python==0.3.32` to raise `KeyError("PATH")` during the immutable bundled runtime probe and abort GPU validation.  This also exposed incorrect import-root selection and empty packaged architecture diagnostics.
- CI and installer validation were certifying a path that never exercised the production Rust sanitizer and bundled Python child environment, so the broken packaged startup slipped through release checks.

### Description

- Ensure every bundled-Python subprocess receives a deterministic, trusted `PATH` constructed from canonicalized packaged runtime locations and validated Windows `System32` instead of inheriting the host `PATH`, by adding `sanitize_packaged_python_subprocess_env_at_root(...)` and using the launcher’s verified runtime root. (Adds PATH, preserves `PYTHONNOUSERSITE` and `PYTHONDONTWRITEBYTECODE`, and continues to strip mutable pip/CMake/virtualenv variables.)
- Make bundled launchers pass the verified runtime root into the sanitizer by exposing `PythonLauncher::bundled_runtime_root()` and calling `sanitize_packaged_python_subprocess_env_at_root` from all bundled-command code paths so probes and nested children share the same environment.
- Attest packaged Windows x86_64 identity to Rust/Python consumers by setting a packaged `TOKEN_PLACE_PACKAGED_TARGET_ARCH` + `PROCESSOR_ARCHITECTURE=AMD64` when launching from an attested runtime, and update `_desktop_arch()` to consume that attested value and fail closed on mismatches.
- Resolve the real installed Tauri import root in packaged mode (supporting `_up_/_up_` relocation) via `resolve_packaged_import_root(...)` and use that resolved import root rather than `resource_root.clone()`, failing on ambiguity or outside-tree candidates.
- Avoid clearing the deterministic native-loader `PATH` a second time during later packaged command configuration so nested probes inherit the deterministic environment.
- Bump canonical desktop release surfaces to `0.1.6` (package.json, Cargo.toml/Cargo.lock, tauri.conf.json, package-lock/Cargo.lock, installer test expectations) so artifact validators and tests reflect the repaired release metadata.
- Files changed (key): `desktop-tauri/src-tauri/src/python_runtime.rs`, `desktop-tauri/src-tauri/src/compute_node.rs`, `desktop-tauri/src-tauri/python/desktop_runtime_setup.py`, `desktop-tauri/src-tauri/Cargo.toml`, `desktop-tauri/package.json`, `desktop-tauri/src-tauri/tauri.conf.json`, `desktop-tauri/scripts/test_windows_installer_identity.py`, and unit test updates under `tests/unit/test_desktop_release_artifacts.py`.

### Testing

- Ran the focused unit suites with: `python -m pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_release_artifacts.py tests/unit/test_windows_nvidia_gpu_smoke_contract.py tests/unit/test_model_manager.py -q` and observed `953 passed`.
- Ran the release-artifact focused tests: `python -m pytest tests/unit/test_desktop_release_artifacts.py -q` and observed `223 passed` after updating version expectations to `0.1.6`.
- Verified Python sources compile with: `python -m py_compile desktop-tauri/src-tauri/python/desktop_runtime_setup.py desktop-tauri/src-tauri/python/compute_node_bridge.py desktop-tauri/scripts/prepare_windows_embedded_python_runtime.py desktop-tauri/scripts/test_windows_installer_identity.py` (passed).
- Ran `cargo fmt --manifest-path desktop-tauri/src-tauri/Cargo.toml` and basic `cargo check` during development; full `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` was blocked in this Linux environment by a missing system `glib-2.0` pkg-config dependency (not a code failure).
- Ran `pre-commit run --all-files`; format/YAML/codespell/vulture/bandit and many hooks passed; the full project-check phase was interrupted in CI environment provisioning but the focused test suites above were executed and green.

Remaining validation and notes

- This environment cannot execute the produced Windows `python.exe`, NSIS/MSI installer, or prove physical RTX GPU usage; final hosted-Windows/RTX gate runs (installer install + production Rust sanitizer + real `python.exe` import of `llama_cpp==0.3.32` + 8K/64K end-to-end worker readiness and encrypted registration/inference) remain for Windows CI and self-hosted RTX runs and are intentionally not blocked on by this PR.
- The change preserves all invariants: CPython 3.11.13 and `llama-cpp-python==0.3.32 cu124` expectations remain unchanged; no runtime fallbacks or relay/E2EE semantics were altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a664a822784832f82c2449c55554c5a)