### PR TITLE
Fix packaged Windows Python runtime launch for desktop 0.1.6

### DIFF
--- a/desktop-tauri/package-lock.json
+++ b/desktop-tauri/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-place-desktop-tauri",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "token-place-desktop-tauri",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/desktop-tauri/package.json
+++ b/desktop-tauri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "token-place-desktop-tauri",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop-tauri/scripts/test_windows_installer_identity.py
+++ b/desktop-tauri/scripts/test_windows_installer_identity.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterable
 
-EXPECTED_VERSION = "0.1.5"
+EXPECTED_VERSION = "0.1.6"
 EXPECTED_MODEL_ARTIFACT_FILENAME = "Qwen3-8B-Q4_K_M.gguf"
 EXPECTED_RUNTIME_ID = "bundled-cpython-3.11-win-x86_64-cu124"
 RUNTIME_PROVENANCE_NAME = "embedded_python_runtime_provenance.json"

--- a/desktop-tauri/src-tauri/Cargo.lock
+++ b/desktop-tauri/src-tauri/Cargo.lock
@@ -4167,7 +4167,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-place-desktop-tauri"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "aes",
  "anyhow",

--- a/desktop-tauri/src-tauri/Cargo.toml
+++ b/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "token-place-desktop-tauri"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 
 [build-dependencies]

--- a/desktop-tauri/src-tauri/python/compute_node_bridge.py
+++ b/desktop-tauri/src-tauri/python/compute_node_bridge.py
@@ -3014,6 +3014,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="token.place desktop compute-node bridge")
     parser.add_argument("--installed-context-smoke", action="store_true")
     parser.add_argument("--operator-preflight-controlled-ready", action="store_true")
+    parser.add_argument("--operator-native-runtime-preflight", action="store_true")
     parser.add_argument("--model", required=False)
     parser.add_argument("--mode", default="auto")
     parser.add_argument("--relay-url", action="append", default=None)
@@ -3049,8 +3050,38 @@ def main() -> int:
             "download_actions": 0,
         }, sort_keys=True, separators=(",", ":")), flush=True)
         return 0
+    if args.operator_native_runtime_preflight:
+        # Release acceptance reaches the real immutable native import before
+        # stopping at the first hardware/model-dependent boundary.  Unlike the
+        # legacy controlled-ready unit hook, this event is never fabricated.
+        dependency_setup = ensure_desktop_python_dependencies()
+        if dependency_setup.get("ok") != "true":
+            raise RuntimeError("operator_native_preflight_dependency_check_failed")
+        from desktop_runtime_setup import _probe_llama_runtime
+
+        probe = _probe_llama_runtime()
+        if probe.error or probe.version != "0.3.32":
+            raise RuntimeError("operator_native_preflight_llama_import_failed")
+        if not probe.constructor_signature_inspectable or probe.qwen_64k_yarn_support != "supported":
+            raise RuntimeError("operator_native_preflight_capability_metadata_incomplete")
+        print(json.dumps({
+            "type": "status",
+            "startup_result": "native_runtime_validated",
+            "context_tier": args.context_tier,
+            "controlled_preflight": False,
+            "native_runtime_imported": True,
+            "runtime_version": probe.version,
+            "hardware_boundary": "physical_device_and_model_construction",
+            "provisioning_actions": 0,
+            "repair_actions": 0,
+            "pip_actions": 0,
+            "compiler_actions": 0,
+            "network_actions": 0,
+            "download_actions": 0,
+        }, sort_keys=True, separators=(",", ":")), flush=True)
+        return 0
     if not args.model:
-        parser.error("--model is required unless --installed-context-smoke or --operator-preflight-controlled-ready is used")
+        parser.error("--model is required unless an installed-runtime preflight is used")
 
     try:
         args.mode = _normalize_compute_mode_local(args.mode)

--- a/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
+++ b/desktop-tauri/src-tauri/python/desktop_runtime_setup.py
@@ -1679,6 +1679,12 @@ def _desktop_platform() -> str:
 
 
 def _desktop_arch() -> str:
+    packaged_arch = os.environ.get("TOKEN_PLACE_PACKAGED_RUNTIME_ARCH", "").strip().lower()
+    if packaged_arch:
+        normalized = packaged_arch.replace("amd64", "x86_64")
+        if normalized not in {"x86_64", "arm64", "aarch64"}:
+            raise RuntimeError("packaged_runtime_arch_attestation_invalid")
+        return normalized
     return platform_module.machine().lower().replace("amd64", "x86_64")
 
 

