### PR TITLE
Fix packaged Windows runtime startup for desktop 0.1.6

### DIFF
--- a/desktop-tauri/package-lock.json
+++ b/desktop-tauri/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-place-desktop-tauri",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "token-place-desktop-tauri",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/desktop-tauri/package.json
+++ b/desktop-tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "token-place-desktop-tauri",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop-tauri/scripts/test_windows_installer_identity.py
+++ b/desktop-tauri/scripts/test_windows_installer_identity.py
@@ -196,7 +196,7 @@ def validate_previous_artifacts(previous_nsis: Path, previous_msi: Path, previou
 def immediate_prior_version(version: str) -> str:
     """Return the immediate prior stable patch release for a semantic version string.
 
-    For '0.1.3' this returns '0.1.2'; for a future '0.1.6' it returns '0.1.4'.
+    For '0.1.3' this returns '0.1.2'; for a future '0.1.6' it returns '0.1.5'.
     """
     match = _SEMVER_RE.match(version)
     if not match:

--- a/desktop-tauri/scripts/test_windows_installer_identity.py
+++ b/desktop-tauri/scripts/test_windows_installer_identity.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterable
 
-EXPECTED_VERSION = "0.1.5"
+EXPECTED_VERSION = "0.1.6"
 EXPECTED_MODEL_ARTIFACT_FILENAME = "Qwen3-8B-Q4_K_M.gguf"
 EXPECTED_RUNTIME_ID = "bundled-cpython-3.11-win-x86_64-cu124"
 RUNTIME_PROVENANCE_NAME = "embedded_python_runtime_provenance.json"
@@ -196,7 +196,7 @@ def validate_previous_artifacts(previous_nsis: Path, previous_msi: Path, previou
 def immediate_prior_version(version: str) -> str:
     """Return the immediate prior stable patch release for a semantic version string.
 
-    For '0.1.3' this returns '0.1.2'; for a future '0.1.5' it returns '0.1.4'.
+    For '0.1.3' this returns '0.1.2'; for a future '0.1.6' it returns '0.1.4'.
     """
     match = _SEMVER_RE.match(version)
     if not match:
@@ -743,8 +743,8 @@ def assert_operator_record(text: str, expected_tier: str | None = None, launch_n
                 raise InstallerIdentityError("operator-start preflight did not use the real Tauri AppHandle resource context")
             if data.get("bridge_child_spawned") is not True or data.get("bridge_event_received") is not True:
                 raise InstallerIdentityError("operator-start preflight did not observe a spawned child and parsed bridge event")
-            if data.get("controlled_ready") is not True or data.get("startup_result") != "ready":
-                raise InstallerIdentityError("operator-start preflight did not observe controlled ready; terminal_actionable_error is not success")
+            if data.get("native_runtime_validated") is not True or data.get("startup_result") != "runtime_validated":
+                raise InstallerIdentityError("operator-start preflight did not validate the production native runtime; terminal_actionable_error is not success")
         elif data.get("startup_result") not in ("ready", "terminal_actionable_error"):
             raise InstallerIdentityError("operator-session smoke did not reach ready or a terminal actionable error")
         fallback_keys = ("fallback_reason", "backend_fallback", "model_fallback", "context_fallback")

--- a/desktop-tauri/src-tauri/Cargo.lock
+++ b/desktop-tauri/src-tauri/Cargo.lock
@@ -4167,7 +4167,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-place-desktop-tauri"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "aes",
  "anyhow",

--- a/desktop-tauri/src-tauri/Cargo.toml
+++ b/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "token-place-desktop-tauri"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -3013,7 +3013,7 @@ def installed_context_smoke_payload(context_tier: str, launch_number: str) -> Di
 def main() -> int:
     parser = argparse.ArgumentParser(description="token.place desktop compute-node bridge")
     parser.add_argument("--installed-context-smoke", action="store_true")
-    parser.add_argument("--operator-preflight-controlled-ready", action="store_true")
+    parser.add_argument("--operator-runtime-preflight", action="store_true")
     parser.add_argument("--model", required=False)
     parser.add_argument("--mode", default="auto")
     parser.add_argument("--relay-url", action="append", default=None)
@@ -3030,16 +3030,24 @@ def main() -> int:
     if args.installed_context_smoke:
         print(json.dumps(installed_context_smoke_payload(args.context_tier, os.environ.get("TOKENPLACE_INSTALLER_IDENTITY_LAUNCH_NUMBER", "1")), sort_keys=True, separators=(",", ":")))
         return 0
-    if args.operator_preflight_controlled_ready:
+    if args.operator_runtime_preflight:
+        # Release acceptance must execute the immutable runtime checks; it may
+        # not substitute a fabricated worker-ready event for native import.
+        dependency = ensure_desktop_python_dependencies()
+        if dependency.get("ok") != "true":
+            raise RuntimeError("operator_preflight_dependency_check_failed")
+        args.mode = _normalize_compute_mode_local(args.mode)
+        runtime = _ensure_desktop_llama_runtime_for_context(args.mode, args.context_tier)
+        if runtime.get("ok") != "true":
+            raise RuntimeError("operator_preflight_runtime_validation_failed")
+        _, normalize_context_tier = _load_context_profile_helpers()
+        context_tier = normalize_context_tier(args.context_tier)
         print(json.dumps({
             "type": "status",
-            "startup_result": "ready",
-            "startup_phase": "ready",
-            "relay_runtime_state": "ready",
-            "worker_state": "ready",
-            "worker_alive": True,
-            "context_tier": args.context_tier,
-            "controlled_preflight": True,
+            "startup_result": "runtime_validated",
+            "startup_phase": "hardware_model_boundary",
+            "context_tier": context_tier,
+            "production_runtime_preflight": True,
             "runtime_provisioning_state": "ready",
             "provisioning_actions": 0,
             "repair_actions": 0,
@@ -3050,7 +3058,7 @@ def main() -> int:
         }, sort_keys=True, separators=(",", ":")), flush=True)
         return 0
     if not args.model:
-        parser.error("--model is required unless --installed-context-smoke or --operator-preflight-controlled-ready is used")
+        parser.error("--model is required unless an installed preflight is used")
 
     try:
         args.mode = _normalize_compute_mode_local(args.mode)

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -3037,11 +3037,15 @@ def main() -> int:
         if dependency.get("ok") != "true":
             raise RuntimeError("operator_preflight_dependency_check_failed")
         args.mode = _normalize_compute_mode_local(args.mode)
-        runtime = _ensure_desktop_llama_runtime_for_context(args.mode, args.context_tier)
-        if runtime.get("ok") != "true":
-            raise RuntimeError("operator_preflight_runtime_validation_failed")
         _, normalize_context_tier = _load_context_profile_helpers()
         context_tier = normalize_context_tier(args.context_tier)
+        runtime = _ensure_desktop_llama_runtime_for_context(args.mode, context_tier)
+        if (
+            not runtime.get("runtime_action")
+            or not runtime.get("selected_backend")
+            or desktop_gpu_runtime_failure_message(args.mode, runtime)
+        ):
+            raise RuntimeError("operator_preflight_runtime_validation_failed")
         print(json.dumps({
             "type": "status",
             "startup_result": "runtime_validated",

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -1679,6 +1679,12 @@ def _desktop_platform() -> str:
 
 
 def _desktop_arch() -> str:
+    packaged_arch = os.environ.get("TOKEN_PLACE_PACKAGED_ARCH", "").strip().lower()
+    packaged_source = os.environ.get("TOKEN_PLACE_PACKAGED_ARCH_SOURCE", "").strip()
+    if packaged_arch or packaged_source:
+        if packaged_arch == "x86_64" and packaged_source == "attested_windows_x86_64":
+            return packaged_arch
+        raise RuntimeError("packaged_runtime_architecture_attestation_invalid")
     return platform_module.machine().lower().replace("amd64", "x86_64")
 
 

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -3954,13 +3954,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn operator_preflight_accepts_valid_controlled_readiness_event() {
+    async fn operator_preflight_accepts_valid_runtime_validation_event() {
         let event = run_production_operator_preflight_child(
             operator_preflight_test_command(Some(PRODUCTION_PREFLIGHT_VALIDATED_EVENT), false),
             Duration::from_secs(2),
         )
         .await
-        .expect("valid controlled readiness");
+        .expect("valid production runtime validation");
 
         assert_eq!(event["type"], "status");
         assert_eq!(event["production_runtime_preflight"], true);

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -9,10 +9,11 @@ use crate::python_runtime::{
     bridge_script_candidates_from_resource_roots, coherent_packaged_resource_roots,
     configure_python_subprocess_env_for_layout, describe_resource_layout, disable_python_user_site,
     resolve_bridge_script_path, resolve_bundled_python_launcher_at_root,
-    resolve_python_launcher_resource_aware, resolve_runtime_import_root,
-    should_enable_runtime_bootstrap, BridgeResourceContext, PythonEnvCommand, PythonLauncher,
-    PythonLauncherCategory, PythonLauncherError, PythonLauncherResolutionOptions,
-    PythonLauncherSource, ResourceLayoutKind, ENABLE_RUNTIME_BOOTSTRAP_ENV,
+    resolve_packaged_runtime_import_root, resolve_python_launcher_resource_aware,
+    resolve_runtime_import_root, should_enable_runtime_bootstrap, BridgeResourceContext,
+    PythonEnvCommand, PythonLauncher, PythonLauncherCategory, PythonLauncherError,
+    PythonLauncherResolutionOptions, PythonLauncherSource, ResourceLayoutKind,
+    ENABLE_RUNTIME_BOOTSTRAP_ENV,
 };
 use crate::subprocess_logging::{SubprocessLogFilter, SubprocessLogPolicy};
 use serde::{Deserialize, Serialize};
@@ -1770,10 +1771,19 @@ pub(crate) fn prepare_operator_bridge_launch(
         };
         let launcher = resolve_bundled_python_launcher_at_root(&resource_root, true)
             .map_err(OperatorBridgeLaunchPreparationError::from_launcher)?;
+        let import_root =
+            resolve_packaged_runtime_import_root(&resource_root).ok_or_else(|| {
+                OperatorBridgeLaunchPreparationError::new(
+                    "import_root_resolution",
+                    "packaged_import_root_invalid",
+                    "packaged_layout_invalid",
+                    "selected packaged resource tree has no unique import root",
+                )
+            })?;
         return Ok(OperatorBridgeLaunchPreparation {
             bridge_script: bridge_script.to_string_lossy().into_owned(),
             launcher: Some(launcher),
-            import_root: resource_root.clone(),
+            import_root,
             resource_root,
             layout,
         });
@@ -1927,7 +1937,7 @@ pub(crate) fn operator_start_preflight_record(
     let preparation = prepare_operator_bridge_launch(&context)?;
     let mut command = preparation.command()?;
     configure_runtime_bootstrap_env(&mut command, &config.preferred_mode);
-    command.arg("--operator-preflight-controlled-ready");
+    command.arg("--operator-runtime-preflight");
     command
         .arg("--context-tier")
         .arg(normalize_context_tier(&config.context_tier));
@@ -1935,7 +1945,7 @@ pub(crate) fn operator_start_preflight_record(
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?
-            .block_on(run_controlled_operator_preflight_child(
+            .block_on(run_production_operator_preflight_child(
                 command,
                 OPERATOR_PREFLIGHT_EVENT_TIMEOUT,
             ))
@@ -1956,7 +1966,7 @@ pub(crate) fn operator_start_preflight_record(
         map.insert("bridge_child_spawned".into(), Value::Bool(true));
         map.insert("bridge_event_received".into(), Value::Bool(true));
         for key in [
-            "controlled_preflight",
+            "production_runtime_preflight",
             "startup_result",
             "provisioning_actions",
             "repair_actions",
@@ -1969,14 +1979,14 @@ pub(crate) fn operator_start_preflight_record(
         }
         map.insert("bridge_event_type".into(), event["type"].clone());
         map.insert(
-            "controlled_ready".into(),
-            Value::Bool(event["controlled_preflight"] == Value::Bool(true)),
+            "native_runtime_validated".into(),
+            Value::Bool(event["production_runtime_preflight"] == Value::Bool(true)),
         );
     }
     Ok(payload)
 }
 
-async fn cleanup_controlled_operator_preflight_child(child: &mut Child, pid: Option<u32>) {
+async fn cleanup_production_operator_preflight_child(child: &mut Child, pid: Option<u32>) {
     if let Some(pid) = pid {
         terminate_bridge_process_tree(pid).await;
     }
@@ -1989,10 +1999,13 @@ async fn cleanup_controlled_operator_preflight_child(child: &mut Child, pid: Opt
     }
 }
 
-fn validate_controlled_operator_preflight_event(event: Value) -> anyhow::Result<Value> {
+fn validate_production_operator_preflight_event(event: Value) -> anyhow::Result<Value> {
     let identity_is_valid = event.get("type").and_then(Value::as_str) == Some("status")
-        && event.get("controlled_preflight").and_then(Value::as_bool) == Some(true)
-        && event.get("startup_result").and_then(Value::as_str) == Some("ready");
+        && event
+            .get("production_runtime_preflight")
+            .and_then(Value::as_bool)
+            == Some(true)
+        && event.get("startup_result").and_then(Value::as_str) == Some("runtime_validated");
     let counters_are_zero = [
         "provisioning_actions",
         "repair_actions",
@@ -2009,7 +2022,7 @@ fn validate_controlled_operator_preflight_event(event: Value) -> anyhow::Result<
     Ok(event)
 }
 
-async fn run_controlled_operator_preflight_child(
+async fn run_production_operator_preflight_child(
     mut command: Command,
     event_timeout: Duration,
 ) -> anyhow::Result<Value> {
@@ -2032,10 +2045,10 @@ async fn run_controlled_operator_preflight_child(
             .ok_or_else(|| anyhow::anyhow!("operator_preflight_event_missing"))?;
         let event = parse_compute_node_event_line(&line)
             .map_err(|_| anyhow::anyhow!("operator_preflight_event_parse_failed"))?;
-        validate_controlled_operator_preflight_event(event)
+        validate_production_operator_preflight_event(event)
     }
     .await;
-    cleanup_controlled_operator_preflight_child(&mut child, pid).await;
+    cleanup_production_operator_preflight_child(&mut child, pid).await;
     result
 }
 
@@ -3909,7 +3922,7 @@ mod tests {
         assert_eq!(event_types, vec!["status".to_string(), "error".to_string()]);
     }
 
-    const CONTROLLED_PREFLIGHT_READY_EVENT: &str = r#"{"type":"status","controlled_preflight":true,"startup_result":"ready","provisioning_actions":0,"repair_actions":0,"pip_actions":0,"compiler_actions":0,"network_actions":0,"download_actions":0}"#;
+    const PRODUCTION_PREFLIGHT_VALIDATED_EVENT: &str = r#"{"type":"status","production_runtime_preflight":true,"startup_result":"runtime_validated","provisioning_actions":0,"repair_actions":0,"pip_actions":0,"compiler_actions":0,"network_actions":0,"download_actions":0}"#;
 
     fn operator_preflight_test_command(output: Option<&str>, wedge: bool) -> Command {
         #[cfg(unix)]
@@ -3942,15 +3955,15 @@ mod tests {
 
     #[tokio::test]
     async fn operator_preflight_accepts_valid_controlled_readiness_event() {
-        let event = run_controlled_operator_preflight_child(
-            operator_preflight_test_command(Some(CONTROLLED_PREFLIGHT_READY_EVENT), false),
+        let event = run_production_operator_preflight_child(
+            operator_preflight_test_command(Some(PRODUCTION_PREFLIGHT_VALIDATED_EVENT), false),
             Duration::from_secs(2),
         )
         .await
         .expect("valid controlled readiness");
 
         assert_eq!(event["type"], "status");
-        assert_eq!(event["controlled_preflight"], true);
+        assert_eq!(event["production_runtime_preflight"], true);
         assert_eq!(event["network_actions"], 0);
     }
 
@@ -3958,18 +3971,18 @@ mod tests {
     fn operator_preflight_rejects_noncontrolled_and_nonzero_action_events() {
         for event in [
             serde_json::json!({
-                "type": "status", "controlled_preflight": false, "startup_result": "ready",
+                "type": "status", "production_runtime_preflight": false, "startup_result": "runtime_validated",
                 "provisioning_actions": 0, "repair_actions": 0, "pip_actions": 0,
                 "compiler_actions": 0, "network_actions": 0, "download_actions": 0,
             }),
             serde_json::json!({
-                "type": "status", "controlled_preflight": true, "startup_result": "ready",
+                "type": "status", "production_runtime_preflight": true, "startup_result": "runtime_validated",
                 "provisioning_actions": 0, "repair_actions": 0, "pip_actions": 1,
                 "compiler_actions": 0, "network_actions": 0, "download_actions": 0,
             }),
         ] {
             assert_eq!(
-                validate_controlled_operator_preflight_event(event)
+                validate_production_operator_preflight_event(event)
                     .expect_err("invalid event")
                     .to_string(),
                 "operator_preflight_invalid_event"
@@ -3980,7 +3993,7 @@ mod tests {
     #[tokio::test]
     async fn operator_preflight_times_out_silent_wedged_child() {
         let started = Instant::now();
-        let error = run_controlled_operator_preflight_child(
+        let error = run_production_operator_preflight_child(
             operator_preflight_test_command(None, true),
             Duration::from_millis(100),
         )
@@ -3994,8 +4007,8 @@ mod tests {
     #[tokio::test]
     async fn operator_preflight_terminates_and_reaps_child_after_ready_event() {
         let started = Instant::now();
-        run_controlled_operator_preflight_child(
-            operator_preflight_test_command(Some(CONTROLLED_PREFLIGHT_READY_EVENT), true),
+        run_production_operator_preflight_child(
+            operator_preflight_test_command(Some(PRODUCTION_PREFLIGHT_VALIDATED_EVENT), true),
             Duration::from_secs(2),
         )
         .await

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -2735,8 +2735,13 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(entries[0], runtime.canonicalize().unwrap());
         assert_eq!(entries[1], native.canonicalize().unwrap());
-        assert_eq!(entries.iter().filter(|entry| **entry == entries[0]).count(), 1);
-        assert!(!entries.iter().any(|entry| entry.to_string_lossy().contains("poison")));
+        assert_eq!(
+            entries.iter().filter(|entry| **entry == entries[0]).count(),
+            1
+        );
+        assert!(!entries
+            .iter()
+            .any(|entry| entry.to_string_lossy().contains("poison")));
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -54,7 +54,10 @@ impl PythonLauncher {
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.args);
         if self.source == PythonLauncherSource::BundledRuntime {
-            sanitize_packaged_python_subprocess_env(&mut cmd);
+            sanitize_packaged_python_subprocess_env(
+                &mut cmd,
+                self.bundled_runtime_root().as_deref(),
+            );
         }
         cmd.arg("--version");
         cmd
@@ -64,7 +67,10 @@ impl PythonLauncher {
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.args);
         if self.source == PythonLauncherSource::BundledRuntime {
-            sanitize_packaged_python_subprocess_env(&mut cmd);
+            sanitize_packaged_python_subprocess_env(
+                &mut cmd,
+                self.bundled_runtime_root().as_deref(),
+            );
         }
         cmd.arg("-c");
         cmd.arg("import json,platform,struct,sys; print(json.dumps({'version': list(sys.version_info[:3]), 'machine': platform.machine(), 'pointer_bits': struct.calcsize('P') * 8, 'executable': sys.executable, 'prefix': sys.prefix}))");
@@ -78,7 +84,10 @@ impl PythonLauncher {
         let mut cmd = tokio::process::Command::new(&self.program);
         cmd.args(&self.args);
         if self.source == PythonLauncherSource::BundledRuntime {
-            sanitize_packaged_python_subprocess_env(&mut cmd);
+            sanitize_packaged_python_subprocess_env(
+                &mut cmd,
+                self.bundled_runtime_root().as_deref(),
+            );
         }
         cmd.arg(script_path);
         cmd
@@ -91,10 +100,21 @@ impl PythonLauncher {
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.args);
         if self.source == PythonLauncherSource::BundledRuntime {
-            sanitize_packaged_python_subprocess_env(&mut cmd);
+            sanitize_packaged_python_subprocess_env(
+                &mut cmd,
+                self.bundled_runtime_root().as_deref(),
+            );
         }
         cmd.arg(script_path);
         cmd
+    }
+}
+
+impl PythonLauncher {
+    fn bundled_runtime_root(&self) -> Option<PathBuf> {
+        (self.source == PythonLauncherSource::BundledRuntime)
+            .then(|| Path::new(&self.program).parent().map(Path::to_path_buf))
+            .flatten()
     }
 }
 
@@ -1193,7 +1213,7 @@ const PACKAGED_MUTABLE_ENV_KEYS: &[&str] = &[
     "FORCE_CMAKE",
 ];
 
-pub fn sanitize_packaged_python_subprocess_env<C>(command: &mut C)
+pub fn sanitize_packaged_python_subprocess_env<C>(command: &mut C, runtime_root: Option<&Path>)
 where
     C: PythonEnvCommand,
 {
@@ -1219,6 +1239,34 @@ where
     }
     command.set_env("PYTHONNOUSERSITE", std::ffi::OsStr::new("1"));
     command.set_env("PYTHONDONTWRITEBYTECODE", std::ffi::OsStr::new("1"));
+    if let Some(runtime_root) = runtime_root.and_then(|path| path.canonicalize().ok()) {
+        let mut trusted = vec![runtime_root.clone()];
+        let native = runtime_root.join("Lib/site-packages/llama_cpp/lib");
+        if let Ok(native) = native.canonicalize() {
+            trusted.push(native);
+        }
+        if cfg!(target_os = "windows") {
+            if let Some(system_root) = std::env::var_os("SystemRoot")
+                .map(PathBuf::from)
+                .filter(|path| path.is_absolute())
+                .and_then(|path| path.canonicalize().ok())
+            {
+                if let Ok(system32) = system_root.join("System32").canonicalize() {
+                    trusted.push(system32);
+                }
+            }
+            command.set_env("PROCESSOR_ARCHITECTURE", "AMD64");
+            command.set_env("TOKEN_PLACE_PACKAGED_ARCH", "x86_64");
+            command.set_env(
+                "TOKEN_PLACE_PACKAGED_ARCH_SOURCE",
+                "attested_windows_x86_64",
+            );
+        }
+        trusted.dedup();
+        if let Ok(path) = std::env::join_paths(trusted) {
+            command.set_env("PATH", path);
+        }
+    }
 }
 
 fn import_root_is_confirmed_unbundled_development(import_root: &Path) -> bool {
@@ -1242,7 +1290,11 @@ pub fn configure_python_subprocess_env_for_layout<C>(
 {
     disable_python_user_site(command);
     if packaged || layout != ResourceLayoutKind::DevSourceTree {
-        sanitize_packaged_python_subprocess_env(command);
+        let runtime_root = import_root
+            .ancestors()
+            .map(|root| root.join("python-runtime"))
+            .find(|root| root.is_dir());
+        sanitize_packaged_python_subprocess_env(command, runtime_root.as_deref());
     }
     command.set_env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", import_root.as_os_str());
     let python_dir = import_root.join("python");
@@ -1423,6 +1475,31 @@ pub fn resolve_runtime_import_root(
     candidates
         .into_iter()
         .find(|candidate| candidate.join("utils").is_dir() || candidate.join("config.py").is_file())
+}
+
+/// Resolve repository Python imports inside one already-selected packaged
+/// resource tree. Ambient overrides are deliberately excluded.
+pub fn resolve_packaged_runtime_import_root(resource_root: &Path) -> Option<PathBuf> {
+    let canonical_root = resource_root.canonicalize().ok()?;
+    let candidates = [
+        canonical_root.clone(),
+        canonical_root.join("_up_"),
+        canonical_root.join("_up_").join("_up_"),
+    ];
+    let mut matches = candidates
+        .into_iter()
+        .filter_map(|candidate| candidate.canonicalize().ok())
+        .filter(|candidate| candidate.starts_with(&canonical_root))
+        .filter(|candidate| {
+            candidate.join("utils").is_dir() && candidate.join("config.py").is_file()
+        })
+        .collect::<Vec<_>>();
+    matches.sort();
+    matches.dedup();
+    match matches.as_slice() {
+        [root] => Some(root.clone()),
+        _ => None,
+    }
 }
 
 fn mode_requests_gpu(mode: &ComputeMode) -> bool {
@@ -2563,7 +2640,7 @@ mod tests {
             Some("1")
         );
         let mut effective = PythonEnvCommandRecorder::with_poisoned_env();
-        sanitize_packaged_python_subprocess_env(&mut effective);
+        sanitize_packaged_python_subprocess_env(&mut effective, None);
         assert!(effective.clear_env_called);
         for key in [
             "PYTHONHOME",
@@ -2616,7 +2693,7 @@ mod tests {
 
         let mut effective = PythonEnvCommandRecorder::with_poisoned_env();
         effective.set_env("PATH", "poison-host-tools");
-        sanitize_packaged_python_subprocess_env(&mut effective);
+        sanitize_packaged_python_subprocess_env(&mut effective, None);
 
         for (key, value) in fundamentals {
             assert_eq!(effective.value(key), Some(std::ffi::OsStr::new(value)));
@@ -2641,6 +2718,25 @@ mod tests {
                 std::env::remove_var(key);
             }
         }
+    }
+
+    #[test]
+    fn packaged_sanitizer_builds_path_from_runtime_not_host_path() {
+        let temp = TempDir::new().expect("tempdir");
+        let runtime = temp.path().join("python-runtime");
+        let native = runtime.join("Lib/site-packages/llama_cpp/lib");
+        std::fs::create_dir_all(&native).expect("native library directory");
+        let mut effective = PythonEnvCommandRecorder::with_poisoned_env();
+        effective.set_env("PATH", "poison-host-tools");
+
+        sanitize_packaged_python_subprocess_env(&mut effective, Some(&runtime));
+
+        let entries = std::env::split_paths(effective.value("PATH").expect("deterministic PATH"))
+            .collect::<Vec<_>>();
+        assert_eq!(entries[0], runtime.canonicalize().unwrap());
+        assert_eq!(entries[1], native.canonicalize().unwrap());
+        assert_eq!(entries.iter().filter(|entry| **entry == entries[0]).count(), 1);
+        assert!(!entries.iter().any(|entry| entry.to_string_lossy().contains("poison")));
     }
 
     #[test]

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "token.place desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "place.token.desktop",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2039,7 +2039,14 @@ def test_main_normalizes_mode_before_run(monkeypatch):
 def test_main_operator_preflight_validates_native_runtime_before_boundary(capsys, monkeypatch):
     calls = []
     monkeypatch.setattr(compute_node_bridge, 'ensure_desktop_python_dependencies', lambda: calls.append('dependencies') or {'ok': 'true'})
-    monkeypatch.setattr(compute_node_bridge, '_ensure_desktop_llama_runtime_for_context', lambda mode, tier: calls.append((mode, tier)) or {'ok': 'true'})
+    monkeypatch.setattr(
+        compute_node_bridge,
+        '_ensure_desktop_llama_runtime_for_context',
+        lambda mode, tier: calls.append((mode, tier)) or {
+            'runtime_action': 'already_supported',
+            'selected_backend': 'cuda',
+        },
+    )
     monkeypatch.setattr(
         sys,
         'argv',
@@ -2069,6 +2076,50 @@ def test_main_operator_preflight_validates_native_runtime_before_boundary(capsys
         'network_actions': 0,
         'download_actions': 0,
     }
+
+
+def test_main_operator_preflight_normalizes_context_before_runtime_validation(capsys, monkeypatch):
+    calls = []
+    monkeypatch.setattr(compute_node_bridge, 'ensure_desktop_python_dependencies', lambda: {'ok': 'true'})
+    monkeypatch.setattr(
+        compute_node_bridge,
+        '_ensure_desktop_llama_runtime_for_context',
+        lambda mode, tier: calls.append((mode, tier)) or {
+            'runtime_action': 'already_supported',
+            'selected_backend': 'cuda',
+        },
+    )
+    monkeypatch.setattr(
+        sys,
+        'argv',
+        ['compute_node_bridge.py', '--operator-runtime-preflight', '--context-tier', ' 64K '],
+    )
+
+    assert compute_node_bridge.main() == 0
+    assert calls == [('auto', '8k-fast')]
+    assert json.loads(capsys.readouterr().out)['context_tier'] == '8k-fast'
+
+
+def test_main_operator_preflight_rejects_failed_runtime_contract(monkeypatch):
+    monkeypatch.setattr(compute_node_bridge, 'ensure_desktop_python_dependencies', lambda: {'ok': 'true'})
+    monkeypatch.setattr(
+        compute_node_bridge,
+        '_ensure_desktop_llama_runtime_for_context',
+        lambda _mode, _tier: {
+            'runtime_action': 'bundled_runtime_probe_failed',
+            'selected_backend': 'cpu',
+            'fallback_reason': 'native import failed',
+        },
+    )
+    monkeypatch.setattr(
+        compute_node_bridge,
+        'desktop_gpu_runtime_failure_message',
+        lambda _mode, _runtime: 'GPU provisioning failed',
+    )
+    monkeypatch.setattr(sys, 'argv', ['compute_node_bridge.py', '--operator-runtime-preflight'])
+
+    with pytest.raises(RuntimeError, match='operator_preflight_runtime_validation_failed'):
+        compute_node_bridge.main()
 
 
 def test_main_emits_structured_error_when_last_resort_exception_path_runs(capsys, monkeypatch):

--- a/tests/unit/test_desktop_compute_node_bridge.py
+++ b/tests/unit/test_desktop_compute_node_bridge.py
@@ -2036,13 +2036,16 @@ def test_main_normalizes_mode_before_run(monkeypatch):
     assert captured['mode'] == 'auto'
 
 
-def test_main_emits_controlled_operator_preflight_ready_event(capsys, monkeypatch):
+def test_main_operator_preflight_validates_native_runtime_before_boundary(capsys, monkeypatch):
+    calls = []
+    monkeypatch.setattr(compute_node_bridge, 'ensure_desktop_python_dependencies', lambda: calls.append('dependencies') or {'ok': 'true'})
+    monkeypatch.setattr(compute_node_bridge, '_ensure_desktop_llama_runtime_for_context', lambda mode, tier: calls.append((mode, tier)) or {'ok': 'true'})
     monkeypatch.setattr(
         sys,
         'argv',
         [
             'compute_node_bridge.py',
-            '--operator-preflight-controlled-ready',
+            '--operator-runtime-preflight',
             '--context-tier',
             '64k-full',
         ],
@@ -2051,15 +2054,13 @@ def test_main_emits_controlled_operator_preflight_ready_event(capsys, monkeypatc
     assert compute_node_bridge.main() == 0
 
     payload = json.loads(capsys.readouterr().out)
+    assert calls == ['dependencies', ('auto', '64k-full')]
     assert payload == {
         'type': 'status',
-        'startup_result': 'ready',
-        'startup_phase': 'ready',
-        'relay_runtime_state': 'ready',
-        'worker_state': 'ready',
-        'worker_alive': True,
+        'startup_result': 'runtime_validated',
+        'startup_phase': 'hardware_model_boundary',
         'context_tier': '64k-full',
-        'controlled_preflight': True,
+        'production_runtime_preflight': True,
         'runtime_provisioning_state': 'ready',
         'provisioning_actions': 0,
         'repair_actions': 0,

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -2539,7 +2539,7 @@ def _load_windows_release_validator():
     return module
 
 
-def _write_windows_runtime_fixture(root: Path, *, version: str = '0.1.5') -> tuple[Path, Path]:
+def _write_windows_runtime_fixture(root: Path, *, version: str = '0.1.6') -> tuple[Path, Path]:
     validator = _load_windows_release_validator()
     manifest = json.loads(Path('desktop-tauri/src-tauri/python/embedded_python_runtime_windows_x86_64_manifest.json').read_text(encoding='utf-8'))
     runtime = root / 'resources' / 'python-runtime'
@@ -2599,7 +2599,7 @@ def test_windows_validator_without_version_args_derives_package_json_version(tmp
 def test_windows_release_validator_accepts_extracted_msi_and_nsis(tmp_path):
     validator = _load_windows_release_validator()
     nsis, msi = _write_windows_runtime_fixture(tmp_path)
-    assert validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.5']) == 0
+    assert validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.6']) == 0
 
 
 def test_windows_release_validator_rejects_version_and_provenance_mismatch(tmp_path):
@@ -2614,7 +2614,7 @@ def test_windows_release_validator_rejects_version_and_provenance_mismatch(tmp_p
     data['llama_cpp_cuda_wheel']['flavor'] = 'cpu'
     provenance.write_text(json.dumps(data), encoding='utf-8')
     with pytest.raises(validator.ValidationError, match='incomplete Windows runtime provenance'):
-        validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.5'])
+        validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.6'])
 
 
 def _extract_workflow_job_block(text: str, job_key: str) -> str:
@@ -4627,10 +4627,10 @@ def test_installed_context_smoke_uses_get_llm_instance_boundary() -> None:
 
 def test_windows_installer_identity_main_non_windows_contract_success(monkeypatch, tmp_path, capsys) -> None:
     guard = _load_windows_installer_identity()
-    current_nsis = tmp_path / 'token.place-desktop-0.1.5-x64-setup.exe'
-    current_msi = tmp_path / 'token.place-desktop-0.1.5-x64.msi'
-    previous_nsis = tmp_path / 'token.place-desktop-0.1.4-x64-setup.exe'
-    previous_msi = tmp_path / 'token.place-desktop-0.1.4-x64.msi'
+    current_nsis = tmp_path / 'token.place-desktop-0.1.6-x64-setup.exe'
+    current_msi = tmp_path / 'token.place-desktop-0.1.6-x64.msi'
+    previous_nsis = tmp_path / 'token.place-desktop-0.1.5-x64-setup.exe'
+    previous_msi = tmp_path / 'token.place-desktop-0.1.5-x64.msi'
     for path in (current_nsis, current_msi, previous_nsis, previous_msi):
         path.write_text('artifact', encoding='utf-8')
     monkeypatch.setattr(guard.sys, 'platform', 'linux')
@@ -4835,8 +4835,8 @@ def test_windows_installer_identity_operator_record_accepts_64k_ready_contract()
         ({'resource_context_source': 'manifest_dir'}, 'real Tauri AppHandle'),
         ({'bridge_child_spawned': False}, 'spawned child and parsed bridge event'),
         ({'bridge_event_received': False}, 'spawned child and parsed bridge event'),
-        ({'controlled_ready': False}, 'controlled ready'),
-        ({'startup_result': 'terminal_actionable_error'}, 'controlled ready'),
+        ({'native_runtime_validated': False}, 'production native runtime'),
+        ({'startup_result': 'terminal_actionable_error'}, 'production native runtime'),
         ({'network_actions': 1}, 'forbidden action counter network_actions'),
     ],
 )
@@ -4857,12 +4857,12 @@ def test_windows_installer_identity_operator_preflight_fails_closed(override, er
         'selected_model_profile': 'qwen3-8b-q4',
         'startup_phase': 'ready',
         'startup_deadline_ms': 15000,
-        'startup_result': 'ready',
+        'startup_result': 'runtime_validated',
         'operator_start_preflight': 'ok',
         'resource_context_source': 'tauri_app_handle',
         'bridge_child_spawned': True,
         'bridge_event_received': True,
-        'controlled_ready': True,
+        'native_runtime_validated': True,
     }
     record.update(override)
 
@@ -5413,20 +5413,20 @@ def test_windows_installer_identity_validate_tiers_detects_runtime_and_profile_d
 
 def test_windows_installer_identity_run_all_and_main_windows_paths(monkeypatch, tmp_path, capsys) -> None:
     guard = _load_windows_installer_identity()
-    current_nsis = tmp_path / 'token.place-desktop-0.1.5-x64-setup.exe'
-    current_msi = tmp_path / 'token.place-desktop-0.1.5-x64.msi'
-    previous_nsis = tmp_path / 'token.place-desktop-0.1.4-x64-setup.exe'
-    previous_msi = tmp_path / 'token.place-desktop-0.1.4-x64.msi'
+    current_nsis = tmp_path / 'token.place-desktop-0.1.6-x64-setup.exe'
+    current_msi = tmp_path / 'token.place-desktop-0.1.6-x64.msi'
+    previous_nsis = tmp_path / 'token.place-desktop-0.1.5-x64-setup.exe'
+    previous_msi = tmp_path / 'token.place-desktop-0.1.5-x64.msi'
     for path in (current_nsis, current_msi, previous_nsis, previous_msi):
         path.write_text('artifact', encoding='utf-8')
 
-    scenarios = [guard.Scenario('clean-nsis-0.1.5', guard.Installer(current_nsis, 'nsis', '0.1.5'))]
+    scenarios = [guard.Scenario('clean-nsis-0.1.6', guard.Installer(current_nsis, 'nsis', '0.1.6'))]
     artifacts_seen = []
     def fake_runner(scenario, build_id):
         artifacts_seen.append((scenario.name, build_id))
 
     guard.run_all_scenarios(scenarios, 'abcdef123456', runner=fake_runner, artifact_root=tmp_path / 'logs')
-    assert artifacts_seen == [('clean-nsis-0.1.5', 'abcdef123456')]
+    assert artifacts_seen == [('clean-nsis-0.1.6', 'abcdef123456')]
 
     old_argv = sys.argv
     monkeypatch.setattr(guard.sys, 'platform', 'win32')


### PR DESCRIPTION
### Motivation
- Packaged Windows startup cleared the child environment but did not define a PATH, causing the pinned bundled llama-cpp-python loader to raise KeyError("PATH") and the immutable bundled probe to fail early. 
- The packaged bridge supplied an incorrect import-root in some installed layouts and tests accepted a fabricated "controlled-ready" event that masked real native-import failures. 
- The goal is to make packaged launches deterministic and fail-closed for provenance/architecture mismatches while making CI exercise the real production preflight path rather than a fake ready event.

### Description
- Repaired the sanitizer to accept a canonical runtime root and build a deterministic child `PATH` that contains only canonical absolute entries for the verified `python-runtime` root, the bundled native-library (llama_cpp) directory when present, and validated Windows `SystemRoot\System32`; the sanitizer still clears mutable Python/pip/CMake/virtualenv variables and preserves `PYTHONNOUSERSITE` / `PYTHONDONTWRITEBYTECODE` (key change in `desktop-tauri/src-tauri/src/python_runtime.rs`).
- Added a small Rust-side attestation for packaged Windows x86_64 by setting `PROCESSOR_ARCHITECTURE=AMD64` plus `TOKEN_PLACE_PACKAGED_ARCH`/`TOKEN_PLACE_PACKAGED_ARCH_SOURCE` from launcher-owned evidence, and made the Python-side `_desktop_arch()` consume that attestation and fail closed on mismatch (`desktop-tauri/src-tauri/python/desktop_runtime_setup.py`).
- Resolved the real Tauri import root inside the coherent selected packaged resource tree via `resolve_packaged_runtime_import_root()` and use that root (instead of naively cloning `resource_root`), failing when the packaged import-root is ambiguous or absent (`desktop-tauri/src-tauri/src/compute_node.rs` and `desktop-tauri/src-tauri/src/python_runtime.rs`).
- Replaced the installed-artifact acceptance shortcut with a production-oriented preflight: `--operator-runtime-preflight` (was `--operator-preflight-controlled-ready`) now runs dependency checks and the real runtime validation sequence up to the hardware/model boundary and only then emits a validated preflight event; the old fabricated worker-ready shortcut no longer satisfies release acceptance (`desktop-tauri/src-tauri/python/compute_node_bridge.py`, tests adjusted accordingly).
- Bumped canonical desktop version surfaces from `0.1.5` to `0.1.6` and updated unit tests and release validators to match; added focused sanitizer unit test that asserts deterministic PATH construction and that poisoned host PATH entries do not survive (`package.json`, `package-lock.json`, `tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, various tests).
- Files changed (key list): desktop-tauri/src-tauri/src/python_runtime.rs; desktop-tauri/src-tauri/src/compute_node.rs; desktop-tauri/src-tauri/python/desktop_runtime_setup.py; desktop-tauri/src-tauri/python/compute_node_bridge.py; desktop-tauri/scripts/test_windows_installer_identity.py; desktop-tauri/package.json; desktop-tauri/package-lock.json; desktop-tauri/src-tauri/Cargo.toml; desktop-tauri/src-tauri/Cargo.lock; desktop-tauri/src-tauri/tauri.conf.json; tests/unit/test_desktop_compute_node_bridge.py; tests/unit/test_desktop_release_artifacts.py.

### Testing
- Ran the requested focused test sweep: `python -m pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_release_artifacts.py tests/unit/test_windows_nvidia_gpu_smoke_contract.py tests/unit/test_model_manager.py -q` which completed with 953 passed.
- Exercised the adjusted installer/validator and preflight unit coverage (selected release-artifact and installer-identity tests) and observed the modified preflight paths and validation assertions passing (targeted `pytest` invocations passed as shown in logs).
- Verified Python source compile checks: `python -m py_compile desktop-tauri/src-tauri/python/desktop_runtime_setup.py desktop-tauri/src-tauri/python/compute_node_bridge.py desktop-tauri/scripts/prepare_windows_embedded_python_runtime.py desktop-tauri/scripts/test_windows_installer_identity.py` succeeded and `pre-commit run --all-files` completed under the repository environment (project checks passed; optional/hardware E2E suites are skipped by repo guards).
- Attempted `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml` but full Rust test execution hit a system dependency failure for `glib-2.0` in this Linux container; the compilation step is environment-limited and not blocking the logical change here.

Notes and residuals: the Linux environment cannot perform hosted Windows NSIS/MSI installs or exercise real RTX hardware; the package and sanitizer changes are in place and covered by unit tests, but the final hosted-Windows runtime/NSIS acceptance and physical RTX GPU gate remain to be executed by the appropriate self-hosted Windows runner as required by the release contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a664a6e4264832f8c15658780722ce8)