--- a/desktop-tauri/src-tauri/src/compute_node.rs
+++ b/desktop-tauri/src-tauri/src/compute_node.rs
@@ -1770,10 +1770,20 @@ pub(crate) fn prepare_operator_bridge_launch(
         };
         let launcher = resolve_bundled_python_launcher_at_root(&resource_root, true)
             .map_err(OperatorBridgeLaunchPreparationError::from_launcher)?;
+        let import_root =
+            crate::python_runtime::resolve_packaged_runtime_import_root(&resource_root)
+                .ok_or_else(|| {
+                    OperatorBridgeLaunchPreparationError::new(
+                        "import_root_resolution",
+                        "desktop_python_runtime_invalid",
+                        "packaged_import_root_invalid",
+                        "packaged import root is missing or ambiguous",
+                    )
+                })?;
         return Ok(OperatorBridgeLaunchPreparation {
             bridge_script: bridge_script.to_string_lossy().into_owned(),
             launcher: Some(launcher),
-            import_root: resource_root.clone(),
+            import_root,
             resource_root,
             layout,
         });
@@ -1927,7 +1937,7 @@ pub(crate) fn operator_start_preflight_record(
     let preparation = prepare_operator_bridge_launch(&context)?;
     let mut command = preparation.command()?;
     configure_runtime_bootstrap_env(&mut command, &config.preferred_mode);
-    command.arg("--operator-preflight-controlled-ready");
+    command.arg("--operator-native-runtime-preflight");
     command
         .arg("--context-tier")
         .arg(normalize_context_tier(&config.context_tier));
@@ -1990,9 +2000,17 @@ async fn cleanup_controlled_operator_preflight_child(child: &mut Child, pid: Opt
 }
 
 fn validate_controlled_operator_preflight_event(event: Value) -> anyhow::Result<Value> {
-    let identity_is_valid = event.get("type").and_then(Value::as_str) == Some("status")
-        && event.get("controlled_preflight").and_then(Value::as_bool) == Some(true)
+    let legacy_unit_event = event.get("controlled_preflight").and_then(Value::as_bool)
+        == Some(true)
         && event.get("startup_result").and_then(Value::as_str) == Some("ready");
+    let native_release_event = event
+        .get("native_runtime_imported")
+        .and_then(Value::as_bool)
+        == Some(true)
+        && event.get("runtime_version").and_then(Value::as_str) == Some("0.3.32")
+        && event.get("startup_result").and_then(Value::as_str) == Some("native_runtime_validated");
+    let identity_is_valid = event.get("type").and_then(Value::as_str) == Some("status")
+        && (legacy_unit_event || native_release_event);
     let counters_are_zero = [
         "provisioning_actions",
         "repair_actions",

--- a/desktop-tauri/src-tauri/src/python_runtime.rs
+++ b/desktop-tauri/src-tauri/src/python_runtime.rs
@@ -36,6 +36,18 @@ pub struct PythonLauncher {
 }
 
 impl PythonLauncher {
+    fn bundled_runtime_root(&self) -> Option<PathBuf> {
+        (self.source == PythonLauncherSource::BundledRuntime)
+            .then(|| bundled_runtime_root_from_candidate(self))
+            .flatten()
+    }
+
+    fn sanitize_bundled_command<C: PythonEnvCommand>(&self, command: &mut C) {
+        if let Some(runtime_root) = self.bundled_runtime_root() {
+            sanitize_packaged_python_subprocess_env(command, &runtime_root);
+        }
+    }
+
     fn new(
         program: impl Into<String>,
         args: Vec<String>,
@@ -54,7 +66,7 @@ impl PythonLauncher {
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.args);
         if self.source == PythonLauncherSource::BundledRuntime {
-            sanitize_packaged_python_subprocess_env(&mut cmd);
+            self.sanitize_bundled_command(&mut cmd);
         }
         cmd.arg("--version");
         cmd
@@ -64,7 +76,7 @@ impl PythonLauncher {
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.args);
         if self.source == PythonLauncherSource::BundledRuntime {
-            sanitize_packaged_python_subprocess_env(&mut cmd);
+            self.sanitize_bundled_command(&mut cmd);
         }
         cmd.arg("-c");
         cmd.arg("import json,platform,struct,sys; print(json.dumps({'version': list(sys.version_info[:3]), 'machine': platform.machine(), 'pointer_bits': struct.calcsize('P') * 8, 'executable': sys.executable, 'prefix': sys.prefix}))");
@@ -78,7 +90,7 @@ impl PythonLauncher {
         let mut cmd = tokio::process::Command::new(&self.program);
         cmd.args(&self.args);
         if self.source == PythonLauncherSource::BundledRuntime {
-            sanitize_packaged_python_subprocess_env(&mut cmd);
+            self.sanitize_bundled_command(&mut cmd);
         }
         cmd.arg(script_path);
         cmd
@@ -91,7 +103,7 @@ impl PythonLauncher {
         let mut cmd = Command::new(&self.program);
         cmd.args(&self.args);
         if self.source == PythonLauncherSource::BundledRuntime {
-            sanitize_packaged_python_subprocess_env(&mut cmd);
+            self.sanitize_bundled_command(&mut cmd);
         }
         cmd.arg(script_path);
         cmd
@@ -1193,7 +1205,7 @@ const PACKAGED_MUTABLE_ENV_KEYS: &[&str] = &[
     "FORCE_CMAKE",
 ];
 
-pub fn sanitize_packaged_python_subprocess_env<C>(command: &mut C)
+pub fn sanitize_packaged_python_subprocess_env<C>(command: &mut C, runtime_root: &Path)
 where
     C: PythonEnvCommand,
 {
@@ -1219,6 +1231,33 @@ where
     }
     command.set_env("PYTHONNOUSERSITE", std::ffi::OsStr::new("1"));
     command.set_env("PYTHONDONTWRITEBYTECODE", std::ffi::OsStr::new("1"));
+    let runtime_root = runtime_root
+        .canonicalize()
+        .unwrap_or_else(|_| runtime_root.to_path_buf());
+    let mut trusted_path = vec![runtime_root.clone()];
+    let native_lib = runtime_root
+        .join("Lib")
+        .join("site-packages")
+        .join("llama_cpp")
+        .join("lib");
+    if native_lib.is_dir() {
+        trusted_path.push(native_lib.canonicalize().unwrap_or(native_lib));
+    }
+    if cfg!(target_os = "windows") {
+        if let Some(system_root) = std::env::var_os("SystemRoot").map(PathBuf::from) {
+            if system_root.is_absolute() {
+                let system32 = system_root.join("System32");
+                trusted_path.push(system32.canonicalize().unwrap_or(system32));
+            }
+        }
+        // This value is an attestation from the compiled/bundled runtime contract,
+        // never a copy of the mutable host architecture environment.
+        command.set_env("PROCESSOR_ARCHITECTURE", "AMD64");
+        command.set_env("TOKEN_PLACE_PACKAGED_RUNTIME_ARCH", "x86_64");
+    }
+    if let Ok(path) = std::env::join_paths(trusted_path) {
+        command.set_env("PATH", path);
+    }
 }
 
 fn import_root_is_confirmed_unbundled_development(import_root: &Path) -> bool {
@@ -1242,7 +1281,19 @@ pub fn configure_python_subprocess_env_for_layout<C>(
 {
     disable_python_user_site(command);
     if packaged || layout != ResourceLayoutKind::DevSourceTree {
-        sanitize_packaged_python_subprocess_env(command);
+        let runtime_root = import_root
+            .ancestors()
+            .map(|root| root.join("python-runtime"))
+            .find(|root| {
+                root.join(if cfg!(target_os = "windows") {
+                    "python.exe"
+                } else {
+                    "bin/python3"
+                })
+                .is_file()
+            })
+            .unwrap_or_else(|| import_root.join("python-runtime"));
+        sanitize_packaged_python_subprocess_env(command, &runtime_root);
     }
     command.set_env("TOKEN_PLACE_PYTHON_IMPORT_ROOT", import_root.as_os_str());
     let python_dir = import_root.join("python");
@@ -1423,6 +1474,28 @@ pub fn resolve_runtime_import_root(
     candidates
         .into_iter()
         .find(|candidate| candidate.join("utils").is_dir() || candidate.join("config.py").is_file())
+}
+
+/// Resolve repository Python resources inside one already-selected packaged
+/// Tauri resource tree. Packaged callers deliberately do not consult the host
+/// override accepted by the development resolver above.
+pub fn resolve_packaged_runtime_import_root(resource_root: &Path) -> Option<PathBuf> {
+    let tree = resource_root.canonicalize().ok()?;
+    let mut candidates = Vec::new();
+    let mut candidate = tree.clone();
+    for _ in 0..=3 {
+        if candidate.join("utils").is_dir() || candidate.join("config.py").is_file() {
+            let canonical = candidate.canonicalize().ok()?;
+            if canonical.starts_with(&tree) && !candidates.contains(&canonical) {
+                candidates.push(canonical);
+            }
+        }
+        candidate = candidate.join("_up_");
+    }
+    match candidates.as_slice() {
+        [root] => Some(root.clone()),
+        _ => None,
+    }
 }
 
 fn mode_requests_gpu(mode: &ComputeMode) -> bool {
@@ -2563,7 +2636,10 @@ mod tests {
             Some("1")
         );
         let mut effective = PythonEnvCommandRecorder::with_poisoned_env();
-        sanitize_packaged_python_subprocess_env(&mut effective);
+        sanitize_packaged_python_subprocess_env(
+            &mut effective,
+            Path::new("/bundle/python-runtime"),
+        );
         assert!(effective.clear_env_called);
         for key in [
             "PYTHONHOME",
@@ -2593,7 +2669,13 @@ mod tests {
             PACKAGED_ENV_FUNDAMENTALS.contains(&key.to_string_lossy().as_ref())
                 || matches!(
                     key.to_str(),
-                    Some("PYTHONNOUSERSITE" | "PYTHONDONTWRITEBYTECODE")
+                    Some(
+                        "PATH"
+                            | "PYTHONNOUSERSITE"
+                            | "PYTHONDONTWRITEBYTECODE"
+                            | "PROCESSOR_ARCHITECTURE"
+                            | "TOKEN_PLACE_PACKAGED_RUNTIME_ARCH"
+                    )
                 )
         }));
     }
@@ -2616,13 +2698,15 @@ mod tests {
 
         let mut effective = PythonEnvCommandRecorder::with_poisoned_env();
         effective.set_env("PATH", "poison-host-tools");
-        sanitize_packaged_python_subprocess_env(&mut effective);
+        sanitize_packaged_python_subprocess_env(
+            &mut effective,
+            Path::new("/bundle/python-runtime"),
+        );
 
         for (key, value) in fundamentals {
             assert_eq!(effective.value(key), Some(std::ffi::OsStr::new(value)));
         }
         for key in [
-            "PATH",
             "PYTHONHOME",
             "PYTHONPATH",
             "VIRTUAL_ENV",
@@ -2633,6 +2717,9 @@ mod tests {
         ] {
             assert_eq!(effective.value(key), None, "{key} must not reach the child");
         }
+        let path = effective.value("PATH").expect("deterministic bundled PATH");
+        assert!(path.to_string_lossy().contains("python-runtime"));
+        assert!(!path.to_string_lossy().contains("poison-host-tools"));
 
         for (key, value) in previous {
             if let Some(value) = value {

--- a/desktop-tauri/src-tauri/tauri.conf.json
+++ b/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "token.place desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "place.token.desktop",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/tests/unit/test_desktop_release_artifacts.py
+++ b/tests/unit/test_desktop_release_artifacts.py
@@ -2539,7 +2539,7 @@ def _load_windows_release_validator():
     return module
 
 
-def _write_windows_runtime_fixture(root: Path, *, version: str = '0.1.5') -> tuple[Path, Path]:
+def _write_windows_runtime_fixture(root: Path, *, version: str = '0.1.6') -> tuple[Path, Path]:
     validator = _load_windows_release_validator()
     manifest = json.loads(Path('desktop-tauri/src-tauri/python/embedded_python_runtime_windows_x86_64_manifest.json').read_text(encoding='utf-8'))
     runtime = root / 'resources' / 'python-runtime'
@@ -2599,7 +2599,7 @@ def test_windows_validator_without_version_args_derives_package_json_version(tmp
 def test_windows_release_validator_accepts_extracted_msi_and_nsis(tmp_path):
     validator = _load_windows_release_validator()
     nsis, msi = _write_windows_runtime_fixture(tmp_path)
-    assert validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.5']) == 0
+    assert validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.6']) == 0
 
 
 def test_windows_release_validator_rejects_version_and_provenance_mismatch(tmp_path):
@@ -2614,7 +2614,7 @@ def test_windows_release_validator_rejects_version_and_provenance_mismatch(tmp_p
     data['llama_cpp_cuda_wheel']['flavor'] = 'cpu'
     provenance.write_text(json.dumps(data), encoding='utf-8')
     with pytest.raises(validator.ValidationError, match='incomplete Windows runtime provenance'):
-        validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.5'])
+        validator.main(['--windows-nsis', str(nsis), '--windows-msi', str(msi), '--expected-version', '0.1.6'])
 
 
 def _extract_workflow_job_block(text: str, job_key: str) -> str:
@@ -4627,10 +4627,10 @@ def test_installed_context_smoke_uses_get_llm_instance_boundary() -> None:
 
 def test_windows_installer_identity_main_non_windows_contract_success(monkeypatch, tmp_path, capsys) -> None:
     guard = _load_windows_installer_identity()
-    current_nsis = tmp_path / 'token.place-desktop-0.1.5-x64-setup.exe'
-    current_msi = tmp_path / 'token.place-desktop-0.1.5-x64.msi'
-    previous_nsis = tmp_path / 'token.place-desktop-0.1.4-x64-setup.exe'
-    previous_msi = tmp_path / 'token.place-desktop-0.1.4-x64.msi'
+    current_nsis = tmp_path / 'token.place-desktop-0.1.6-x64-setup.exe'
+    current_msi = tmp_path / 'token.place-desktop-0.1.6-x64.msi'
+    previous_nsis = tmp_path / 'token.place-desktop-0.1.5-x64-setup.exe'
+    previous_msi = tmp_path / 'token.place-desktop-0.1.5-x64.msi'
     for path in (current_nsis, current_msi, previous_nsis, previous_msi):
         path.write_text('artifact', encoding='utf-8')
     monkeypatch.setattr(guard.sys, 'platform', 'linux')
@@ -5413,20 +5413,20 @@ def test_windows_installer_identity_validate_tiers_detects_runtime_and_profile_d
 
 def test_windows_installer_identity_run_all_and_main_windows_paths(monkeypatch, tmp_path, capsys) -> None:
     guard = _load_windows_installer_identity()
-    current_nsis = tmp_path / 'token.place-desktop-0.1.5-x64-setup.exe'
-    current_msi = tmp_path / 'token.place-desktop-0.1.5-x64.msi'
-    previous_nsis = tmp_path / 'token.place-desktop-0.1.4-x64-setup.exe'
-    previous_msi = tmp_path / 'token.place-desktop-0.1.4-x64.msi'
+    current_nsis = tmp_path / 'token.place-desktop-0.1.6-x64-setup.exe'
+    current_msi = tmp_path / 'token.place-desktop-0.1.6-x64.msi'
+    previous_nsis = tmp_path / 'token.place-desktop-0.1.5-x64-setup.exe'
+    previous_msi = tmp_path / 'token.place-desktop-0.1.5-x64.msi'
     for path in (current_nsis, current_msi, previous_nsis, previous_msi):
         path.write_text('artifact', encoding='utf-8')
 
-    scenarios = [guard.Scenario('clean-nsis-0.1.5', guard.Installer(current_nsis, 'nsis', '0.1.5'))]
+    scenarios = [guard.Scenario('clean-nsis-0.1.6', guard.Installer(current_nsis, 'nsis', '0.1.6'))]
     artifacts_seen = []
     def fake_runner(scenario, build_id):
         artifacts_seen.append((scenario.name, build_id))
 
     guard.run_all_scenarios(scenarios, 'abcdef123456', runner=fake_runner, artifact_root=tmp_path / 'logs')
-    assert artifacts_seen == [('clean-nsis-0.1.5', 'abcdef123456')]
+    assert artifacts_seen == [('clean-nsis-0.1.6', 'abcdef123456')]
 
     old_argv = sys.argv
     monkeypatch.setattr(guard.sys, 'platform', 'win32')


### PR DESCRIPTION
### Motivation
- Packaged Windows launches cleared the child environment but did not reconstruct a deterministic `PATH`, causing the bundled `llama-cpp-python==0.3.32` Windows loader to raise `KeyError("PATH")` during the immutable runtime probe. 
- The bundled launcher also supplied a brittle import root and removed architecture attestations, producing misleading `arch=` diagnostics and allowing release gating to pass via a fabricated ready event instead of exercising the real native import path.

### Description
- Ensure every bundled-Python child gets a deterministic, minimal `PATH` built from canonical trusted locations (canonicalized `python-runtime`, bundled `llama_cpp` native dir when present, and `System32` derived from `SystemRoot`) and never inherit or append the host `PATH`, while preserving `PYTHONNOUSERSITE=1` and `PYTHONDONTWRITEBYTECODE=1` and continuing to remove mutable/potentially-poisoned variables such as `PYTHONHOME`, `PYTHONPATH`, `PIP_*`, and `CMAKE_*`. (see `desktop-tauri/src-tauri/src/python_runtime.rs`) 
- Make the sanitizer receive the verified runtime root and apply it for version/metadata probes, compute bridge commands, model bridge, nested probes, and installed preflight paths; canonicalize/discover `python-runtime` location from the resolved import root. (`python_runtime.rs` and `configure_python_subprocess_env_for_layout`) 
- Add a packaged runtime architecture attestation (`TOKEN_PLACE_PACKAGED_RUNTIME_ARCH` / `PROCESSOR_ARCHITECTURE` = `AMD64`) emitted by the sanitizer and consumed by Python (`desktop_runtime_setup.py::_desktop_arch()`), so packaged Windows x86-64 is trusted even when `platform.machine()` is empty. 
- Resolve the real Tauri import root inside the selected coherent packaged resource tree (support `_up_/_up_` relocations) and fail closed on missing/ambiguous roots; ensure `TOKEN_PLACE_PYTHON_IMPORT_ROOT` and `PYTHONPATH` are set from this resolved root. (`resolve_packaged_runtime_import_root` and `prepare_operator_bridge_launch`) 
- Replace the installed release acceptance unit hook that printed a fabricated ready event with a `--operator-native-runtime-preflight` that drives the real production launcher path and performs a real native `llama_cpp` import/version/capability preflight (requires `llama-cpp-python==0.3.32` and inspects constructor/YaRN metadata). (`desktop-tauri/src-tauri/python/compute_node_bridge.py`, `desktop-tauri/src-tauri/src/compute_node.rs`) 
- Bump canonical desktop release surfaces to `0.1.6` (package.json, Cargo.toml, tauri.conf.json, related test expectations) so validators and installer identity tests align with the repaired behavior. 
- Files changed (key): `desktop-tauri/src-tauri/src/python_runtime.rs`, `desktop-tauri/src-tauri/python/desktop_runtime_setup.py`, `desktop-tauri/src-tauri/python/compute_node_bridge.py`, `desktop-tauri/src-tauri/src/compute_node.rs`, `desktop-tauri/package.json`, `desktop-tauri/src-tauri/Cargo.toml`, `desktop-tauri/src-tauri/tauri.conf.json`, `desktop-tauri/scripts/test_windows_installer_identity.py`, and tests adjusted to `0.1.6` where appropriate. 

### Testing
- Ran the repository unit suites used by the desktop verification; the main test command executed was `python -m pytest tests/unit/test_desktop_runtime_setup.py tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_release_artifacts.py tests/unit/test_windows_nvidia_gpu_smoke_contract.py tests/unit/test_model_manager.py -q`, and the impacted unit tests passed after the fixes and test updates (the small set of release-version fixtures were updated to `0.1.6` and re-run). 
- Verified focused regressions and preflight hooks by running `python -m pytest tests/unit/test_desktop_compute_node_bridge.py tests/unit/test_desktop_release_artifacts.py -q` and targeted failing cases that were fixed (four installer/version tests updated to `0.1.6` now pass). 
- Static/compile checks performed: `python -m py_compile desktop-tauri/src-tauri/python/desktop_runtime_setup.py desktop-tauri/src-tauri/python/compute_node_bridge.py desktop-tauri/scripts/prepare_windows_embedded_python_runtime.py desktop-tauri/scripts/test_windows_installer_identity.py` passed, `cargo fmt --manifest-path desktop-tauri/src-tauri/Cargo.toml` ran, and `pre-commit run --all-files` passed the configured hooks in this environment. 
- `cargo test --manifest-path desktop-tauri/src-tauri/Cargo.toml --no-run` could not complete in the Linux container due to missing native `glib-2.0` pkg-config metadata required by `glib-sys`; this is an environment limitation and does not change the Rust code intent. 

Notes and residual risk
- Confirmed root cause: the sanitizer cleared env without a deterministic `PATH`, causing `llama-cpp-python` to crash on import with `KeyError("PATH")`; the new sanitizer rebuilds a minimal trusted `PATH` and sets a packaged architecture attestation. 
- The changes wire the installer acceptance gate to import the real bundled native runtime under the same sanitizer used in production; however, final proof of full end-to-end CUDA GPU offload, worker readiness, relay registration, and encrypted inference still requires the designated hosted/self-hosted RTX runner (physical hardware) and the Windows packaged runtime extraction steps used by release workflows. 
- No runtime dependencies, relay schemas, E2EE behaviour, API v1 policies, macOS packaging/signing rules, or model-selection invariants were weakened.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a664a844d68832fa18a1af280f1bbf7)